### PR TITLE
ci: refresh live snapshot before nightly validation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
 name: nightly (live UC)
 
-# Nightly workflow -- runs the real-UC integration + Playwright suites
-# against the dev Databricks workspace at ~05:00 CT (10:00 UTC). This is
-# the canary that catches:
+# Nightly workflow -- refreshes the governed dev UC snapshot, then runs the
+# real-UC integration + Playwright suites against the dev Databricks workspace
+# at ~05:00 CT (10:00 UTC). This is the canary that catches:
 #   - SQL<->Python parity drift (tests/integration/test_sql_python_parity.py)
 #   - Genie space regression (tests/integration/test_genie_live.py)
 #   - Lakebase schema/auth drift (tests/integration/test_lakebase_round_trip.py)
@@ -48,7 +48,7 @@ jobs:
   parity-live:
     name: SQL<->Python + Lakebase + Genie live
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     env:
       LAKEBASE_DATABASE: ${{ secrets.LAKEBASE_DATABASE || 'mip_app_state' }}
       LAKEBASE_INSTANCE_NAME: mip-app-state
@@ -74,7 +74,8 @@ jobs:
         run: databricks --version
       - name: Prepare bundle sync inputs
         run: |
-          python tools/render_sql.py --catalog "${MIP_DEFAULT_CATALOG:-mip}"
+          MIP_ENABLE_DEMO_FIRST_PARTY_FEEDS=1 \
+            python tools/render_sql.py --catalog "${MIP_DEFAULT_CATALOG:-mip}"
           npm --prefix frontend run build
       - name: Export live Databricks test env
         # Catches the "secrets were rotated and nobody updated the repo"
@@ -127,6 +128,34 @@ jobs:
           } > "$HOME/.databrickscfg"
           chmod 600 "$HOME/.databrickscfg"
           databricks bundle validate -t dev --profile DEFAULT
+      - name: Refresh live FRED market rates before validation
+        # The parity gate compares gold borrower scoring against the latest
+        # reviewed FRED MORTGAGE30US row. FRED publishes independently of repo
+        # deploys, so scheduled nightly must refresh rates before validating.
+        env:
+          DATABRICKS_AUTH_TYPE: pat
+          BUNDLE_VAR_sql_warehouse_id: ${{ secrets.DATABRICKS_WAREHOUSE_ID }}
+          BUNDLE_VAR_genie_space_id: ${{ secrets.GENIE_SPACE_ID }}
+        run: databricks bundle run mip_fred_rates_ingest -t dev --profile DEFAULT
+      - name: Refresh live Cotality silver features before validation
+        # The raw-share parity reference reads Cotality directly, while app gold
+        # reads mip.silver.*. Refresh silver here so raw-share expansions or
+        # corrections do not create the same stale-snapshot failure shape.
+        env:
+          DATABRICKS_AUTH_TYPE: pat
+          BUNDLE_VAR_sql_warehouse_id: ${{ secrets.DATABRICKS_WAREHOUSE_ID }}
+          BUNDLE_VAR_genie_space_id: ${{ secrets.GENIE_SPACE_ID }}
+        run: databricks bundle run mip_refresh_silver -t dev --profile DEFAULT
+      - name: Refresh live gold scoring snapshot before validation
+        # Rebuild borrower_360, lead_scores, segment_population, rollups, and
+        # source_readiness from the just-refreshed silver/reference inputs.
+        # Without this, weekly FRED/source-readiness changes make nightly fail
+        # until a human happens to run deploy.sh or mip_refresh_scores.
+        env:
+          DATABRICKS_AUTH_TYPE: pat
+          BUNDLE_VAR_sql_warehouse_id: ${{ secrets.DATABRICKS_WAREHOUSE_ID }}
+          BUNDLE_VAR_genie_space_id: ${{ secrets.GENIE_SPACE_ID }}
+        run: databricks bundle run mip_refresh_scores -t dev --profile DEFAULT
       - name: SQL <-> Python parity
         run: pytest -q tests/integration/test_sql_python_parity.py
       - name: Lakeview widgets resolve (dashboards)
@@ -691,9 +720,10 @@ jobs:
               `Nightly real-UC workflow failed. Run: ${runUrl}`,
               '',
               '**Likely causes (in order):**',
+              '- The new pre-validation refresh step failed (`mip_fred_rates_ingest`, `mip_refresh_silver`, or `mip_refresh_scores`). Inspect those logs first.',
               '- Databricks workspace credentials rotated (check repo secrets).',
               '- Serverless warehouse or Lakebase instance stopped.',
-              '- `fn_*` UDF redeployed without fixture update (see `docs/runbook.md` §3).',
+              '- A parity step failed after refresh, which now means real SQL/Python or raw-share/gold predicate drift.',
               '- Genie space deleted or its trusted-assets list pruned.',
               '',
               '**Triage:** docs/runbook.md §3 (parity-red) and §8 (CI failure triage).',

--- a/docs/validation/segment-count-parity.md
+++ b/docs/validation/segment-count-parity.md
@@ -22,6 +22,12 @@ rebuilt gold at `0.0636`, restored CA ITM to `16,706`, and made
 explicit `borrower_360.market_rate_fraction` freshness guard so the next FRED
 refresh without a gold refresh fails with that root cause directly.
 
+**2026-05-31 operational hardening:** The scheduled nightly now runs
+`mip_fred_rates_ingest`, `mip_refresh_silver`, and `mip_refresh_scores` before
+any live parity, source-readiness, Genie, or Playwright assertions. This keeps
+the release gate validating the current governed snapshot instead of whatever
+silver/gold tables a human last refreshed during deploy or rehearsal.
+
 Follow-up live smoke found the dev bundle had been deployed with rendered
 Summit first-party demo feeds disabled, which made all contactability fields
 empty after the refresh (`marketing_eligible=0`, `consent_status='unknown'`)

--- a/tests/unit/test_nightly_workflow_contract.py
+++ b/tests/unit/test_nightly_workflow_contract.py
@@ -1,0 +1,57 @@
+"""Contracts for the live-UC nightly workflow.
+
+The nightly is a release-readiness gate over live Databricks assets. It must
+refresh the governed snapshot before asserting raw-share/gold parity; otherwise
+weekly upstream FRED changes can make gold look wrong until a human manually
+reruns the scoring job.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+NIGHTLY = REPO / ".github" / "workflows" / "nightly.yml"
+
+
+def test_nightly_refreshes_live_snapshot_before_live_parity() -> None:
+    text = NIGHTLY.read_text(encoding="utf-8")
+
+    validate_pos = text.index("databricks bundle validate -t dev --profile DEFAULT")
+    fred_pos = text.index("databricks bundle run mip_fred_rates_ingest -t dev --profile DEFAULT")
+    silver_pos = text.index("databricks bundle run mip_refresh_silver -t dev --profile DEFAULT")
+    gold_pos = text.index("databricks bundle run mip_refresh_scores -t dev --profile DEFAULT")
+    parity_pos = text.index("pytest -q tests/integration/test_sql_python_parity.py")
+    segment_pos = text.index("pytest tests/integration/test_segment_count_parity.py -q --tb=short")
+    source_pos = text.index("pytest tests/integration/test_source_readiness_live.py -q --tb=short")
+
+    assert validate_pos < fred_pos < silver_pos < gold_pos < parity_pos < segment_pos < source_pos
+
+
+def test_nightly_refresh_steps_use_real_dev_bundle_profile() -> None:
+    text = NIGHTLY.read_text(encoding="utf-8")
+
+    for step_name in (
+        "Refresh live FRED market rates before validation",
+        "Refresh live Cotality silver features before validation",
+        "Refresh live gold scoring snapshot before validation",
+    ):
+        step_pos = text.index(f"- name: {step_name}")
+        next_step_pos = text.find("\n      - name:", step_pos + 1)
+        block = text[step_pos:] if next_step_pos == -1 else text[step_pos:next_step_pos]
+
+        assert "DATABRICKS_AUTH_TYPE: pat" in block
+        assert "BUNDLE_VAR_sql_warehouse_id: ${{ secrets.DATABRICKS_WAREHOUSE_ID }}" in block
+        assert "BUNDLE_VAR_genie_space_id: ${{ secrets.GENIE_SPACE_ID }}" in block
+        assert "-t dev --profile DEFAULT" in block
+
+
+def test_nightly_renders_dev_demo_feeds_for_bundle_validation() -> None:
+    text = NIGHTLY.read_text(encoding="utf-8")
+
+    prepare_pos = text.index("- name: Prepare bundle sync inputs")
+    export_pos = text.index("- name: Export live Databricks test env")
+    block = text[prepare_pos:export_pos]
+
+    assert "MIP_ENABLE_DEMO_FIRST_PARTY_FEEDS=1" in block
+    assert 'python tools/render_sql.py --catalog "${MIP_DEFAULT_CATALOG:-mip}"' in block


### PR DESCRIPTION
## Summary
- refresh FRED, Cotality silver, and gold before nightly live-UC validation
- render dev SQL with Summit first-party feeds enabled for bundle validation parity
- add a unit contract test so the nightly refresh order cannot regress
- update the segment-count parity note with the operational hardening

## Validation
- actionlint .github/workflows/nightly.yml
- .venv/bin/ruff check tests/unit/test_nightly_workflow_contract.py
- .venv/bin/python -m pytest tests/unit/test_nightly_workflow_contract.py tests/unit/test_docs_claim_guardrails.py::test_nightly_runs_standard_genie_fuzz_and_keeps_deep_fuzz_manual -q
- .venv/bin/python -m pytest tests/unit/test_configuration_files.py tests/unit/test_disaster_recovery_contract.py -q
- git diff --check

## Root cause
Nightly was validating moving live data without first materializing the current governed snapshot. FRED advanced to 0.0653 while gold.borrower_360 still carried 0.0651, which also shifted the CO in-the-money reference count. The test was correct; the orchestration was incomplete.
