### PR TITLE
Fix live dossier parity and dependency audit gates

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 fastapi==0.136.1
-starlette==1.0.1  # security floor for PYSEC-2026-161; FastAPI only sets a lower bound
+starlette==1.3.1  # security floor for GHSA-wqp7-x3pw-xc5r/GHSA-x746-7m8f-x49c/GHSA-82w8-qh3p-5jfq/GHSA-jp82-jpqv-5vv3; FastAPI only sets a lower bound
 uvicorn[standard]==0.47.0
 pydantic==2.10.4
 pydantic-settings==2.7.1
@@ -7,6 +7,7 @@ python-dotenv==1.2.2
 httpx==0.28.1
 databricks-sdk==0.103.0
 databricks-sql-connector==4.2.6
+cryptography==48.0.1  # security floor for GHSA-537c-gmf6-5ccf via google-auth
 # Security floor for PYSEC-2026-175/PYSEC-2026-177/PYSEC-2026-178/PYSEC-2026-179.
 # databricks-sql-connector depends on PyJWT; keep the transitive pin explicit
 # so pip-audit failures have a first-party dependency contract to resolve.

--- a/tests/integration/test_borrower_dossier_parity.py
+++ b/tests/integration/test_borrower_dossier_parity.py
@@ -103,18 +103,20 @@ def _run_sql(
 
 
 # ---------------------------------------------------------------------------
-# Columns to compare. Mirror of
-# backend.services.repositories.databricks_repo._BORROWER_360_COLUMNS so a
-# drift in either direction is caught.
+# Columns to compare. This mirrors every borrower_360 column projected by
+# sql/transformations/gold_borrower_dossier.sql before the dossier-only evidence
+# arrays/refreshed_at columns, so CTAS drift in live MLS/propensity fields is
+# caught alongside the legacy borrower scalar fields.
 # ---------------------------------------------------------------------------
 
 _PARITY_COLUMNS: tuple[str, ...] = (
     "clip",
     "borrower_id",
-    "owner_name_hash",
+    "display_name",
     "city",
     "state",
     "zip",
+    "situs_cbsa_code",
     # segment_codes is an ARRAY -- compared as a JSON-encoded string.
     "segment_codes",
     "equity_estimate",
@@ -136,15 +138,46 @@ _PARITY_COLUMNS: tuple[str, ...] = (
     "ltv",
     "related_property_count",
     "is_owner_occupied",
+    "is_absentee",
+    "is_corporate_owner",
+    "has_permit",
+    "listed_for_sale",
+    "listing_status_category",
+    "listing_status_description",
+    "listing_date",
+    "listing_status_date",
+    "listing_price",
+    "listing_days_on_market",
+    "listing_service",
+    "heloc_propensity_score",
+    "heloc_propensity_run_date",
+    "has_heloc_propensity_trigger",
+    "refi_propensity_score",
+    "refi_propensity_run_date",
+    "has_refi_propensity_trigger",
     "is_investor",
     "is_current_customer",
     "is_former_customer",
     "is_competitor_lien",
-    "has_permit",
-    "listed_for_sale",
+    "has_first_party_relationship",
+    "first_party_relationship_depth",
+    "first_party_recent_interactions",
+    "first_party_recent_application",
+    "first_party_synthetic_demo",
+    "marketing_eligible",
+    "consent_status",
+    "suppression_reason",
+    "last_touch_at",
+    "eligible_recontact_at",
+    "current_lender_ref",
     "second_pos_amount",
+    "first_pos_loan_type",
+    "owner_name_hash",
     "min_spread_bps_applied",
     "min_equity_pct_applied",
+    "heloc_equity_min_applied",
+    "cashout_equity_min_applied",
+    "retention_min_spread_applied",
     "in_the_money",
     "trigger_timeline_json",
 )
@@ -168,12 +201,56 @@ def warehouse() -> tuple[str, str, str]:
 
 
 @pytest.fixture(scope="module")
-def sample_borrower_ids(warehouse: tuple[str, str, str]) -> list[str]:
-    """Pick 5 random borrower_ids from the live dossier.
+def listed_borrower_ids(warehouse: tuple[str, str, str]) -> list[str]:
+    """Pick live MLS/listing borrowers when the source-readiness contract says
+    MLS Listings is live.
+
+    This prevents the parity suite from passing on an all-non-listed random
+    sample after MLS/listing evidence changed the top-3 timeline contract.
+    """
+    host, token, wh = warehouse
+    readiness = _run_sql(
+        host,
+        token,
+        wh,
+        "SELECT LOWER(status) FROM mip.gold.source_readiness "
+        "WHERE source_name = 'MLS Listings' LIMIT 1",
+    )
+    mls_live = bool(readiness and readiness[0] and readiness[0][0] == "live")
+    if not mls_live:
+        return []
+
+    rows = _run_sql(
+        host,
+        token,
+        wh,
+        "SELECT borrower_id FROM mip.gold.borrower_dossier "
+        "WHERE listed_for_sale = TRUE "
+        "  AND EXISTS(evidence_events, ev -> ev.signal_type = 'listing') "
+        "ORDER BY opportunity_score DESC NULLS LAST, borrower_id "
+        "LIMIT 3",
+    )
+    ids = [r[0] for r in rows if r and r[0]]
+    if not ids:
+        pytest.fail(
+            "MLS Listings is source-ready/live, but borrower_dossier has no "
+            "listed_for_sale borrowers with listing evidence."
+        )
+    return ids
+
+
+@pytest.fixture(scope="module")
+def sample_borrower_ids(
+    warehouse: tuple[str, str, str],
+    listed_borrower_ids: list[str],
+) -> list[str]:
+    """Pick random borrower_ids plus explicit listed borrowers from the live
+    dossier.
 
     Using `TABLESAMPLE (5 ROWS)` keeps the selection deterministic only
-    per-run -- different runs may pick different IDs, which is exactly
-    what we want for a parity sweep.
+    per-run -- different runs may pick different IDs, which is exactly what we
+    want for a parity sweep. The listed slice is deterministic by score so the
+    live MLS path is always exercised when that source is live.
     """
     host, token, wh = warehouse
     rows = _run_sql(
@@ -183,13 +260,44 @@ def sample_borrower_ids(warehouse: tuple[str, str, str]) -> list[str]:
         "SELECT borrower_id FROM mip.gold.borrower_dossier "
         "TABLESAMPLE (5 ROWS)",
     )
-    ids = [r[0] for r in rows if r and r[0]]
+    ids: list[str] = []
+    for row in [*rows, *[[bid] for bid in listed_borrower_ids]]:
+        if row and row[0] and row[0] not in ids:
+            ids.append(row[0])
     if not ids:
         pytest.skip(
             "mip.gold.borrower_dossier is empty -- run `databricks bundle "
             "run mip_refresh_scores -t dev` before this test."
         )
     return ids
+
+
+def test_live_mls_listing_sample_is_present(
+    warehouse: tuple[str, str, str],
+    listed_borrower_ids: list[str],
+) -> None:
+    """When source readiness marks MLS Listings live, the suite must exercise
+    borrowers with listing evidence instead of relying on random TABLESAMPLE
+    coverage."""
+    if not listed_borrower_ids:
+        pytest.skip("MLS Listings is not live in this workspace.")
+
+    host, token, wh = warehouse
+    for bid in listed_borrower_ids:
+        rows = _run_sql(
+            host,
+            token,
+            wh,
+            "SELECT listed_for_sale, "
+            "       EXISTS(evidence_events, ev -> ev.signal_type = 'listing') "
+            "FROM mip.gold.borrower_dossier "
+            f"WHERE borrower_id = '{_sanitize(bid)}' LIMIT 1",
+        )
+        assert rows, f"dossier missing listed borrower_id={bid!r}"
+        assert rows[0] == [True, True] or rows[0] == ["true", "true"], (
+            f"borrower_id={bid!r} is not a live listed/evidence-backed sample: "
+            f"{rows[0]!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -264,53 +372,55 @@ def test_dossier_top3_matches_evidence_events_top3(
         assert clip_rows, f"dossier missing borrower_id={bid!r}"
         clip = clip_rows[0][0]
 
-        # Pull authoritative top-3 straight from evidence_events.
+        # Pull authoritative top-3 straight from evidence_events, serialized
+        # with the same field order as the dossier evidence ARRAY<STRUCT>.
         direct = _run_sql(
             host,
             token,
             wh,
-            "SELECT evidence_id, signal_type, signal_rank "
-            "FROM mip.gold.evidence_events "
-            f"WHERE clip = '{_sanitize(str(clip))}' "
-            "AND signal_type <> 'permit' "
-            "ORDER BY signal_rank ASC, evidence_id ASC "
-            "LIMIT 3",
+            "WITH ranked AS ("
+            "  SELECT "
+            "    STRUCT("
+            "      evidence_id, source_product, source_table, signal_type, "
+            "      signal_value, display_text, confidence, `timestamp`, signal_rank"
+            "    ) AS ev, "
+            "    ROW_NUMBER() OVER (ORDER BY signal_rank ASC, evidence_id ASC) AS rn "
+            "  FROM mip.gold.evidence_events "
+            f"  WHERE clip = '{_sanitize(str(clip))}' "
+            "    AND signal_type <> 'permit'"
+            ") "
+            "SELECT to_json(array_sort(collect_list(ev), (a, b) -> CASE "
+            "  WHEN a.signal_rank < b.signal_rank THEN -1 "
+            "  WHEN a.signal_rank > b.signal_rank THEN 1 "
+            "  WHEN a.evidence_id < b.evidence_id THEN -1 "
+            "  WHEN a.evidence_id > b.evidence_id THEN 1 "
+            "  ELSE 0 END)) "
+            "FROM ranked WHERE rn <= 3",
         )
 
-        # Pull the dossier's top-3 timeline.
+        # Pull the dossier's top-3 timeline and the head of the full evidence
+        # array, serialized as JSON so the comparison covers every public
+        # EvidenceEvent field, not only ids/ranks.
         dossier = _run_sql(
             host,
             token,
             wh,
-            "SELECT "
-            "  get(trigger_timeline, 0).evidence_id, get(trigger_timeline, 0).signal_rank, "
-            "  get(trigger_timeline, 1).evidence_id, get(trigger_timeline, 1).signal_rank, "
-            "  get(trigger_timeline, 2).evidence_id, get(trigger_timeline, 2).signal_rank, "
-            "  get(evidence_events, 0).evidence_id, get(evidence_events, 1).evidence_id, "
-            "  get(evidence_events, 2).evidence_id "
+            "SELECT to_json(trigger_timeline), to_json(slice(evidence_events, 1, 3)) "
             "FROM mip.gold.borrower_dossier "
             f"WHERE borrower_id = '{_sanitize(bid)}' LIMIT 1",
         )
         assert dossier, f"dossier missing borrower_id={bid!r}"
-        r = dossier[0]
-        # Build dossier-side lists, trimming to the length of `direct`
-        # so CLIPs with fewer than 3 live signals don't spuriously fail.
-        n = len(direct)
-        dossier_timeline = [
-            (evidence_id, int(signal_rank))
-            for evidence_id, signal_rank in [(r[0], r[1]), (r[2], r[3]), (r[4], r[5])][:n]
-        ]
-        dossier_full_head = [r[6], r[7], r[8]][:n]
-        direct_pairs = [(row[0], int(row[2])) for row in direct]
-        direct_ids = [row[0] for row in direct]
+        direct_events = _json_array(direct[0][0] if direct and direct[0] else None)
+        dossier_timeline = _json_array(dossier[0][0])
+        dossier_full_head = _json_array(dossier[0][1])
 
-        assert dossier_timeline == direct_pairs, (
+        assert dossier_timeline == direct_events, (
             f"borrower_id={bid!r} trigger_timeline drift: "
-            f"dossier={dossier_timeline} direct={direct_pairs}"
+            f"dossier={dossier_timeline!r} direct={direct_events!r}"
         )
-        assert dossier_full_head == direct_ids, (
+        assert dossier_full_head == direct_events, (
             f"borrower_id={bid!r} evidence_events[:3] drift: "
-            f"dossier={dossier_full_head} direct={direct_ids}"
+            f"dossier={dossier_full_head!r} direct={direct_events!r}"
         )
 
 
@@ -359,3 +469,13 @@ def _sanitize(v: str) -> str:
     SQL-breaking character into a literal.
     """
     return "".join(c for c in str(v) if c.isalnum() or c in "-_")
+
+
+def _json_array(raw: Any) -> list[Any]:
+    if raw in (None, ""):
+        return []
+    if isinstance(raw, list):
+        return raw
+    parsed = json.loads(str(raw))
+    assert isinstance(parsed, list)
+    return parsed

--- a/tests/integration/test_borrower_dossier_parity.py
+++ b/tests/integration/test_borrower_dossier_parity.py
@@ -249,7 +249,9 @@ def test_dossier_top3_matches_evidence_events_top3(
     """The dossier's trigger_timeline (top-3) AND the head of
     evidence_events[:3] must equal gold.evidence_events for the same
     CLIP ordered by (signal_rank ASC, evidence_id ASC), filtered to
-    live signal types (excluding permit/listing per data-contract §9)."""
+    live signal types (excluding only blocked permit rows per data-contract
+    §9). MLS listing is now a live signal and must be part of the parity
+    comparison."""
     host, token, wh = warehouse
     for bid in sample_borrower_ids:
         clip_rows = _run_sql(
@@ -270,7 +272,7 @@ def test_dossier_top3_matches_evidence_events_top3(
             "SELECT evidence_id, signal_type, signal_rank "
             "FROM mip.gold.evidence_events "
             f"WHERE clip = '{_sanitize(str(clip))}' "
-            "AND signal_type NOT IN ('permit', 'listing') "
+            "AND signal_type <> 'permit' "
             "ORDER BY signal_rank ASC, evidence_id ASC "
             "LIMIT 3",
         )

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,8 @@ anyio==4.13.0
     #   httpx
     #   starlette
     #   watchfiles
+ast-serialize==0.5.0
+    # via mypy
 attrs==26.1.0
     # via hypothesis
 certifi==2026.4.22
@@ -29,8 +31,10 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   uvicorn
 coverage==7.14.0
     # via pytest-cov
-cryptography==48.0.0
-    # via google-auth
+cryptography==48.0.1
+    # via
+    #   -r requirements.in
+    #   google-auth
 databricks-sdk==0.103.0
     # via -r requirements.in
 databricks-sql-connector==4.2.6
@@ -70,8 +74,14 @@ importlib-metadata==8.7.1
     # via opentelemetry-api
 iniconfig==2.3.0
     # via pytest
+librt==0.11.0 ; platform_python_implementation != 'PyPy'
+    # via mypy
 lz4==4.4.5
     # via databricks-sql-connector
+mypy==2.1.0
+    # via -r requirements.in
+mypy-extensions==1.1.0
+    # via mypy
 numpy==2.4.5
     # via pandas
 oauthlib==3.3.1
@@ -110,6 +120,8 @@ packaging==26.2
     # via pytest
 pandas==2.3.3
     # via databricks-sql-connector
+pathspec==1.1.1
+    # via mypy
 pluggy==1.6.0
     # via pytest
 protobuf==6.33.6
@@ -177,7 +189,7 @@ six==1.17.0
     # via python-dateutil
 sortedcontainers==2.4.0
     # via hypothesis
-starlette==1.0.1
+starlette==1.3.1
     # via
     #   -r requirements.in
     #   fastapi
@@ -187,6 +199,7 @@ typing-extensions==4.15.0
     # via
     #   fastapi
     #   grpcio
+    #   mypy
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http


### PR DESCRIPTION
## Summary
- update borrower dossier parity to include live MLS listing evidence while still excluding blocked filed-permit evidence
- strengthen live parity coverage so MLS-listed borrowers are always sampled when source readiness is live
- compare the full borrower scalar projection and full top-3 EvidenceEvent structs, not just evidence IDs/ranks
- raise Python dependency security floors for Starlette and Cryptography and regenerate uv.lock

## Validation
- live Databricks: `.venv/bin/python ... pytest -q tests/integration/test_borrower_dossier_parity.py --tb=short` => 4 passed
- backend focused suite: `.venv/bin/python -m pytest tests/unit/test_api_boundaries.py tests/unit/test_marketing_safety.py tests/unit/test_outreach_reject.py -q` => 94 passed
- `.venv/bin/ruff check tests/integration/test_borrower_dossier_parity.py`
- `.venv/bin/python -m pip_audit -r requirements.txt --strict` => no known vulnerabilities
- `npm --prefix frontend audit --audit-level=high` => 0 vulnerabilities
- `git diff --check`

## Notes
- Building Permits remains blocked/pending and is not claimed live.