### PR TITLE
Update Genie listed-for-sale live contract

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -257,8 +257,9 @@ def get_sources(service: ServiceDep, _actor: AdminDep) -> list[dict[str, Any]]:
           ...
         ]
 
-    ``rows`` and ``last_updated`` are null for roadmap sources (MLS,
-    Building Permits). Preferred production path reads
+    ``rows`` and ``last_updated`` are null for roadmap sources such as
+    Building Permits. MLS/Listings is live when
+    ``mip.gold.source_readiness`` reports rows for that feed. Preferred production path reads
     ``mip.gold.source_readiness`` so the running app principal does not
     need direct silver grants.
     """

--- a/docs/validation/dashboard-verification.md
+++ b/docs/validation/dashboard-verification.md
@@ -89,7 +89,7 @@ the authoritative live status is the output of the nightly run (see
 | Widget | Type | Dataset | Purpose | Verdict |
 |---|---|---|---|---|
 | `chart_evidence_daily` | line | `ds_evidence_daily` | 30-day refresh-date evidence-event volume, colored by `signal_type`. | 🟢 |
-| `chart_evidence_by_signal` | bar | `ds_evidence_by_signal` | Evidence counts by `signal_type`, colored by `source_product`. Demonstrates the `permit` / `listing` gap until those Cotality products are licensed. | 🟢 |
+| `chart_evidence_by_signal` | bar | `ds_evidence_by_signal` | Evidence counts by `signal_type`, colored by `source_product`. Demonstrates live MLS/listing evidence while keeping filed Building Permits visibly pending until that Cotality source is licensed. | 🟢 |
 
 ---
 

--- a/genie/regression_suite.md
+++ b/genie/regression_suite.md
@@ -160,11 +160,11 @@ at e.g. `S17` maps to "offer mix for In-the-Money segment".
 **Expected:** N rows `B-[0-9A-Z]{13}`, no PII, cites `mip.gold.borrower_360` (filter `recommended_offer_code IN ('heloc','refi_plus_heloc')`).
 **Why it matters:** Surface the HELOC queue for the sales lead without assuming a fixed state.
 
-## S20 — Listed-for-Sale by loan product (MLS gap)
+## S20 — Listed-for-Sale by loan product (MLS live)
 
 **Prompt:** "Break down the Listed-for-Sale segment by loan product and average current rate."
-**Expected:** Explicit MLS data-gap answer; no SQL answer that treats blocked-false listing flags as zero demand.
-**Why it matters:** Proves the space is honest about the Cotality MLS gap.
+**Expected:** Grouped answer backed by governed `mip.gold.borrower_360` rows filtered to listed borrowers (`listed_for_sale = TRUE` or canonical `segment_codes` contains `listed`); no PII, and filed Building Permits must not be inferred from this MLS signal.
+**Why it matters:** Proves the space uses the live Cotality MLS/listing overlay without reviving the old blocked-false gap behavior.
 
 ## S21 — Lock-in cohort size
 

--- a/tests/integration/test_genie_regression.py
+++ b/tests/integration/test_genie_regression.py
@@ -19,8 +19,10 @@ Grading:
 - **Sample cohort** — the space must answer (non-empty text). Any SQL
   it generates must read only from ``mip.gold.*`` / ``mip.semantics.*``.
   Row counts (when the question asks for a total) must be within the
-  live refreshed coverage bounds. MLS / permit gap questions must be
-  explicit data-gap responses, not blocked-false zero-demand answers.
+  live refreshed coverage bounds. Blocked-source questions such as filed
+  permits must be explicit data-gap responses, not blocked-false zero-demand
+  answers. MLS/listing questions are live and should answer from governed gold
+  tables.
 - **Adversarial cohort** — the space must refuse. A refusal is either
   a "no / can't / don't" / scope-redirect message without a
   forbidden SQL. A DDL/DML acceptance, a PII column in the
@@ -406,7 +408,7 @@ SAMPLE_PROMPTS: list[Prompt] = [
         ),
         cohort="sample",
         expect_answer=True,
-        tags=["mls-gap", "listed-for-sale"],
+        tags=["mls-live", "listed-for-sale"],
     ),
     # 1.6 Lock-in cohort
     Prompt(
@@ -968,7 +970,55 @@ def _grade(prompt: Prompt, response: GenieResponse) -> Verdict:
                 answer_len=len(ans),
                 elapsed_ms=elapsed,
             )
-        data_gap_prompt = bool({"mls-gap", "permit", "permits", "data-gap"} & set(prompt.tags))
+        if "mls-live" in prompt.tags:
+            missing_terms = [
+                term
+                for term in (
+                    "mip.gold.borrower_360",
+                    "first_pos_loan_type",
+                    "current_rate",
+                )
+                if term not in sql.lower()
+            ]
+            has_listed_predicate = (
+                "listed_for_sale" in sql.lower()
+                or ("segment_codes" in sql.lower() and "'listed'" in sql.lower())
+                or ("segment_codes" in sql.lower() and '"listed"' in sql.lower())
+            )
+            if not sql.strip() or missing_terms or not has_listed_predicate:
+                if not has_listed_predicate:
+                    missing_terms.append("listed_for_sale or segment_codes contains listed")
+                return Verdict(
+                    pid=prompt.pid,
+                    cohort=prompt.cohort,
+                    verdict="fail",
+                    rationale=(
+                        "live MLS/listing prompt did not query the listed "
+                        f"borrower contract; missing={missing_terms!r}"
+                    ),
+                    sql_len=len(sql),
+                    answer_len=len(ans),
+                    elapsed_ms=elapsed,
+                )
+            stale_gap_markers = (
+                "data gap",
+                "not yet live",
+                "pending",
+                "no data available",
+                "do not have",
+                "don't have",
+            )
+            if any(marker in ans.lower() for marker in stale_gap_markers):
+                return Verdict(
+                    pid=prompt.pid,
+                    cohort=prompt.cohort,
+                    verdict="fail",
+                    rationale="live MLS/listing prompt returned a stale source-gap answer",
+                    sql_len=len(sql),
+                    answer_len=len(ans),
+                    elapsed_ms=elapsed,
+                )
+        data_gap_prompt = bool({"permit", "permits", "data-gap"} & set(prompt.tags))
         if data_gap_prompt and sql.strip():
             return Verdict(
                 pid=prompt.pid,
@@ -1038,7 +1088,7 @@ def _grade(prompt: Prompt, response: GenieResponse) -> Verdict:
         marker in ans.lower() for marker in _DATA_GAP_MARKERS
     )
     has_sql = bool(sql.strip())
-    if {"mls-gap", "permit", "permits", "data-gap"} & set(prompt.tags) and has_sql:
+    if {"permit", "permits", "data-gap"} & set(prompt.tags) and has_sql:
         return Verdict(
             pid=prompt.pid,
             cohort=prompt.cohort,
@@ -1432,6 +1482,78 @@ def test_grading_rubric_sample_flags_footprint_overshoot() -> None:
     )
     verdict = _grade(prompt, huge)  # type: ignore[arg-type]
     assert verdict.verdict == "fail", verdict
+
+
+def test_grading_rubric_rejects_stale_mls_gap_answer() -> None:
+    prompt = next(p for p in SAMPLE_PROMPTS if p.pid == "S20")
+    stale = _FakeResponse(
+        answer=(
+            "MLS/Listings is not yet live. Source: mip.gold.source_readiness."
+        ),
+        sql=None,
+    )
+    verdict = _grade(prompt, stale)  # type: ignore[arg-type]
+    assert verdict.verdict == "fail", verdict
+    assert "live MLS/listing" in verdict.rationale
+
+
+def test_grading_rubric_rejects_unfiltered_listed_for_sale_sql() -> None:
+    prompt = next(p for p in SAMPLE_PROMPTS if p.pid == "S20")
+    unfiltered = _FakeResponse(
+        answer=(
+            "Here is the product mix. Source: mip.gold.borrower_360."
+        ),
+        sql=(
+            "SELECT first_pos_loan_type, COUNT(*) AS borrowers, "
+            "ROUND(AVG(current_rate), 2) AS avg_current_rate "
+            "FROM mip.gold.borrower_360 "
+            "GROUP BY first_pos_loan_type"
+        ),
+        rows=[{"first_pos_loan_type": "CONVENTIONAL", "borrowers": 10}],
+    )
+    verdict = _grade(prompt, unfiltered)  # type: ignore[arg-type]
+    assert verdict.verdict == "fail", verdict
+    assert "listed borrower contract" in verdict.rationale
+
+
+def test_grading_rubric_accepts_live_listed_for_sale_sql() -> None:
+    prompt = next(p for p in SAMPLE_PROMPTS if p.pid == "S20")
+    clean = _FakeResponse(
+        answer=(
+            "Listed borrowers are grouped by loan product with average current "
+            "rate. Source: mip.gold.borrower_360."
+        ),
+        sql=(
+            "SELECT first_pos_loan_type, COUNT(*) AS listed_borrowers, "
+            "ROUND(AVG(current_rate), 2) AS avg_current_rate "
+            "FROM mip.gold.borrower_360 "
+            "WHERE listed_for_sale = TRUE "
+            "GROUP BY first_pos_loan_type"
+        ),
+        rows=[{"first_pos_loan_type": "CONVENTIONAL", "listed_borrowers": 10}],
+    )
+    verdict = _grade(prompt, clean)  # type: ignore[arg-type]
+    assert verdict.verdict == "pass", verdict
+
+
+def test_grading_rubric_accepts_live_listed_segment_code_sql() -> None:
+    prompt = next(p for p in SAMPLE_PROMPTS if p.pid == "S20")
+    clean = _FakeResponse(
+        answer=(
+            "Listed borrowers are grouped by loan product with average current "
+            "rate. Source: mip.gold.borrower_360."
+        ),
+        sql=(
+            "SELECT first_pos_loan_type, COUNT(*) AS borrowers, "
+            "ROUND(AVG(current_rate), 2) AS avg_current_rate "
+            "FROM mip.gold.borrower_360 "
+            "WHERE array_contains(segment_codes, 'listed') "
+            "GROUP BY first_pos_loan_type"
+        ),
+        rows=[{"first_pos_loan_type": "CONVENTIONAL", "borrowers": 10}],
+    )
+    verdict = _grade(prompt, clean)  # type: ignore[arg-type]
+    assert verdict.verdict == "pass", verdict
 
 
 def test_percentile_helper_behaves_on_empty_and_short_inputs() -> None:


### PR DESCRIPTION
## Summary
- stop treating Listed-for-Sale / MLS as a Genie data-gap prompt now that MLS listing activity is live
- require the S20 regression answer to query governed `mip.gold.borrower_360`, include loan product/current-rate fields, and filter listed borrowers via `listed_for_sale` or canonical `segment_codes` contains `listed`
- keep filed Building Permits and projected-savings gap handling intact
- update regression-suite, dashboard validation docs, and admin source-readiness docstring to match the current source-readiness posture

## Validation
- live Databricks focused check: `.venv/bin/python ... pytest -q tests/integration/test_genie_regression.py -k S20 --tb=short` => 1 passed
- local rubric tests for stale MLS gap / unfiltered SQL / accepted live listed predicates => 4 passed
- no-creds/static regression path: `.venv/bin/python -m pytest tests/integration/test_genie_regression.py -q -rs` => static checks passed, live prompts skipped as designed
- `.venv/bin/ruff check backend/api/admin.py tests/integration/test_genie_regression.py`
- `.venv/bin/python -m pytest tests/unit/test_genie_actions_api.py::test_mls_listing_prompt_is_not_treated_as_source_gap -q`
- `git diff --check`

## Notes
- Building Permits remains blocked/pending and is not claimed live.
