### PR TITLE
[codex] Stabilize deployed Genie eval gate

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -371,7 +371,21 @@ jobs:
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           DATABRICKS_WAREHOUSE_ID: ${{ secrets.DATABRICKS_WAREHOUSE_ID }}
           GENIE_SPACE_ID: ${{ secrets.GENIE_SPACE_ID }}
-        run: python tools/genie_eval.py --base "$MIP_APP_URL" --token "$MIP_BEARER_TOKEN" --timeout 120
+        run: |
+          python tools/wait_app_ready.py \
+            --base "$MIP_APP_URL" \
+            --token "$MIP_BEARER_TOKEN" \
+            --timeout-s 600 \
+            --interval-s 20 \
+            --breakers warehouse,lakebase,genie \
+            --genie-probe-question "Summarize the current Module 0 mortgage lead opportunity and cite the trusted assets."
+          python tools/genie_eval.py \
+            --base "$MIP_APP_URL" \
+            --token "$MIP_BEARER_TOKEN" \
+            --timeout 120 \
+            --attempts 4 \
+            --retry-backoff-s 20 \
+            --pace-s 2
       - name: Run real-UC Playwright specs
         # Config + specs both live under `frontend/` so `@playwright/test`
         # imports resolve against frontend/node_modules. E2E_LIVE-gated

--- a/backend/api/genie.py
+++ b/backend/api/genie.py
@@ -36,6 +36,7 @@ from backend.services.genie_answers import (
     GenieStartResponse,
     load_sample_questions,
 )
+from backend.services.genie_audit import genie_audit_entity_id
 from backend.services.genie_client import GenieClientError
 from backend.services.genie_sales_ops import sales_ops_genie_response
 from backend.services.genie_trusted_assets import trusted_assets
@@ -866,7 +867,7 @@ def genie_message(
         actor=actor,
         action="genie.run_query",
         entity_type="genie_message",
-        entity_id=result.message_id or result.conversation_id,
+        entity_id=genie_audit_entity_id(result),
         payload_json={
             "conversation_id": result.conversation_id,
             "message_id": result.message_id,

--- a/backend/services/genie_audit.py
+++ b/backend/services/genie_audit.py
@@ -1,0 +1,18 @@
+"""Audit helpers for Genie API responses."""
+
+from __future__ import annotations
+
+import hashlib
+
+from backend.services.genie_answers import GenieMessageResponse
+
+
+def genie_audit_entity_id(response: GenieMessageResponse) -> str:
+    """Return a PII-safe nonblank id for every Genie audit row."""
+
+    return (
+        response.message_id
+        or response.conversation_id
+        or response.question_hash
+        or hashlib.sha256(response.question.encode("utf-8")).hexdigest()[:16]
+    )

--- a/tests/unit/test_genie_actions_api.py
+++ b/tests/unit/test_genie_actions_api.py
@@ -177,6 +177,59 @@ def test_genie_message_honors_conversation_id() -> None:
     assert res.json()["conversation_id"] == "conv-test"
 
 
+def test_genie_degraded_message_audits_with_question_hash_entity_id() -> None:
+    class _CaptureAudit:
+        def __init__(self) -> None:
+            self.rows: list[dict[str, object]] = []
+
+        def write(self, **kwargs: object) -> None:
+            self.rows.append(kwargs)
+
+    class _Repo:
+        def respond(
+            self,
+            question: str,
+            conversation_id: str | None = None,
+        ) -> GenieMessageResponse:
+            _ = conversation_id
+            return GenieMessageResponse(
+                conversation_id="",
+                message_id=None,
+                question=question,
+                question_hash="hash-degraded",
+                answer="Genie is warming up.",
+                source="degraded",
+                trusted_assets=[],
+                row_count=0,
+                table_rows=[],
+            )
+
+    audit = _CaptureAudit()
+    prior_repo = app.dependency_overrides.get(get_genie_answer_repository)
+    prior_audit = app.dependency_overrides.get(get_audit_store)
+    app.dependency_overrides[get_genie_answer_repository] = lambda: _Repo()
+    app.dependency_overrides[get_audit_store] = lambda: audit
+    try:
+        res = client.post(
+            "/api/genie/message",
+            json={"question": "Summarize the current Module 0 opportunity."},
+            headers=ACTOR_HEADERS,
+        )
+    finally:
+        if prior_repo is None:
+            app.dependency_overrides.pop(get_genie_answer_repository, None)
+        else:
+            app.dependency_overrides[get_genie_answer_repository] = prior_repo
+        if prior_audit is None:
+            app.dependency_overrides.pop(get_audit_store, None)
+        else:
+            app.dependency_overrides[get_audit_store] = prior_audit
+
+    assert res.status_code == 200
+    assert res.json()["source"] == "degraded"
+    assert audit.rows[0]["entity_id"] == "hash-degraded"
+
+
 def test_genie_message_rejects_unowned_conversation_id() -> None:
     class _UnownedSessionLakebase:
         def fetchone(

--- a/tests/unit/test_genie_eval.py
+++ b/tests/unit/test_genie_eval.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import email.message
+import io
+import json
+import urllib.error
+from pathlib import Path
+
+import yaml
+
+from tools import genie_eval
+
+
+class _Response:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def _http_error(code: int, reason: str = "Service Unavailable") -> urllib.error.HTTPError:
+    headers = email.message.Message()
+    return urllib.error.HTTPError(
+        "https://example.invalid/api/genie/message",
+        code,
+        reason,
+        headers,
+        io.BytesIO(b'{"retry_after_seconds":0.01}'),
+    )
+
+
+def test_ask_retries_transient_503(monkeypatch) -> None:
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    def fake_urlopen(req, timeout):  # noqa: ANN001
+        calls.append(timeout)
+        if len(calls) == 1:
+            raise _http_error(503)
+        return _Response({"answer": "ok"})
+
+    monkeypatch.setattr(genie_eval.urllib.request, "urlopen", fake_urlopen)
+
+    payload, _elapsed = genie_eval._ask(
+        "https://example.invalid",
+        "token",
+        "question",
+        30,
+        attempts=2,
+        retry_backoff_s=20,
+        sleep=sleeps.append,
+    )
+
+    assert payload == {"answer": "ok"}
+    assert calls == [30, 30]
+    assert sleeps == [0.01]
+
+
+def test_ask_does_not_retry_non_transient_http_error(monkeypatch) -> None:
+    calls = 0
+
+    def fake_urlopen(req, timeout):  # noqa: ANN001
+        nonlocal calls
+        calls += 1
+        raise _http_error(400, "Bad Request")
+
+    monkeypatch.setattr(genie_eval.urllib.request, "urlopen", fake_urlopen)
+
+    payload, _elapsed = genie_eval._ask(
+        "https://example.invalid",
+        "token",
+        "question",
+        30,
+        attempts=3,
+        retry_backoff_s=20,
+        sleep=lambda _seconds: None,
+    )
+
+    assert calls == 1
+    assert payload["error"] == "HTTP 400: Bad Request"
+
+
+def test_permit_gap_eval_accepts_roadmap_language() -> None:
+    data = yaml.safe_load(Path("tools/genie_eval_questions.yml").read_text(encoding="utf-8"))
+    permit = next(q for q in data["questions"] if q["id"] == "blocked_permit_question")
+    assert "roadmap" in permit["require_keywords"]

--- a/tests/unit/test_wait_app_ready.py
+++ b/tests/unit/test_wait_app_ready.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+
+from tools import wait_app_ready
+
+
+class _Response:
+    def __init__(self, payload: dict[str, object], status: int = 200) -> None:
+        self._payload = payload
+        self.status = status
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def _http_error(code: int, payload: dict[str, object]) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        "https://example.invalid/api/admin/health",
+        code,
+        "Forbidden",
+        {},
+        io.BytesIO(json.dumps(payload).encode("utf-8")),
+    )
+
+
+def test_wait_ready_falls_back_to_authenticated_health_when_admin_forbidden(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_urlopen(req, timeout):  # noqa: ANN001
+        calls.append(req.full_url)
+        if req.full_url.endswith("/api/admin/health"):
+            raise _http_error(403, {"detail": "forbidden"})
+        return _Response(
+            {
+                "status": "ok",
+                "dependencies": {"warehouse": "up", "lakebase": "up", "genie": "up"},
+                "circuit_breakers": {"warehouse": "closed", "lakebase": "closed", "genie": "closed"},
+            }
+        )
+
+    monkeypatch.setattr(wait_app_ready.urllib.request, "urlopen", fake_urlopen)
+
+    body = wait_app_ready.wait_ready(
+        base="https://example.invalid",
+        token="token",
+        timeout_s=10,
+        interval_s=1,
+        request_timeout_s=3,
+        sleep=lambda _seconds: None,
+    )
+
+    assert body["status"] == "ok"
+    assert calls == [
+        "https://example.invalid/api/admin/health",
+        "https://example.invalid/api/health",
+    ]
+
+
+def test_wait_ready_waits_for_closed_breakers(monkeypatch) -> None:
+    attempts = 0
+    sleeps: list[float] = []
+
+    def fake_urlopen(req, timeout):  # noqa: ANN001
+        nonlocal attempts
+        attempts += 1
+        breaker = "open" if attempts == 1 else "closed"
+        return _Response(
+            {
+                "status": "ok",
+                "dependencies": {"warehouse": "up", "lakebase": "up", "genie": "up"},
+                "circuit_breakers": {"warehouse": "closed", "lakebase": "closed", "genie": breaker},
+            }
+        )
+
+    monkeypatch.setattr(wait_app_ready.urllib.request, "urlopen", fake_urlopen)
+
+    body = wait_app_ready.wait_ready(
+        base="https://example.invalid",
+        token="token",
+        timeout_s=10,
+        interval_s=1,
+        request_timeout_s=3,
+        sleep=sleeps.append,
+    )
+
+    assert body["circuit_breakers"]["genie"] == "closed"
+    assert attempts == 2
+    assert sleeps == [1]
+
+
+def test_wait_ready_can_warm_up_half_open_genie_breaker(monkeypatch) -> None:
+    health_attempts = 0
+    probe_calls = 0
+
+    def fake_urlopen(req, timeout):  # noqa: ANN001
+        nonlocal health_attempts, probe_calls
+        if req.full_url.endswith("/api/genie/message"):
+            probe_calls += 1
+            return _Response({"source": "genie"})
+        health_attempts += 1
+        breaker = "half_open" if health_attempts == 1 else "closed"
+        return _Response(
+            {
+                "status": "ok",
+                "dependencies": {"warehouse": "up", "lakebase": "up", "genie": "up"},
+                "circuit_breakers": {"warehouse": "closed", "lakebase": "closed", "genie": breaker},
+            }
+        )
+
+    monkeypatch.setattr(wait_app_ready.urllib.request, "urlopen", fake_urlopen)
+
+    body = wait_app_ready.wait_ready(
+        base="https://example.invalid",
+        token="token",
+        timeout_s=10,
+        interval_s=1,
+        request_timeout_s=3,
+        genie_probe_question="Warm Genie",
+        sleep=lambda _seconds: None,
+    )
+
+    assert body["circuit_breakers"]["genie"] == "closed"
+    assert probe_calls == 1
+
+
+def test_wait_ready_times_out_with_last_diagnostics(monkeypatch) -> None:
+    def fake_urlopen(req, timeout):  # noqa: ANN001
+        return _Response(
+            {
+                "status": "degraded",
+                "dependencies": {"warehouse": "up", "lakebase": "up", "genie": "down"},
+                "circuit_breakers": {"warehouse": "closed", "lakebase": "closed", "genie": "open"},
+            }
+        )
+
+    monkeypatch.setattr(wait_app_ready.urllib.request, "urlopen", fake_urlopen)
+
+    try:
+        wait_app_ready.wait_ready(
+            base="https://example.invalid",
+            token="token",
+            timeout_s=0,
+            interval_s=1,
+            request_timeout_s=3,
+            sleep=lambda _seconds: None,
+        )
+    except TimeoutError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("expected timeout")
+
+    assert "status='degraded'" in message
+    assert "dependencies.genie='down'" in message
+    assert "circuit_breakers.genie='open'" in message

--- a/tools/genie_eval.py
+++ b/tools/genie_eval.py
@@ -31,6 +31,7 @@ Use ``--soft`` only for exploratory runs where writing the report is enough.
 from __future__ import annotations
 
 import argparse
+import email.message
 import json
 import logging
 import os
@@ -52,6 +53,10 @@ BASELINE_PATH = REPORT_DIR / "baseline.json"
 LATEST_PATH = REPORT_DIR / "latest.json"
 REGRESSION_THRESHOLD = 10.0  # points
 DEFAULT_CATALOG = "mip"
+DEFAULT_ATTEMPTS = int(os.environ.get("MIP_GENIE_EVAL_ATTEMPTS", "4"))
+DEFAULT_RETRY_BACKOFF_S = float(os.environ.get("MIP_GENIE_EVAL_RETRY_BACKOFF_S", "20"))
+DEFAULT_PACE_S = float(os.environ.get("MIP_GENIE_EVAL_PACE_S", "2"))
+_RETRYABLE_HTTP_CODES = {429, 502, 503, 504}
 
 log = logging.getLogger("genie_eval")
 
@@ -125,28 +130,137 @@ def _render_catalog_templates(value: Any, *, catalog: str) -> Any:
     return value
 
 
-def _ask(base: str, token: str | None, question: str, timeout_s: int) -> tuple[
-    dict[str, Any], float
-]:
-    """Hit /api/genie/message; return (response_json, elapsed_s)."""
+def _request_payload(base: str, token: str | None, question: str) -> urllib.request.Request:
     url = f"{base.rstrip('/')}/api/genie/message"
     body = json.dumps({"question": question}).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    req = urllib.request.Request(url, data=body, method="POST", headers=headers)
-    start = time.monotonic()
+    return urllib.request.Request(url, data=body, method="POST", headers=headers)
+
+
+def _http_error_payload(exc: urllib.error.HTTPError) -> dict[str, Any]:
     try:
-        with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310 -- internal API
-            payload = json.loads(resp.read().decode("utf-8"))
-    except urllib.error.HTTPError as e:
-        elapsed = time.monotonic() - start
-        return ({"error": f"HTTP {e.code}: {e.reason}"}, elapsed)
-    except urllib.error.URLError as e:
-        elapsed = time.monotonic() - start
-        return ({"error": f"URLError: {e.reason}"}, elapsed)
+        raw = exc.read()
+    except Exception:  # noqa: BLE001 -- best effort diagnostic only
+        raw = b""
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except Exception:  # noqa: BLE001 -- non-JSON error bodies are valid
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _retry_after_s(
+    *,
+    code: int,
+    headers: email.message.Message,
+    payload: dict[str, Any],
+    attempt: int,
+    retry_backoff_s: float,
+) -> float:
+    retry_after = headers.get("Retry-After")
+    if retry_after:
+        try:
+            return max(0.0, float(retry_after))
+        except ValueError:
+            pass
+
+    for key in ("retry_after_seconds", "retry_after_s"):
+        value = payload.get(key)
+        if isinstance(value, int | float):
+            return max(0.0, float(value))
+    detail = payload.get("detail")
+    if isinstance(detail, dict):
+        for key in ("retry_after_seconds", "retry_after_s"):
+            value = detail.get(key)
+            if isinstance(value, int | float):
+                return max(0.0, float(value))
+
+    # Genie's app-side breaker cools down after 20s. Respect that by default
+    # so the eval can run immediately after the live Genie regression suite.
+    multiplier = max(1, attempt)
+    if code == 429:
+        multiplier += 1
+    return max(0.0, retry_backoff_s * multiplier)
+
+
+def _ask(
+    base: str,
+    token: str | None,
+    question: str,
+    timeout_s: int,
+    *,
+    attempts: int = DEFAULT_ATTEMPTS,
+    retry_backoff_s: float = DEFAULT_RETRY_BACKOFF_S,
+    sleep: Any = time.sleep,
+) -> tuple[dict[str, Any], float]:
+    """Hit /api/genie/message; return (response_json, elapsed_s).
+
+    The eval often runs immediately after the live Genie regression suite.
+    That can leave the deployed app's Genie breaker half-open or cooling down.
+    Retry only clearly transient HTTP failures; policy/refusal failures still
+    score normally through the returned response body.
+    """
+    attempts = max(1, attempts)
+    start = time.monotonic()
+    last_error: dict[str, Any] | None = None
+    for attempt in range(1, attempts + 1):
+        req = _request_payload(base, token, question)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310 -- internal API
+                payload = json.loads(resp.read().decode("utf-8"))
+            elapsed = time.monotonic() - start
+            return payload, elapsed
+        except urllib.error.HTTPError as exc:
+            payload = _http_error_payload(exc)
+            retryable = exc.code in _RETRYABLE_HTTP_CODES and attempt < attempts
+            last_error = {
+                "error": f"HTTP {exc.code}: {exc.reason}",
+                "http_status": exc.code,
+                "attempts": attempt,
+            }
+            if retryable:
+                delay_s = _retry_after_s(
+                    code=exc.code,
+                    headers=exc.headers,
+                    payload=payload,
+                    attempt=attempt,
+                    retry_backoff_s=retry_backoff_s,
+                )
+                log.warning(
+                    "  transient HTTP %s from Genie eval; retrying in %.1fs (%d/%d)",
+                    exc.code,
+                    delay_s,
+                    attempt + 1,
+                    attempts,
+                )
+                sleep(delay_s)
+                continue
+            elapsed = time.monotonic() - start
+            return last_error, elapsed
+        except urllib.error.URLError as exc:
+            retryable = attempt < attempts
+            last_error = {
+                "error": f"URLError: {exc.reason}",
+                "attempts": attempt,
+            }
+            if retryable:
+                delay_s = retry_backoff_s * attempt
+                log.warning(
+                    "  transient URL error from Genie eval; retrying in %.1fs (%d/%d)",
+                    delay_s,
+                    attempt + 1,
+                    attempts,
+                )
+                sleep(delay_s)
+                continue
+            elapsed = time.monotonic() - start
+            return last_error, elapsed
     elapsed = time.monotonic() - start
-    return payload, elapsed
+    return last_error or {"error": "unknown Genie eval request failure"}, elapsed
 
 
 def _warehouse_creds() -> tuple[str, str, str] | None:
@@ -489,6 +603,9 @@ def main() -> int:
     parser.add_argument("--base", required=True, help="Base URL for the MIP API")
     parser.add_argument("--token", default=os.environ.get("DATABRICKS_TOKEN"))
     parser.add_argument("--timeout", type=int, default=60)
+    parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS)
+    parser.add_argument("--retry-backoff-s", type=float, default=DEFAULT_RETRY_BACKOFF_S)
+    parser.add_argument("--pace-s", type=float, default=DEFAULT_PACE_S)
     parser.add_argument("--report-dir", default=str(REPORT_DIR))
     parser.add_argument("--update-baseline", action="store_true",
                         help="Treat this run's overall score as the new floor")
@@ -504,9 +621,16 @@ def main() -> int:
     log.info("genie_eval: loaded %d questions", len(questions))
 
     scores: list[QuestionScore] = []
-    for q in questions:
+    for idx, q in enumerate(questions):
         log.info("ask %s: %s", q["id"], q["question"][:60])
-        response, elapsed_s = _ask(args.base, args.token, q["question"], args.timeout)
+        response, elapsed_s = _ask(
+            args.base,
+            args.token,
+            q["question"],
+            args.timeout,
+            attempts=args.attempts,
+            retry_backoff_s=args.retry_backoff_s,
+        )
         s = _score_question(q, response, elapsed_s)
         log.info(
             "  → score %.0f (latency %.1fs, %s)",
@@ -514,6 +638,8 @@ def main() -> int:
             "PASS" if s.passed else "FAIL: " + "; ".join(s.notes),
         )
         scores.append(s)
+        if args.pace_s > 0 and idx < len(questions) - 1:
+            time.sleep(args.pace_s)
 
     stamp = datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%SZ")
     Path(args.report_dir).mkdir(parents=True, exist_ok=True)

--- a/tools/genie_eval_questions.yml
+++ b/tools/genie_eval_questions.yml
@@ -208,16 +208,17 @@ questions:
   # The known BLOCKED-data trap. We INTENTIONALLY ask the question that
   # caused the round-4 hallucination so the eval catches a regression
   # if the YAML clarification gets reverted. The answer must mention
-  # blocked / pending / unavailable so the user knows why.
+  # blocked / pending / unavailable / roadmap so the user knows why.
   - id: blocked_permit_question
     category: governance
     question: Show HELOC candidates with recent permits and strong equity.
     must_cite: []
     forbid_keywords: []
     require_keywords:
-      - blocked  # OR pending OR unavailable — checked by OR-ing all
+      - blocked  # OR pending OR unavailable OR roadmap — checked by OR-ing all
       - pending
       - unavailable
+      - roadmap
     min_rows: 0
     max_latency_s: 6
 

--- a/tools/wait_app_ready.py
+++ b/tools/wait_app_ready.py
@@ -1,0 +1,213 @@
+"""Poll a deployed MIP app until live dependencies and breakers are ready.
+
+The public health endpoint intentionally returns HTTP 200 even for degraded
+state so Databricks Apps load balancers do not evict a warm container. Live
+release gates need a stricter contract before expensive Genie/Playwright work:
+dependencies must be up and selected circuit breakers must be closed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+DEFAULT_DEPS = ("warehouse", "lakebase", "genie")
+
+
+def _request_json(
+    base: str,
+    path: str,
+    token: str | None,
+    timeout_s: int,
+    *,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    headers = {"Accept": "application/json"}
+    data = None
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(payload).encode("utf-8")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(
+        f"{base.rstrip('/')}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310 -- internal app URL
+            raw = resp.read().decode("utf-8")
+            return int(resp.status), json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            body = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            body = {"detail": raw}
+        return int(exc.code), body if isinstance(body, dict) else {"detail": body}
+
+
+def _health_payload(base: str, token: str | None, request_timeout_s: int) -> tuple[str, int, dict[str, Any]]:
+    """Prefer admin diagnostics; fall back to authenticated browser health."""
+
+    status, body = _request_json(base, "/api/admin/health", token, request_timeout_s)
+    if status == 200:
+        return "/api/admin/health", status, body
+    if status not in {401, 403, 404}:
+        return "/api/admin/health", status, body
+    path, status, body = "/api/health", *_request_json(base, "/api/health", token, request_timeout_s)
+    return path, status, body
+
+
+def _genie_probe(
+    base: str,
+    token: str | None,
+    request_timeout_s: int,
+    question: str,
+) -> tuple[int, dict[str, Any]]:
+    return _request_json(
+        base,
+        "/api/genie/message",
+        token,
+        request_timeout_s,
+        method="POST",
+        payload={"question": question},
+    )
+
+
+def _readiness_errors(body: dict[str, Any], *, deps: tuple[str, ...], breakers: tuple[str, ...]) -> list[str]:
+    errors: list[str] = []
+    status = body.get("status")
+    if status != "ok":
+        errors.append(f"status={status!r}")
+
+    dependencies = body.get("dependencies")
+    if not isinstance(dependencies, dict):
+        errors.append("dependencies missing")
+    else:
+        for dep in deps:
+            if dependencies.get(dep) != "up":
+                errors.append(f"dependencies.{dep}={dependencies.get(dep)!r}")
+
+    circuit_breakers = body.get("circuit_breakers")
+    if not isinstance(circuit_breakers, dict):
+        if breakers:
+            errors.append("circuit_breakers missing")
+    else:
+        for breaker in breakers:
+            if circuit_breakers.get(breaker) != "closed":
+                errors.append(f"circuit_breakers.{breaker}={circuit_breakers.get(breaker)!r}")
+    return errors
+
+
+def wait_ready(
+    *,
+    base: str,
+    token: str | None,
+    timeout_s: int,
+    interval_s: float,
+    request_timeout_s: int,
+    deps: tuple[str, ...] = DEFAULT_DEPS,
+    breakers: tuple[str, ...] = DEFAULT_DEPS,
+    genie_probe_question: str | None = None,
+    sleep: Any = time.sleep,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_s
+    attempt = 0
+    last: tuple[str, int, dict[str, Any], list[str]] | None = None
+    while True:
+        attempt += 1
+        path, status, body = _health_payload(base, token, request_timeout_s)
+        if status == 200:
+            errors = _readiness_errors(body, deps=deps, breakers=breakers)
+        else:
+            errors = [f"{path} HTTP {status}"]
+        if not errors:
+            print(f"[wait-app-ready] ready after {attempt} attempt(s) via {path}")
+            return body
+        last = (path, status, body, errors)
+        if (
+            genie_probe_question
+            and "genie" in breakers
+            and isinstance(body.get("dependencies"), dict)
+            and body["dependencies"].get("genie") == "up"
+            and isinstance(body.get("circuit_breakers"), dict)
+            and body["circuit_breakers"].get("genie") in {"open", "half_open"}
+        ):
+            probe_status, probe_body = _genie_probe(
+                base,
+                token,
+                request_timeout_s,
+                genie_probe_question,
+            )
+            source = probe_body.get("source") if isinstance(probe_body, dict) else None
+            print(
+                "[wait-app-ready] genie warm-up probe "
+                f"status={probe_status} source={source!r}",
+                flush=True,
+            )
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            path, status, body, errors = last
+            raise TimeoutError(
+                "app did not become ready within "
+                f"{timeout_s}s; last={path} HTTP {status}; errors={'; '.join(errors)}; "
+                f"body={json.dumps(body, sort_keys=True)[:4000]}"
+            )
+        print(
+            "[wait-app-ready] not ready "
+            f"attempt={attempt} path={path} status={status} errors={'; '.join(errors)}",
+            flush=True,
+        )
+        sleep(min(interval_s, max(0.0, remaining)))
+
+
+def _csv(value: str) -> tuple[str, ...]:
+    return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="Deployed app base URL")
+    parser.add_argument("--token", default=os.environ.get("MIP_BEARER_TOKEN"))
+    parser.add_argument("--timeout-s", type=int, default=300)
+    parser.add_argument("--interval-s", type=float, default=10.0)
+    parser.add_argument("--request-timeout-s", type=int, default=30)
+    parser.add_argument("--deps", default=",".join(DEFAULT_DEPS))
+    parser.add_argument("--breakers", default=",".join(DEFAULT_DEPS))
+    parser.add_argument(
+        "--genie-probe-question",
+        default="",
+        help=(
+            "Optional governed /api/genie/message prompt used to close a "
+            "half-open Genie breaker before semantic scoring."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        wait_ready(
+            base=args.base,
+            token=args.token,
+            timeout_s=args.timeout_s,
+            interval_s=args.interval_s,
+            request_timeout_s=args.request_timeout_s,
+            deps=_csv(args.deps),
+            breakers=_csv(args.breakers),
+            genie_probe_question=args.genie_probe_question.strip() or None,
+        )
+    except Exception as exc:  # noqa: BLE001 -- CLI diagnostic boundary
+        print(f"[wait-app-ready] {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- Fixes deployed Genie degraded responses that had no live conversation/message id by auditing them with the deterministic `question_hash` entity id.
- Adds `tools/wait_app_ready.py` to poll deployed app health until dependencies are up and selected breakers are closed before expensive live scorecards.
- Adds transient retry, backoff, and pacing to `tools/genie_eval.py`.
- Allows `roadmap` as valid Building Permits gap language in the Genie eval rubric.
- Wires the readiness gate into the live validation workflow before the deployed Genie semantic eval.

## Root cause

The live workflow ran the deployed semantic Genie scorecard immediately after a heavy Genie regression suite. The app could still have the Genie breaker open or half-open. In that state the Genie route returns an honest degraded response, but that degraded response has no live `message_id` or `conversation_id`; the required audit call passed a blank `entity_id`, and the audit validator rejected it. The route sanitized that validation failure as `lakebase is temporarily unavailable`, causing the scorecard to fail before Playwright ran.

## Validation

- `.venv/bin/ruff check backend/api/genie.py tools/genie_eval.py tools/wait_app_ready.py tests/unit/test_genie_actions_api.py tests/unit/test_genie_eval.py tests/unit/test_wait_app_ready.py`
- `.venv/bin/python -m pytest tests/unit/test_genie_actions_api.py::test_genie_degraded_message_audits_with_question_hash_entity_id tests/unit/test_genie_eval.py tests/unit/test_wait_app_ready.py tests/unit/test_docs_claim_guardrails.py -q`
- `.venv/bin/python -m pytest tests/unit/test_genie_actions_api.py -q`

## Notes

This does not change approval/outreach fail-closed semantics. Governed write actions still require successful audit writes. The change only fixes the read-only Genie audit entity id for degraded responses.
