### PR TITLE
[codex] Retry degraded Genie eval responses

### DIFF
--- a/tests/unit/test_genie_eval.py
+++ b/tests/unit/test_genie_eval.py
@@ -63,6 +63,33 @@ def test_ask_retries_transient_503(monkeypatch) -> None:
     assert sleeps == [0.01]
 
 
+def test_ask_retries_degraded_response_body(monkeypatch) -> None:
+    calls: list[int] = []
+    sleeps: list[float] = []
+
+    def fake_urlopen(req, timeout):  # noqa: ANN001
+        calls.append(timeout)
+        if len(calls) == 1:
+            return _Response({"source": "degraded", "answer": "warming"})
+        return _Response({"source": "genie", "answer": "ok"})
+
+    monkeypatch.setattr(genie_eval.urllib.request, "urlopen", fake_urlopen)
+
+    payload, _elapsed = genie_eval._ask(
+        "https://example.invalid",
+        "token",
+        "question",
+        30,
+        attempts=2,
+        retry_backoff_s=20,
+        sleep=sleeps.append,
+    )
+
+    assert payload == {"source": "genie", "answer": "ok"}
+    assert calls == [30, 30]
+    assert sleeps == [20]
+
+
 def test_ask_does_not_retry_non_transient_http_error(monkeypatch) -> None:
     calls = 0
 

--- a/tools/genie_eval.py
+++ b/tools/genie_eval.py
@@ -212,6 +212,16 @@ def _ask(
         try:
             with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310 -- internal API
                 payload = json.loads(resp.read().decode("utf-8"))
+            if payload.get("source") == "degraded" and attempt < attempts:
+                delay_s = retry_backoff_s * attempt
+                log.warning(
+                    "  transient degraded Genie response; retrying in %.1fs (%d/%d)",
+                    delay_s,
+                    attempt + 1,
+                    attempts,
+                )
+                sleep(delay_s)
+                continue
             elapsed = time.monotonic() - start
             return payload, elapsed
         except urllib.error.HTTPError as exc:


### PR DESCRIPTION
## What changed

- Retries `source="degraded"` Genie response bodies in `tools/genie_eval.py` before scoring.
- Adds a unit regression test for degraded-body retry behavior.

## Root cause

After the router fix, a live Genie warm-up question correctly returns HTTP 200 instead of the previous Lakebase 503. However, the first request after deploy can still legitimately return `source="degraded"` while Genie reconnects. The semantic scorecard treated that body as a final answer and would score it as a content failure instead of a transient runtime state.

## Validation

- `.venv/bin/ruff check tools/genie_eval.py tests/unit/test_genie_eval.py`
- `.venv/bin/python -m pytest tests/unit/test_genie_eval.py -q`
