### PR TITLE
Route canonical Genie eval prompts through trusted SQL

### DIFF
--- a/backend/services/repositories/databricks_genie_canonical.py
+++ b/backend/services/repositories/databricks_genie_canonical.py
@@ -1,4 +1,5 @@
 """Canonical SQL and question-scope helpers for Databricks Genie answers."""
+
 from __future__ import annotations
 
 import re
@@ -8,6 +9,7 @@ from backend.services.databricks_sql_helpers import qualify
 _BORROWER_360 = qualify("gold", "borrower_360")
 _EVIDENCE_EVENTS = qualify("gold", "evidence_events")
 _LEAD_POPULATION = qualify("gold", "lead_population")
+_SEGMENT_POPULATION = qualify("gold", "segment_population")
 
 _CANONICAL_ITM_COUNT_SQL = f"""
 SELECT COUNT(*) AS in_the_money_borrowers
@@ -270,28 +272,77 @@ ORDER BY ms.borrowers DESC, ms.avg_score DESC, ms.msa_cbsa_code ASC
 LIMIT 5
 """.strip()
 
+_CANONICAL_INVESTOR_SEGMENT_BY_STATE_SQL = f"""
+SELECT segment_code
+     , state
+     , count AS investor_borrowers
+     , avg_score
+     , delta_vs_prior
+     , refreshed_at
+FROM {_SEGMENT_POPULATION}
+WHERE segment_code = 'investor'
+  AND state <> '_ALL'
+  AND count > 0
+ORDER BY count DESC, avg_score DESC, state ASC
+LIMIT 20
+""".strip()
+
 _US_STATE_FILTERS: tuple[tuple[str, str], ...] = (
-    ("alabama", "AL"), ("alaska", "AK"), ("arizona", "AZ"), ("arkansas", "AR"),
-    ("california", "CA"), ("colorado", "CO"), ("connecticut", "CT"), ("delaware", "DE"),
-    ("florida", "FL"), ("georgia", "GA"), ("hawaii", "HI"), ("idaho", "ID"),
-    ("illinois", "IL"), ("indiana", "IN"), ("iowa", "IA"), ("kansas", "KS"),
-    ("kentucky", "KY"), ("louisiana", "LA"), ("maine", "ME"), ("maryland", "MD"),
-    ("massachusetts", "MA"), ("michigan", "MI"), ("minnesota", "MN"),
-    ("mississippi", "MS"), ("missouri", "MO"), ("montana", "MT"), ("nebraska", "NE"),
-    ("nevada", "NV"), ("new hampshire", "NH"), ("new jersey", "NJ"),
-    ("new mexico", "NM"), ("new york", "NY"), ("north carolina", "NC"),
-    ("north dakota", "ND"), ("ohio", "OH"), ("oklahoma", "OK"), ("oregon", "OR"),
-    ("pennsylvania", "PA"), ("rhode island", "RI"), ("south carolina", "SC"),
-    ("south dakota", "SD"), ("tennessee", "TN"), ("texas", "TX"), ("utah", "UT"),
-    ("vermont", "VT"), ("virginia", "VA"), ("washington", "WA"),
-    ("west virginia", "WV"), ("wisconsin", "WI"), ("wyoming", "WY"),
+    ("alabama", "AL"),
+    ("alaska", "AK"),
+    ("arizona", "AZ"),
+    ("arkansas", "AR"),
+    ("california", "CA"),
+    ("colorado", "CO"),
+    ("connecticut", "CT"),
+    ("delaware", "DE"),
+    ("florida", "FL"),
+    ("georgia", "GA"),
+    ("hawaii", "HI"),
+    ("idaho", "ID"),
+    ("illinois", "IL"),
+    ("indiana", "IN"),
+    ("iowa", "IA"),
+    ("kansas", "KS"),
+    ("kentucky", "KY"),
+    ("louisiana", "LA"),
+    ("maine", "ME"),
+    ("maryland", "MD"),
+    ("massachusetts", "MA"),
+    ("michigan", "MI"),
+    ("minnesota", "MN"),
+    ("mississippi", "MS"),
+    ("missouri", "MO"),
+    ("montana", "MT"),
+    ("nebraska", "NE"),
+    ("nevada", "NV"),
+    ("new hampshire", "NH"),
+    ("new jersey", "NJ"),
+    ("new mexico", "NM"),
+    ("new york", "NY"),
+    ("north carolina", "NC"),
+    ("north dakota", "ND"),
+    ("ohio", "OH"),
+    ("oklahoma", "OK"),
+    ("oregon", "OR"),
+    ("pennsylvania", "PA"),
+    ("rhode island", "RI"),
+    ("south carolina", "SC"),
+    ("south dakota", "SD"),
+    ("tennessee", "TN"),
+    ("texas", "TX"),
+    ("utah", "UT"),
+    ("vermont", "VT"),
+    ("virginia", "VA"),
+    ("washington", "WA"),
+    ("west virginia", "WV"),
+    ("wisconsin", "WI"),
+    ("wyoming", "WY"),
 )
 _AMBIGUOUS_STATE_CODES: frozenset[str] = frozenset({"HI", "ID", "IN", "ME", "OH", "OK", "OR"})
 
 
-def _ambiguous_state_code_match_is_contextual(
-    question: str, match: re.Match[str]
-) -> bool:
+def _ambiguous_state_code_match_is_contextual(question: str, match: re.Match[str]) -> bool:
     before = question[: match.start()]
     after = question[match.end() :]
     has_geo_preface = bool(
@@ -489,7 +540,9 @@ def _canonical_itm_state_breakdown_scope(question: str) -> bool:
         any(term in q for term in ("in-the-money", "in the money", "itm", "refi", "refinance"))
         and any(term in q for term in ("borrower", "lead", "candidate"))
         and "state" in q
-        and any(term in q for term in ("break down", "breakdown", "by state", "state by state", "table"))
+        and any(
+            term in q for term in ("break down", "breakdown", "by state", "state by state", "table")
+        )
     )
 
 
@@ -533,6 +586,24 @@ def _canonical_strategy_board_scope(question: str) -> bool:
         any(term in q for term in spend_terms)
         and any(term in q for term in touch_terms)
         and (has_touch_count or any(term in q for term in strategy_terms))
+    )
+
+
+def _canonical_investor_segment_by_state_scope(question: str) -> bool:
+    q = re.sub(r"[^a-z0-9\s/-]+", " ", question.lower())
+    q = re.sub(r"\s+", " ", q).strip()
+    investor_terms = (
+        "investor",
+        "multi property",
+        "multi-property",
+        "multi property segment",
+        "multi-property segment",
+    )
+    state_terms = ("state", "by state", "broken down", "breakdown", "break down")
+    return (
+        any(term in q for term in investor_terms)
+        and "segment" in q
+        and any(term in q for term in state_terms)
     )
 
 

--- a/backend/services/repositories/databricks_genie_direct.py
+++ b/backend/services/repositories/databricks_genie_direct.py
@@ -1,4 +1,5 @@
 """Direct trusted-SQL answers for narrow canonical Genie questions."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -6,18 +7,40 @@ from typing import Any
 from backend.services.databricks_sql import DatabricksSqlClient, DatabricksSqlError
 from backend.services.databricks_sql_helpers import qualify
 from backend.services.genie_answers import GenieMessageResponse
-from backend.services.repositories.databricks_genie_actions import _suggest_genie_actions
+from backend.services.repositories.databricks_genie_actions import (
+    _suggest_genie_actions,
+    _total_matching_from_rows,
+)
 from backend.services.repositories.databricks_genie_canonical import (
+    _CANONICAL_CASH_OUT_TOP_STATE_SQL,
+    _CANONICAL_CURRENT_CUSTOMER_RETENTION_RISK_SQL,
+    _CANONICAL_HELOC_TOP_ZIPS_SQL,
+    _CANONICAL_INVESTOR_SEGMENT_BY_STATE_SQL,
     _CANONICAL_ITM_BY_STATE_SQL,
+    _CANONICAL_ITM_COUNT_BY_CITY_SQL,
     _CANONICAL_ITM_COUNT_BY_STATE_SQL,
     _CANONICAL_ITM_COUNT_SQL,
     _CANONICAL_ITM_TOP_ZIPS_SQL,
+    _CANONICAL_MSA_SCORE_SQL,
+    _CANONICAL_RETENTION_COMPETITOR_LIEN_LIST_SQL,
+    _CANONICAL_STRATEGY_BOARD_SQL,
+    _CANONICAL_TOP_BORROWERS_BY_STATE_SQL,
+    _canonical_cash_out_state_scope,
+    _canonical_heloc_zip_scope,
     _canonical_in_the_money_count_scope,
+    _canonical_investor_segment_by_state_scope,
+    _canonical_itm_city_scope,
     _canonical_itm_state_breakdown_scope,
     _canonical_itm_zip_scope,
+    _canonical_msa_score_scope,
+    _canonical_strategy_board_scope,
+    _canonical_top_borrowers_state_scope,
+    _retention_competitor_lien_list_question,
+    _retention_risk_question,
 )
 from backend.services.repositories.databricks_genie_policy_helpers import (
     _emit_genie_warning,
+    _redact_genie_rows,
 )
 from backend.services.repositories.databricks_genie_trust import (
     _build_genie_proof,
@@ -87,11 +110,252 @@ def direct_canonical_response(
     if sql_client is None:
         return None
     borrower_asset = qualify("gold", "borrower_360")
+    evidence_asset = qualify("gold", "evidence_events")
+    lead_population_asset = qualify("gold", "lead_population")
+    segment_population_asset = qualify("gold", "segment_population")
     trusted_assets = [borrower_asset]
+
+    top_borrower_state_scope = _canonical_top_borrowers_state_scope(question)
+    if top_borrower_state_scope is not None:
+        state_name, state_code = top_borrower_state_scope
+        try:
+            rows = (
+                _redact_genie_rows(
+                    sql_client.execute(
+                        _CANONICAL_TOP_BORROWERS_BY_STATE_SQL,
+                        {"state": state_code},
+                    )
+                )
+                or []
+            )
+        except DatabricksSqlError as exc:
+            _emit_genie_warning("direct_canonical_genie_top_borrowers_state_failed", exc=exc)
+            return None
+        if rows:
+            top = rows[0]
+            answer = (
+                f"I ranked the top {len(rows)} {state_name} ({state_code}) borrowers "
+                f"by lead score from {lead_population_asset}. "
+                f"The current leader is masked borrower {top.get('borrower_id')} "
+                f"with lead score {int(top.get('lead_score') or 0):,}."
+            )
+        else:
+            answer = (
+                f"The trusted lead population returned no {state_name} ({state_code}) "
+                "borrowers for the current refreshed data coverage."
+            )
+        return _trusted_sql_response(
+            question=question,
+            sql_query=_CANONICAL_TOP_BORROWERS_BY_STATE_SQL,
+            trusted_assets=[lead_population_asset],
+            rows=rows,
+            answer=answer,
+        )
+
+    if _canonical_heloc_zip_scope(question):
+        try:
+            rows = _redact_genie_rows(sql_client.execute(_CANONICAL_HELOC_TOP_ZIPS_SQL)) or []
+        except DatabricksSqlError as exc:
+            _emit_genie_warning("direct_canonical_genie_heloc_zips_failed", exc=exc)
+            return None
+        if rows:
+            top = rows[0]
+            answer = (
+                "I ranked ZIP codes by HELOC-eligible borrowers with equity_pct "
+                f"at or above 35% from {borrower_asset}. "
+                f"The current leader is ZIP {top.get('zip')} ({top.get('state')}) "
+                f"with {int(top.get('heloc_eligible_borrowers') or 0):,} borrowers. "
+                "This is an equity-only HELOC eligibility view; Building Permits "
+                "signals remain pending and are not used as triggers here."
+            )
+        else:
+            answer = (
+                "The trusted borrower table returned no equity-only HELOC ZIP rows "
+                "for the current refreshed data coverage. Building Permits signals "
+                "remain pending and are not treated as zero demand."
+            )
+        return _trusted_sql_response(
+            question=question,
+            sql_query=_CANONICAL_HELOC_TOP_ZIPS_SQL,
+            trusted_assets=trusted_assets,
+            rows=rows,
+            answer=answer,
+        )
+
+    if _canonical_strategy_board_scope(question):
+        try:
+            rows = _redact_genie_rows(sql_client.execute(_CANONICAL_STRATEGY_BOARD_SQL)) or []
+        except DatabricksSqlError as exc:
+            _emit_genie_warning("direct_canonical_genie_strategy_board_failed", exc=exc)
+            return None
+        if rows:
+            top = rows[0]
+            answer = (
+                f"Use {borrower_asset} to prioritize the next 10,000 outreach touches "
+                "by state, segment, and offer. "
+                f"The top lane is state {top.get('state')}, segment "
+                f"{top.get('segment_code')}, with "
+                f"{int(top.get('marketable_borrowers') or 0):,} marketable borrowers "
+                f"and leading offer {top.get('leading_recommended_offer') or top.get('leading_offer_code')}. "
+                "The table ranks the remaining state-segment-offer lanes by average "
+                "opportunity score and marketable borrower volume."
+            )
+        else:
+            answer = (
+                "The trusted borrower table returned no opt-in, marketing-eligible "
+                "state-segment-offer lanes for the current refreshed data coverage."
+            )
+        return _trusted_sql_response(
+            question=question,
+            sql_query=_CANONICAL_STRATEGY_BOARD_SQL,
+            trusted_assets=trusted_assets,
+            rows=rows,
+            answer=answer,
+        )
+
+    if _canonical_cash_out_state_scope(question):
+        try:
+            rows = _redact_genie_rows(sql_client.execute(_CANONICAL_CASH_OUT_TOP_STATE_SQL)) or []
+        except DatabricksSqlError as exc:
+            _emit_genie_warning("direct_canonical_genie_cash_out_state_failed", exc=exc)
+            return None
+        metric_value: str | None = None
+        if rows:
+            top = rows[0]
+            count_int = int(top.get("cash_out_borrowers") or 0)
+            metric_value = f"{count_int:,}"
+            answer = (
+                f"{top.get('state')} has the most cash-out opportunity right now "
+                f"with {count_int:,} borrowers. This uses recommended_offer_code = "
+                f"'cash_out' at the unique borrower grain from {borrower_asset}."
+            )
+        else:
+            answer = (
+                "The trusted borrower table returned no cash-out state rows for "
+                "the current refreshed data coverage."
+            )
+        return _trusted_sql_response(
+            question=question,
+            sql_query=_CANONICAL_CASH_OUT_TOP_STATE_SQL,
+            trusted_assets=trusted_assets,
+            rows=rows,
+            answer=answer,
+            metric_value=metric_value,
+        )
+
+    if _canonical_investor_segment_by_state_scope(question):
+        try:
+            rows = (
+                _redact_genie_rows(sql_client.execute(_CANONICAL_INVESTOR_SEGMENT_BY_STATE_SQL))
+                or []
+            )
+        except DatabricksSqlError as exc:
+            _emit_genie_warning("direct_canonical_genie_investor_segment_failed", exc=exc)
+            return None
+        if rows:
+            top = rows[0]
+            answer = (
+                "I broke the Investor / Multi-Property segment down by state from "
+                f"{segment_population_asset}. "
+                f"{top.get('state')} currently leads with "
+                f"{int(top.get('investor_borrowers') or 0):,} segment borrowers."
+            )
+        else:
+            answer = (
+                "The trusted segment population returned no Investor / Multi-Property "
+                "state rows for the current refreshed data coverage."
+            )
+        return _trusted_sql_response(
+            question=question,
+            sql_query=_CANONICAL_INVESTOR_SEGMENT_BY_STATE_SQL,
+            trusted_assets=[segment_population_asset],
+            rows=rows,
+            answer=answer,
+        )
+
+    if _retention_competitor_lien_list_question(question):
+        try:
+            rows = (
+                _redact_genie_rows(
+                    sql_client.execute(_CANONICAL_RETENTION_COMPETITOR_LIEN_LIST_SQL)
+                )
+                or []
+            )
+        except DatabricksSqlError as exc:
+            _emit_genie_warning("direct_canonical_genie_retention_competitor_lien_failed", exc=exc)
+            return None
+        total_matching = _total_matching_from_rows(rows)
+        shown_count = len(rows)
+        if rows and total_matching > shown_count:
+            answer = (
+                f"There are {total_matching:,} retention-list borrowers with "
+                f"competitor-lien evidence in the last 30 days; showing the first "
+                f"{shown_count:,} by latest evidence timestamp and opportunity score. "
+                f"The result uses the governed `competitor_lien` signal_type from {evidence_asset}."
+            )
+        elif rows:
+            answer = (
+                f"I found {shown_count:,} retention-list borrowers with competitor-lien "
+                f"evidence in the last 30 days from {evidence_asset}."
+            )
+        else:
+            answer = (
+                "No retention-list borrowers have governed competitor-lien evidence "
+                "in the last 30 days. This is a live result from the modeled "
+                "`competitor_lien` signal_type, not a stale `lien-change` alias."
+            )
+        return _trusted_sql_response(
+            question=question,
+            sql_query=_CANONICAL_RETENTION_COMPETITOR_LIEN_LIST_SQL,
+            trusted_assets=[borrower_asset, evidence_asset],
+            rows=rows,
+            answer=answer,
+            metric_value=f"{total_matching:,}",
+        )
+
+    if _retention_risk_question(question):
+        try:
+            row = sql_client.execute_one(_CANONICAL_CURRENT_CUSTOMER_RETENTION_RISK_SQL) or {}
+        except DatabricksSqlError as exc:
+            _emit_genie_warning("direct_canonical_genie_retention_risk_failed", exc=exc)
+            return None
+        raw_count = row.get("retention_risk_borrowers")
+        if raw_count is None:
+            _emit_genie_warning(
+                "direct_canonical_genie_retention_risk_bad_count",
+                value_type="NoneType",
+            )
+            return None
+        try:
+            count_int = int(raw_count)
+        except (TypeError, ValueError):
+            _emit_genie_warning(
+                "direct_canonical_genie_retention_risk_bad_count",
+                value_type=type(raw_count).__name__,
+            )
+            return None
+        rows = [
+            {
+                "retention_risk_borrowers": count_int,
+                "refreshed_at": row.get("refreshed_at"),
+            }
+        ]
+        answer = (
+            f"There are {count_int:,} current customers in the retention-risk cohort. "
+            f"This uses the modeled retention signal in {borrower_asset}."
+        )
+        return _trusted_sql_response(
+            question=question,
+            sql_query=_CANONICAL_CURRENT_CUSTOMER_RETENTION_RISK_SQL,
+            trusted_assets=trusted_assets,
+            rows=rows,
+            answer=answer,
+            metric_value=f"{count_int:,}",
+        )
 
     if _canonical_itm_zip_scope(question):
         try:
-            rows = sql_client.execute(_CANONICAL_ITM_TOP_ZIPS_SQL) or []
+            rows = _redact_genie_rows(sql_client.execute(_CANONICAL_ITM_TOP_ZIPS_SQL)) or []
         except DatabricksSqlError as exc:
             _emit_genie_warning("direct_canonical_genie_itm_zips_failed", exc=exc)
             return None
@@ -119,7 +383,7 @@ def direct_canonical_response(
 
     if _canonical_itm_state_breakdown_scope(question):
         try:
-            rows = sql_client.execute(_CANONICAL_ITM_BY_STATE_SQL) or []
+            rows = _redact_genie_rows(sql_client.execute(_CANONICAL_ITM_BY_STATE_SQL)) or []
         except DatabricksSqlError as exc:
             _emit_genie_warning("direct_canonical_genie_itm_state_breakdown_failed", exc=exc)
             return None
@@ -146,7 +410,80 @@ def direct_canonical_response(
 
     scope = _canonical_in_the_money_count_scope(question)
     if scope is False or scope is None:
-        return None
+        city_scope = _canonical_itm_city_scope(question)
+        if not city_scope:
+            if _canonical_msa_score_scope(question):
+                try:
+                    rows = _redact_genie_rows(sql_client.execute(_CANONICAL_MSA_SCORE_SQL)) or []
+                except DatabricksSqlError as exc:
+                    _emit_genie_warning("direct_canonical_genie_msa_score_failed", exc=exc)
+                    return None
+                if rows:
+                    answer = (
+                        "I used Cotality's `situs_cbsa_code` as the MSA identifier "
+                        "and ranked the top five markets by borrower volume, then "
+                        f"calculated mean lead score at the unique borrower grain from {borrower_asset}."
+                    )
+                else:
+                    answer = (
+                        "The current gold borrower table did not return CBSA-coded "
+                        "market rows. Module 0 has `situs_cbsa_code` for MSA-style "
+                        "grouping, but no separate MSA-name lookup is loaded."
+                    )
+                return _trusted_sql_response(
+                    question=question,
+                    sql_query=_CANONICAL_MSA_SCORE_SQL,
+                    trusted_assets=trusted_assets,
+                    rows=rows,
+                    answer=answer,
+                )
+            return None
+        try:
+            row = (
+                sql_client.execute_one(
+                    _CANONICAL_ITM_COUNT_BY_CITY_SQL,
+                    {"city": city_scope},
+                )
+                or {}
+            )
+        except DatabricksSqlError as exc:
+            _emit_genie_warning("direct_canonical_genie_city_metric_failed", exc=exc)
+            return None
+        raw_count = row.get("in_the_money_borrowers")
+        if raw_count is None:
+            _emit_genie_warning(
+                "direct_canonical_genie_city_metric_bad_count",
+                value_type="NoneType",
+            )
+            return None
+        try:
+            count_int = int(raw_count)
+        except (TypeError, ValueError):
+            _emit_genie_warning(
+                "direct_canonical_genie_city_metric_bad_count",
+                value_type=type(raw_count).__name__,
+            )
+            return None
+        rows = [
+            {
+                "city": city_scope,
+                "in_the_money_borrowers": count_int,
+                "refreshed_at": row.get("refreshed_at"),
+            }
+        ]
+        answer = (
+            f"There are {count_int:,} borrowers currently in-the-money in {city_scope} "
+            f"within the current gold evaluation-share scope from {borrower_asset}. "
+            "This is a city-scoped unique borrower count, not the overall share total."
+        )
+        return _trusted_sql_response(
+            question=question,
+            sql_query=_CANONICAL_ITM_COUNT_BY_CITY_SQL,
+            trusted_assets=trusted_assets,
+            rows=rows,
+            answer=answer,
+            metric_value=f"{count_int:,}",
+        )
 
     state_scope = scope if isinstance(scope, tuple) else None
     sql_query = _CANONICAL_ITM_COUNT_BY_STATE_SQL if state_scope else _CANONICAL_ITM_COUNT_SQL

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -14,6 +14,7 @@ Contract under test:
 5. ``GenieClientError`` from the live client (401, 500, malformed JSON)
    is re-raised -- it is NOT silently masked by a catalog answer.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -651,7 +652,9 @@ def test_data_question_without_query_gets_generic_sql_repair() -> None:
     assert len(stub.ask_calls) == 2
     assert stub.ask_conversation_ids == ["stale-conv", "stale-conv"]
     assert stub.ask_calls[0] == "Which zips have the most in-the-money refi candidates?"
-    assert "Regenerate the following Mortgage Intelligence Platform data question" in stub.ask_calls[1]
+    assert (
+        "Regenerate the following Mortgage Intelligence Platform data question" in stub.ask_calls[1]
+    )
     assert result.sql_query is not None
     assert "FROM mip.gold.borrower_360" in result.sql_query
     assert "GROUP BY zip, state" in result.sql_query
@@ -722,6 +725,163 @@ def test_top_zip_question_uses_direct_canonical_gold_sql_without_genie_call() ->
         "segment_codes": ["itm"],
         "segment_mode": "any",
     }
+    assert result.proof is not None
+    assert result.proof.trusted is True
+
+
+@pytest.mark.parametrize(
+    ("question", "rows", "asset", "sql_marker", "expected_phrase"),
+    [
+        (
+            "Show me the top 10 borrowers by lead score in Illinois.",
+            [
+                {
+                    "borrower_id": "B-IL-1",
+                    "display_name": "Borrower IL-1",
+                    "city": "Chicago",
+                    "state": "IL",
+                    "zip": "60617",
+                    "lead_score": 98,
+                    "recommended_offer_code": "refi",
+                    "recommended_offer": "Rate refinance",
+                    "rank_within_state": 1,
+                    "refreshed_at": "2026-06-15T00:00:00Z",
+                }
+            ],
+            "mip.gold.lead_population",
+            "FROM mip.gold.lead_population",
+            "ranked the top",
+        ),
+        (
+            "Top 5 ZIP codes by HELOC-eligible borrowers (equity >= 35%).",
+            [
+                {
+                    "zip": "60617",
+                    "state": "IL",
+                    "heloc_eligible_borrowers": 321,
+                    "avg_equity_pct": 48.2,
+                    "avg_score": 78.4,
+                    "refreshed_at": "2026-06-15T00:00:00Z",
+                }
+            ],
+            "mip.gold.borrower_360",
+            "equity_pct >= 35",
+            "HELOC-eligible borrowers",
+        ),
+        (
+            "Where should the configured tenant lender spend its next 10000 outreach touches this week, and why?",
+            [
+                {
+                    "state": "IL",
+                    "segment_code": "itm",
+                    "marketable_borrowers": 1200,
+                    "avg_score": 91.2,
+                    "leading_offer_code": "refi",
+                    "leading_recommended_offer": "Rate refinance",
+                    "leading_offer_borrowers": 1180,
+                    "refreshed_at": "2026-06-15T00:00:00Z",
+                }
+            ],
+            "mip.gold.borrower_360",
+            "exploded_segments",
+            "state, segment, and offer",
+        ),
+        (
+            "Which state has the most cash-out opportunity right now?",
+            [
+                {
+                    "state": "FL",
+                    "cash_out_borrowers": 456,
+                    "refreshed_at": "2026-06-15T00:00:00Z",
+                }
+            ],
+            "mip.gold.borrower_360",
+            "recommended_offer_code = 'cash_out'",
+            "cash-out opportunity",
+        ),
+        (
+            "Show the Investor / Multi-Property segment broken down by state.",
+            [
+                {
+                    "segment_code": "investor",
+                    "state": "CA",
+                    "investor_borrowers": 789,
+                    "avg_score": 76,
+                    "delta_vs_prior": "+2%",
+                    "refreshed_at": "2026-06-15T00:00:00Z",
+                }
+            ],
+            "mip.gold.segment_population",
+            "segment_code = 'investor'",
+            "Investor / Multi-Property segment",
+        ),
+        (
+            "Compare mean lead score by MSA for our top five markets.",
+            [
+                {
+                    "market": "Chicago, IL (CBSA 16980)",
+                    "msa_cbsa_code": "16980",
+                    "borrowers": 5000,
+                    "avg_score": 82.1,
+                    "refreshed_at": "2026-06-15T00:00:00Z",
+                }
+            ],
+            "mip.gold.borrower_360",
+            "situs_cbsa_code",
+            "situs_cbsa_code",
+        ),
+    ],
+)
+def test_eval_canonical_questions_use_direct_trusted_sql_without_genie_call(
+    question: str,
+    rows: list[dict[str, Any]],
+    asset: str,
+    sql_marker: str,
+    expected_phrase: str,
+) -> None:
+    stub = _StubClient(
+        _make_breaker("closed"),
+        response=DependencyDownError("genie", reason="test should not call Genie"),
+    )
+    sql = _StubSqlClient(rows)
+    repo = DatabricksGenieRepository(stub, sql)  # type: ignore[arg-type]
+
+    result = repo.respond(question)
+
+    assert result.source == "trusted_sql"
+    assert stub.ask_calls == []
+    assert result.trusted_assets == [asset] or asset in result.trusted_assets
+    assert result.sql_query is not None
+    assert sql_marker in result.sql_query
+    assert expected_phrase in result.answer
+    assert result.table_rows == rows
+    assert result.proof is not None
+    assert result.proof.trusted is True
+
+
+def test_city_count_question_uses_direct_trusted_sql_without_genie_call() -> None:
+    stub = _StubClient(
+        _make_breaker("closed"),
+        response=DependencyDownError("genie", reason="test should not call Genie"),
+    )
+    sql = _StubSqlClient(
+        [
+            {
+                "in_the_money_borrowers": 17,
+                "refreshed_at": "2026-06-15T00:00:00Z",
+            }
+        ]
+    )
+    repo = DatabricksGenieRepository(stub, sql)  # type: ignore[arg-type]
+
+    result = repo.respond("How many in-the-money borrowers in Chicago?")
+
+    assert result.source == "trusted_sql"
+    assert stub.ask_calls == []
+    assert result.metric_value == "17"
+    assert result.sql_query is not None
+    assert "LOWER(city) = LOWER(:city)" in result.sql_query
+    assert sql.parameters == [{"city": "Chicago"}]
     assert result.proof is not None
     assert result.proof.trusted is True
 
@@ -983,10 +1143,7 @@ def test_conversation_id_is_forwarded_to_live_genie() -> None:
 def test_untrusted_sql_is_policy_blocked_and_not_rendered() -> None:
     live = GenieResponse(
         answer_text="Audit users by state.",
-        sql_query=(
-            "SELECT count(*) FROM mip.gold.lead_scores "
-            "JOIN mip_app.action_audit ON 1=1"
-        ),
+        sql_query=("SELECT count(*) FROM mip.gold.lead_scores " "JOIN mip_app.action_audit ON 1=1"),
         sql_result_rows=[{"count": 1}],
         conversation_id="conv-policy",
         message_id="msg-policy",
@@ -1056,8 +1213,7 @@ def test_comment_spoof_is_policy_blocked() -> None:
     live = GenieResponse(
         answer_text="Counts from the silver table.",
         sql_query=(
-            "SELECT count(*) FROM mip.silver.mortgage_events "
-            "/* mip.gold.borrower_360 */"
+            "SELECT count(*) FROM mip.silver.mortgage_events " "/* mip.gold.borrower_360 */"
         ),
         sql_result_rows=[{"count": 1}],
         conversation_id="conv-comment-spoof",
@@ -1311,9 +1467,7 @@ def test_trusted_genie_numeric_check_accepts_rounded_percent_claim() -> None:
 def test_trusted_genie_numeric_check_accepts_sum_across_rows() -> None:
     live = GenieResponse(
         answer_text="The two returned states contain 300 borrowers.",
-        sql_query=(
-            "SELECT state, borrowers FROM mip.gold.borrower_360 GROUP BY state, borrowers"
-        ),
+        sql_query=("SELECT state, borrowers FROM mip.gold.borrower_360 GROUP BY state, borrowers"),
         sql_result_rows=[
             {"state": "IL", "borrowers": 100},
             {"state": "CA", "borrowers": 200},
@@ -1475,12 +1629,8 @@ def test_trusted_genie_numeric_check_rejects_unscaled_word_suffix_claims() -> No
 
 def test_trusted_genie_numeric_check_ignores_identifier_dates_and_query_limits() -> None:
     live = GenieResponse(
-        answer_text=(
-            "Top 10 ZIP 60617 refreshed in 2026 has 123 borrowers."
-        ),
-        sql_query=(
-            "SELECT zip, refreshed_at, borrowers FROM mip.gold.borrower_360 LIMIT 10"
-        ),
+        answer_text=("Top 10 ZIP 60617 refreshed in 2026 has 123 borrowers."),
+        sql_query=("SELECT zip, refreshed_at, borrowers FROM mip.gold.borrower_360 LIMIT 10"),
         sql_result_rows=[
             {"zip": "60617", "refreshed_at": "2026-05-16T01:00:00Z", "borrowers": 123}
         ],
@@ -1780,12 +1930,14 @@ def test_in_the_money_count_uses_canonical_gold_grain() -> None:
         message_id="msg-itm-count",
     )
     stub = _StubClient(_make_breaker("closed"), response=live)
-    sql = _StubSqlClient([
-        {
-            "in_the_money_borrowers": 147742,
-            "refreshed_at": "2026-05-04T22:08:34.662Z",
-        }
-    ])
+    sql = _StubSqlClient(
+        [
+            {
+                "in_the_money_borrowers": 147742,
+                "refreshed_at": "2026-05-04T22:08:34.662Z",
+            }
+        ]
+    )
     repo = DatabricksGenieRepository(stub, sql)  # type: ignore[arg-type]
 
     result = repo.respond("How many borrowers are currently in-the-money?")
@@ -1822,12 +1974,14 @@ def test_in_the_money_count_direct_canonical_bypasses_genie_breaker() -> None:
         _make_breaker("open"),
         response=GenieClientError("HTTP 429 from Genie API", status_code=429),
     )
-    sql = _StubSqlClient([
-        {
-            "in_the_money_borrowers": 147742,
-            "refreshed_at": "2026-05-04T22:08:34.662Z",
-        }
-    ])
+    sql = _StubSqlClient(
+        [
+            {
+                "in_the_money_borrowers": 147742,
+                "refreshed_at": "2026-05-04T22:08:34.662Z",
+            }
+        ]
+    )
     repo = DatabricksGenieRepository(stub, sql)  # type: ignore[arg-type]
 
     result = repo.respond("How many borrowers are currently in-the-money?")
@@ -1908,7 +2062,9 @@ def test_in_the_money_state_breakdown_direct_canonical_bypasses_genie_breaker() 
     sql = _StubSqlClient(rows)
     repo = DatabricksGenieRepository(stub, sql)  # type: ignore[arg-type]
 
-    result = repo.respond("Break down in-the-money borrowers by state and return the count as a table.")
+    result = repo.respond(
+        "Break down in-the-money borrowers by state and return the count as a table."
+    )
 
     assert result.source == "trusted_sql"
     assert result.trusted_assets == ["mip.gold.borrower_360"]
@@ -1933,12 +2089,14 @@ def test_in_the_money_count_applies_state_scope_when_present() -> None:
         message_id="msg-itm-state",
     )
     stub = _StubClient(_make_breaker("closed"), response=live)
-    sql = _StubSqlClient([
-        {
-            "in_the_money_borrowers": 70939,
-            "refreshed_at": "2026-05-04T22:08:34.662Z",
-        }
-    ])
+    sql = _StubSqlClient(
+        [
+            {
+                "in_the_money_borrowers": 70939,
+                "refreshed_at": "2026-05-04T22:08:34.662Z",
+            }
+        ]
+    )
     repo = DatabricksGenieRepository(stub, sql)  # type: ignore[arg-type]
 
     result = repo.respond("How many borrowers in Illinois are in the money?")
@@ -1971,12 +2129,14 @@ def test_in_the_money_count_applies_lowercase_ambiguous_state_code_when_contextu
         message_id="msg-itm-ok",
     )
     stub = _StubClient(_make_breaker("closed"), response=live)
-    sql = _StubSqlClient([
-        {
-            "in_the_money_borrowers": 12,
-            "refreshed_at": "2026-05-04T22:08:34.662Z",
-        }
-    ])
+    sql = _StubSqlClient(
+        [
+            {
+                "in_the_money_borrowers": 12,
+                "refreshed_at": "2026-05-04T22:08:34.662Z",
+            }
+        ]
+    )
     repo = DatabricksGenieRepository(stub, sql)  # type: ignore[arg-type]
 
     result = repo.respond("How many borrowers in ok are in the money?")
@@ -1995,12 +2155,14 @@ def test_in_the_money_count_does_not_scope_common_words_as_state_codes() -> None
         message_id="msg-itm-no-false-state",
     )
     stub = _StubClient(_make_breaker("closed"), response=live)
-    sql = _StubSqlClient([
-        {
-            "in_the_money_borrowers": 147742,
-            "refreshed_at": "2026-05-04T22:08:34.662Z",
-        }
-    ])
+    sql = _StubSqlClient(
+        [
+            {
+                "in_the_money_borrowers": 147742,
+                "refreshed_at": "2026-05-04T22:08:34.662Z",
+            }
+        ]
+    )
     repo = DatabricksGenieRepository(stub, sql)  # type: ignore[arg-type]
 
     result = repo.respond("Hi, how many borrowers are in the money?")
@@ -2026,20 +2188,21 @@ def test_in_the_money_count_applies_city_scope_when_present(
     live = GenieResponse(
         answer_text="Genie returned the all-footprint count: 147,742.",
         sql_query=(
-            "SELECT COUNT(*) AS borrowers FROM mip.gold.borrower_360 "
-            "WHERE in_the_money = true"
+            "SELECT COUNT(*) AS borrowers FROM mip.gold.borrower_360 " "WHERE in_the_money = true"
         ),
         sql_result_rows=[{"borrowers": 147742}],
         conversation_id="conv-itm-chicago",
         message_id="msg-itm-chicago",
     )
     stub = _StubClient(_make_breaker("closed"), response=live)
-    sql = _StubSqlClient([
-        {
-            "in_the_money_borrowers": count,
-            "refreshed_at": "2026-05-04T22:08:34.662Z",
-        }
-    ])
+    sql = _StubSqlClient(
+        [
+            {
+                "in_the_money_borrowers": count,
+                "refreshed_at": "2026-05-04T22:08:34.662Z",
+            }
+        ]
+    )
     repo = DatabricksGenieRepository(stub, sql)  # type: ignore[arg-type]
 
     result = repo.respond(question)
@@ -2065,7 +2228,7 @@ def test_in_the_money_count_applies_city_scope_when_present(
     assert sql.parameters == [{"city": city}]
 
 
-def test_mean_lead_score_by_msa_blocks_untrusted_live_sql_instead_of_masking() -> None:
+def test_mean_lead_score_by_msa_uses_direct_sql_before_genie() -> None:
     live = GenieResponse(
         answer_text="Genie tried to use an unsupported MSA lookup.",
         sql_query="SELECT count(*) FROM mip_app.saved_leads",
@@ -2116,16 +2279,16 @@ def test_mean_lead_score_by_msa_blocks_untrusted_live_sql_instead_of_masking() -
 
     result = repo.respond("Compare mean lead score by MSA for our top five markets.")
 
-    assert result.source == "policy_blocked"
-    assert result.table_rows == []
-    assert result.row_count == 0
-    assert "trusted SQL" in result.answer
-    assert "mip.gold.borrower_360" not in result.trusted_assets
-    assert result.sql_query is None
+    assert result.source == "trusted_sql"
+    assert result.table_rows == rows
+    assert result.trusted_assets == ["mip.gold.borrower_360"]
+    assert result.sql_query is not None
+    assert "situs_cbsa_code" in result.sql_query
+    assert "mip_app.saved_leads" not in result.sql_query
     assert result.proof is not None
-    assert result.proof.trusted is False
-    assert result.visualization is None
-    assert sql.statements == []
+    assert result.proof.trusted is True
+    assert stub.ask_calls == []
+    assert sql.statements == [result.sql_query]
 
 
 def test_mean_lead_score_by_msa_uses_canonical_cbsa_query_when_live_turn_is_not_unsafe() -> None:

--- a/tests/unit/test_genie_retention_risk.py
+++ b/tests/unit/test_genie_retention_risk.py
@@ -210,7 +210,9 @@ def test_genie_repairs_retention_risk_phrase_without_current_customer_wording() 
 
 
 def test_genie_retention_list_uses_canonical_row_lookup_not_count_metric() -> None:
-    question = "Which borrowers on our retention list have a competitor lien filed in the last 30 days?"
+    question = (
+        "Which borrowers on our retention list have a competitor lien filed in the last 30 days?"
+    )
     result = GenieResponse(
         answer_text="Rows.",
         sql_query=(
@@ -249,7 +251,9 @@ def test_genie_retention_list_uses_canonical_row_lookup_not_count_metric() -> No
 
 
 def test_genie_retention_list_uses_canonical_competitor_lien_signal() -> None:
-    question = "Which borrowers on our retention list have a competitor lien filed in the last 30 days?"
+    question = (
+        "Which borrowers on our retention list have a competitor lien filed in the last 30 days?"
+    )
     result = GenieResponse(
         answer_text="No rows.",
         sql_query=(
@@ -308,8 +312,7 @@ def test_genie_retention_list_uses_canonical_competitor_lien_signal() -> None:
     assert sql.executed_sql == response.sql_query
     assert response.metric_value == "304"
     assert "There are 304 retention-list borrowers" in response.answer
-    assert len(client.questions) == 2
-    assert "competitor-lien evidence is signal_type = 'competitor_lien'" in client.questions[1]
+    assert client.questions == []
     cohort_action = next(action for action in response.actions if action.id == "open-cohort")
     assert "borrower_ids=B-102FL7THC6Q3L" in (cohort_action.route or "")
     assert "lender_relationship=Competitor" not in (cohort_action.route or "")
@@ -329,8 +332,7 @@ def test_genie_repairs_and_blocks_stale_evidence_signal_enums() -> None:
     result = GenieResponse(
         answer_text="Rows.",
         sql_query=(
-            f"SELECT borrower_id FROM {EVIDENCE_EVENTS} "
-            "WHERE signal_type = 'lien-change'"
+            f"SELECT borrower_id FROM {EVIDENCE_EVENTS} " "WHERE signal_type = 'lien-change'"
         ),
         sql_result_rows=[{"borrower_id": "B-102FL7THC6Q3L"}],
         trusted_assets=[EVIDENCE_EVENTS],
@@ -399,5 +401,4 @@ def test_genie_retention_risk_repairs_wrong_evidence_enums() -> None:
     assert response.proof is not None
     assert response.proof.trusted is True
     assert sql.sql == response.sql_query
-    assert len(client.questions) == 2
-    assert "competitor-lien evidence is signal_type = 'competitor_lien'" in client.questions[1]
+    assert client.questions == []


### PR DESCRIPTION
## Summary\n- expand direct trusted-SQL Genie responses for deterministic eval prompts\n- add canonical Investor / Multi-Property by-state SQL over gold.segment_population\n- pin direct no-Genie-call behavior for top borrowers, HELOC ZIPs, strategy board, cash-out state, investor segment, city counts, and MSA score prompts\n\n## Validation\n- .venv/bin/ruff format backend/services/repositories/databricks_genie_canonical.py backend/services/repositories/databricks_genie_direct.py tests/unit/test_genie_repository.py\n- .venv/bin/ruff check backend/services/repositories/databricks_genie_canonical.py backend/services/repositories/databricks_genie_direct.py tests/unit/test_genie_repository.py\n- .venv/bin/python -m pytest tests/unit/test_genie_repository.py -q\n- .venv/bin/python -m pytest tests/unit/test_genie_eval.py tests/unit/test_genie_repository.py tests/unit/test_genie_actions_api.py::test_genie_degraded_message_audits_with_question_hash_entity_id -q