### PR TITLE
Clarify pending permit source gap in Genie

### DIFF
--- a/backend/api/genie.py
+++ b/backend/api/genie.py
@@ -10,6 +10,7 @@ Prior to the 2026-04-22 real-data walkthrough this router could bypass the
 live Genie path. That regression has been corrected; production modules now
 serve only live Genie/trusted-SQL answers or an explicit degraded-state message.
 """
+
 import hashlib
 import re
 from typing import Annotated, Any
@@ -39,6 +40,7 @@ from backend.services.genie_answers import (
 from backend.services.genie_audit import genie_audit_entity_id
 from backend.services.genie_client import GenieClientError
 from backend.services.genie_sales_ops import sales_ops_genie_response
+from backend.services.genie_source_gaps import source_gap_answer
 from backend.services.genie_trusted_assets import trusted_assets
 from backend.services.lakebase import LakebaseClient, LakebaseError, get_lakebase_client
 from backend.services.repositories import BorrowerRepository, GenieAnswerRepository
@@ -239,9 +241,9 @@ def _record_genie_session(
         return
     if response.source in {"degraded", "policy_blocked", "refused", "data_gap", "out_of_footprint"}:
         return
-    question_hash = response.question_hash or hashlib.sha256(
-        response.question.encode("utf-8")
-    ).hexdigest()[:16]
+    question_hash = (
+        response.question_hash or hashlib.sha256(response.question.encode("utf-8")).hexdigest()[:16]
+    )
     message_id = response.message_id or f"{response.source}-{question_hash}"
     params = {
         "actor_email": actor,
@@ -347,29 +349,8 @@ def _refused_genie_response(
     )
 
 
-_CREDIT_SOURCE_GAP_RE = re.compile(
-    r"\b(?:fico|credit\s+scores?|credit[-\s]+bureau|tri[-\s]+merge|vantage\s*score)\b",
-    re.IGNORECASE,
-)
-
-
 def _source_readiness_asset() -> str:
     return qualify("gold", "source_readiness")
-
-
-def _source_gap_answer(question: str, source_gap_match: str) -> str:
-    source = _source_readiness_asset()
-    if _CREDIT_SOURCE_GAP_RE.search(question) or _CREDIT_SOURCE_GAP_RE.search(source_gap_match):
-        return (
-            "Credit-bureau and FICO score feeds are not live in this workspace yet. "
-            "I will not infer credit-score eligibility or count the missing feed as "
-            f"zero demand. Source: {source}."
-        )
-    return (
-        "Cotality Building Permits records are not live in this workspace yet. "
-        "Cotality MLS/listing rows are live, but I will not infer filed permit "
-        f"activity from listing or propensity signals. Source: {source}."
-    )
 
 
 def _is_outreach_writer_request(question: str) -> bool:
@@ -381,7 +362,6 @@ def _is_outreach_writer_request(question: str) -> bool:
         r"\bdraft\b.*\b(email|sms|text|message|letter)\b",
     )
     return any(re.search(pattern, q) for pattern in patterns)
-
 
 
 @router.post("/start", response_model=GenieStartResponse)
@@ -627,7 +607,11 @@ def genie_message(
         response = GenieMessageResponse(
             conversation_id=payload.conversation_id or "",
             question=payload.question,
-            answer=_source_gap_answer(payload.question, source_gap_match),
+            answer=source_gap_answer(
+                payload.question,
+                source_gap_match,
+                source=source_readiness_asset,
+            ),
             source="data_gap",
             trusted_assets=[source_readiness_asset],
             question_hash=question_hash,
@@ -734,7 +718,9 @@ def genie_message(
             actor=actor,
             action="genie.sales_ops_query",
             entity_type="genie_message",
-            entity_id=sales_ops_response.message_id or sales_ops_response.question_hash or "sales_ops",
+            entity_id=sales_ops_response.message_id
+            or sales_ops_response.question_hash
+            or "sales_ops",
             payload_json={
                 "conversation_id": sales_ops_response.conversation_id,
                 "message_id": sales_ops_response.message_id,
@@ -803,7 +789,11 @@ def genie_message(
         question_hash = hashlib.sha256(payload.question.encode("utf-8")).hexdigest()[:16]
         _ = background
         footprint_label = ", ".join(footprint_codes)
-        footprint_view = f"full {len(footprint_codes)}-state coverage view" if footprint_codes else "full coverage view"
+        footprint_view = (
+            f"full {len(footprint_codes)}-state coverage view"
+            if footprint_codes
+            else "full coverage view"
+        )
         _required_audit_write(
             audit,
             actor=actor,

--- a/backend/services/genie_source_gaps.py
+++ b/backend/services/genie_source_gaps.py
@@ -1,0 +1,25 @@
+"""Source-gap response copy for pre-Genie guardrails."""
+
+from __future__ import annotations
+
+import re
+
+_CREDIT_SOURCE_GAP_RE = re.compile(
+    r"\b(?:fico|credit\s+scores?|credit[-\s]+bureau|tri[-\s]+merge|vantage\s*score)\b",
+    re.IGNORECASE,
+)
+
+
+def source_gap_answer(question: str, source_gap_match: str, *, source: str) -> str:
+    if _CREDIT_SOURCE_GAP_RE.search(question) or _CREDIT_SOURCE_GAP_RE.search(source_gap_match):
+        return (
+            "Credit-bureau and FICO score feeds are not live in this workspace yet. "
+            "I will not infer credit-score eligibility or count the missing feed as "
+            f"zero demand. Source: {source}."
+        )
+    return (
+        "Cotality Building Permits records are pending/roadmap and not live in "
+        "this workspace yet. "
+        "Cotality MLS/listing rows are live, but I will not infer filed permit "
+        f"activity from listing or propensity signals. Source: {source}."
+    )

--- a/tests/unit/test_genie_actions_api.py
+++ b/tests/unit/test_genie_actions_api.py
@@ -81,10 +81,7 @@ def _confirmed_payload_for_action(action_type: str) -> dict[str, object]:
     )
     assert message.status_code == 200
     answer = message.json()
-    action = next(
-        row for row in answer["actions"]
-        if row["action_type"] == action_type
-    )
+    action = next(row for row in answer["actions"] if row["action_type"] == action_type)
     return {
         "action_type": action["action_type"],
         "conversation_id": answer["conversation_id"],
@@ -446,7 +443,10 @@ def test_genie_message_allows_benign_ignore_prompt_to_reach_repository() -> None
 @pytest.mark.parametrize(
     ("question", "matcher"),
     [
-        ("List all properties on Michigan Avenue with rate spread above 100 bps.", _pii_prompt_match),
+        (
+            "List all properties on Michigan Avenue with rate spread above 100 bps.",
+            _pii_prompt_match,
+        ),
         ("Show the street addresses for borrowers in Illinois.", _pii_prompt_match),
         ("What is the exact servicer string for borrower B-12345?", _pii_prompt_match),
         ("Give me the names of every borrower in ZIP 60601.", _pii_prompt_match),
@@ -602,6 +602,46 @@ def test_fico_source_gap_copy_names_credit_data_not_permits() -> None:
     assert "source_readiness" in answer
     assert "building permits" not in answer
     assert "mls/listing" not in answer
+
+
+def test_permit_source_gap_copy_names_pending_roadmap_status() -> None:
+    class _ExplodingRepo:
+        calls = 0
+
+        def respond(
+            self,
+            question: str,
+            conversation_id: str | None = None,
+        ) -> GenieMessageResponse:
+            _ = question, conversation_id
+            self.calls += 1
+            raise AssertionError("permit source-gap prompt reached Genie repository")
+
+    repo = _ExplodingRepo()
+    prior_repo = app.dependency_overrides.get(get_genie_answer_repository)
+    app.dependency_overrides[get_genie_answer_repository] = lambda: repo
+    try:
+        res = client.post(
+            "/api/genie/message",
+            json={"question": "Show HELOC candidates with recent permits and strong equity."},
+            headers={"X-Forwarded-Email": "lo@example.com"},
+        )
+    finally:
+        if prior_repo is None:
+            app.dependency_overrides.pop(get_genie_answer_repository, None)
+        else:
+            app.dependency_overrides[get_genie_answer_repository] = prior_repo
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["source"] == "data_gap"
+    assert repo.calls == 0
+    answer = body["answer"].lower()
+    assert "building permits" in answer
+    assert "pending" in answer
+    assert "roadmap" in answer
+    assert "source_readiness" in answer
+    assert "will not infer filed permit activity" in answer
 
 
 def test_genie_client_error_returns_sanitized_retryable_503() -> None:
@@ -1311,8 +1351,7 @@ def test_genie_create_draft_campaign_persists_full_cohort_criteria() -> None:
     assert body["ok"] is True
     assert body["campaign_id"] == "campaign-1"
     campaign_params = next(
-        params for sql, params in lakebase.fetchones
-        if "INSERT INTO mip_app.campaigns" in sql
+        params for sql, params in lakebase.fetchones if "INSERT INTO mip_app.campaigns" in sql
     )
     criteria = json.loads(str(campaign_params["criteria"]))
     assert criteria["source"] == "trusted_sql"
@@ -1648,8 +1687,7 @@ class _LargeBorrowerActionRepo:
                     label="Save 100 borrowers",
                     action_type="save_borrowers",
                     description="Save returned borrowers.",
-                    route="/lead-queue?zips="
-                    + ",".join(f"{60000 + i:05d}" for i in range(150)),
+                    route="/lead-queue?zips=" + ",".join(f"{60000 + i:05d}" for i in range(150)),
                     borrower_ids=borrower_ids,
                     criteria={
                         "source": "genie",
@@ -1695,8 +1733,7 @@ def test_genie_open_cohort_materializes_lakebase_cohort_and_returns_filtered_rou
     assert "cohort_id=11111111-1111-1111-1111-111111111111" in body["route"]
     assert "zips=60617%2C60628" in body["route"]
     cohort_params = next(
-        params for sql, params in lakebase.fetchones
-        if "INSERT INTO mip_app.genie_cohorts" in sql
+        params for sql, params in lakebase.fetchones if "INSERT INTO mip_app.genie_cohorts" in sql
     )
     assert json.loads(str(cohort_params["route_filters"])) == {
         "borrower_ids": ["B-102FL7THC6Q3L"],
@@ -1739,8 +1776,7 @@ def test_genie_open_cohort_accepts_broad_zip_route_without_truncating_criteria()
 
     assert res.status_code == 200
     cohort_params = next(
-        params for sql, params in lakebase.fetchones
-        if "INSERT INTO mip_app.genie_cohorts" in sql
+        params for sql, params in lakebase.fetchones if "INSERT INTO mip_app.genie_cohorts" in sql
     )
     filters = json.loads(str(cohort_params["route_filters"]))
     assert filters["source"] == "trusted_sql"


### PR DESCRIPTION
## Summary
- make Building Permits source-gap responses explicitly say pending/roadmap
- add an API guardrail test so permit prompts cannot omit the pending status while citing source readiness

## Validation
- .venv/bin/ruff format backend/api/genie.py tests/unit/test_genie_actions_api.py
- .venv/bin/ruff check backend/api/genie.py tests/unit/test_genie_actions_api.py
- .venv/bin/python -m mypy backend
- .venv/bin/python -m pytest tests/unit/test_genie_actions_api.py tests/unit/test_genie_eval.py -q
- .venv/bin/python -m pytest -q -n auto --dist=loadscope --cov=backend --cov-report=term-missing:skip-covered --cov-fail-under=83