### PR TITLE
Add household rollup campaign dedup

### DIFF
--- a/backend/schemas/portfolio.py
+++ b/backend/schemas/portfolio.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from backend.schemas._validators import (
     configured_public_lender_name,
@@ -458,6 +458,68 @@ class PortfolioPreviewRequest(BaseModel):
     criteria: PortfolioCriteria = Field(default_factory=PortfolioCriteria)
 
 
+HouseholdDedupeUnit = Literal["borrower", "household"]
+HouseholdPrimaryStrategy = Literal["highest_opportunity_eligible"]
+
+
+def _household_source_assets() -> list[str]:
+    return ["mip.gold.household_rollup", "mip.gold.borrower_360"]
+
+
+class HouseholdDedupConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    dedupe_unit: HouseholdDedupeUnit = "borrower"
+    primary_contact_strategy: HouseholdPrimaryStrategy = "highest_opportunity_eligible"
+
+    @model_validator(mode="after")
+    def _normalize_dedupe_unit(self) -> "HouseholdDedupConfig":
+        self.dedupe_unit = "household" if self.enabled else "borrower"
+        return self
+
+
+class HouseholdDedupSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    candidate_borrower_count: int = 0
+    selected_primary_count: int = 0
+    suppressed_co_owner_count: int = 0
+    household_count: int = 0
+    owner_link_household_count: int = 0
+    mailing_address_household_count: int = 0
+    singleton_household_count: int = 0
+    primary_contact_strategy: HouseholdPrimaryStrategy = "highest_opportunity_eligible"
+    source_assets: list[str] = Field(default_factory=_household_source_assets)
+
+    @field_validator(
+        "candidate_borrower_count",
+        "selected_primary_count",
+        "suppressed_co_owner_count",
+        "household_count",
+        "owner_link_household_count",
+        "mailing_address_household_count",
+        "singleton_household_count",
+    )
+    @classmethod
+    def _validate_count(cls, value: int) -> int:
+        if isinstance(value, bool) or value < 0 or value > 10_000_000:
+            raise ValueError("household counts must be bounded non-negative integers")
+        return int(value)
+
+    @field_validator("source_assets")
+    @classmethod
+    def _validate_source_assets(cls, value: list[str]) -> list[str]:
+        if not value or len(value) > 5:
+            raise ValueError("source_assets must cite bounded governed UC assets")
+        normalized = [str(item).strip() for item in value]
+        for asset in normalized:
+            if asset not in {"mip.gold.household_rollup", "mip.gold.borrower_360"}:
+                raise ValueError("source_assets must cite household_rollup and borrower_360 only")
+        return normalized
+
+
 class PortfolioCreateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -469,6 +531,7 @@ class PortfolioCreateRequest(BaseModel):
     send_window: dict[str, object] = Field(default_factory=dict)
     holdout: dict[str, object] | None = None
     roi_assumptions: dict[str, object] | None = None
+    household_dedup: HouseholdDedupConfig = Field(default_factory=HouseholdDedupConfig)
 
     @field_validator("name")
     @classmethod
@@ -683,6 +746,7 @@ class PortfolioCreateResponse(BaseModel):
     campaign_id: str | None = None
     name: str
     marketable_population: int
+    household_summary: HouseholdDedupSummary = Field(default_factory=HouseholdDedupSummary)
     audit_event_id: str | None = None
 
 
@@ -701,6 +765,8 @@ class CampaignSummary(BaseModel):
     send_window: dict[str, object] = Field(default_factory=dict)
     holdout: dict[str, object] | None = None
     roi_assumptions: dict[str, object] | None = None
+    household_dedup: HouseholdDedupConfig = Field(default_factory=HouseholdDedupConfig)
+    household_summary: HouseholdDedupSummary = Field(default_factory=HouseholdDedupSummary)
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/backend/services/audit_store.py
+++ b/backend/services/audit_store.py
@@ -285,6 +285,16 @@ _ALLOWED_METADATA_KEYS: frozenset[str] = frozenset(
         "holdout",
         "roi_assumptions",
         "marketable_population",
+        "dedupe_unit",
+        "household_dedup_enabled",
+        "household_primary_strategy",
+        "household_candidate_count",
+        "household_primary_count",
+        "household_suppressed_count",
+        "household_household_count",
+        "household_owner_link_count",
+        "household_mailing_address_count",
+        "household_singleton_count",
         "status",
         # Admin degraded-banner proof drill
         "forced_state",
@@ -438,6 +448,8 @@ _FORCED_DEGRADED_DEPENDENCIES: frozenset[str] = frozenset({"warehouse", "lakebas
 _ACTIVATION_DESTINATION_TYPES: frozenset[str] = frozenset({"salesforce", "crm_cdp", "los_pos", "servicing", "webhook"})
 _ACTIVATION_STATUSES: frozenset[str] = frozenset({"dry_run", "staged", "delivered", "failed", "cancelled"})
 _ACTIVATION_DESTINATION_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_]{1,63}$")
+_HOUSEHOLD_DEDUPE_UNITS: frozenset[str] = frozenset({"borrower", "household"})
+_HOUSEHOLD_PRIMARY_STRATEGIES: frozenset[str] = frozenset({"highest_opportunity_eligible"})
 _GROWTH_AGENT_WORKFLOWS: frozenset[str] = frozenset(
     {
         "daily_refi_brief",
@@ -736,6 +748,8 @@ def _assert_public_safe_values(metadata: dict[str, Any]) -> None:
         "forced_dependency": _FORCED_DEGRADED_DEPENDENCIES,
         "forced_state": {"on", "off"},
         "proof_scope": {"browser_cookie"},
+        "dedupe_unit": _HOUSEHOLD_DEDUPE_UNITS,
+        "household_primary_strategy": _HOUSEHOLD_PRIMARY_STRATEGIES,
     }.items():
         for _, value in _metadata_values_for(metadata, {field}):
             if value is not None and str(value) not in allowed:
@@ -797,7 +811,10 @@ def _assert_public_safe_values(metadata: dict[str, Any]) -> None:
     for field, value in _metadata_values_for(metadata, {"refusal_reason"}):
         if value is not None and str(value) not in _GENIE_REFUSAL_REASONS:
             raise AuditMetadataValueViolation(field, "must be a governed Genie refusal reason")
-    for field, value in _metadata_values_for(metadata, {"helpful", "comment_present", "hit"}):
+    for field, value in _metadata_values_for(
+        metadata,
+        {"helpful", "comment_present", "hit", "household_dedup_enabled"},
+    ):
         if value is not None and not isinstance(value, bool):
             raise AuditMetadataValueViolation(field, "must be a boolean")
     for field, value in _metadata_values_for(metadata, {"address_hash"}):
@@ -905,7 +922,16 @@ def _assert_public_safe_values(metadata: dict[str, Any]) -> None:
                 validate_sql_hash(value)
             except ValueError as exc:
                 raise AuditMetadataValueViolation(field, str(exc)) from exc
-    for field, value in _metadata_values_for(metadata, {"row_count"}):
+    household_count_fields = {
+        "household_candidate_count",
+        "household_primary_count",
+        "household_suppressed_count",
+        "household_household_count",
+        "household_owner_link_count",
+        "household_mailing_address_count",
+        "household_singleton_count",
+    }
+    for field, value in _metadata_values_for(metadata, {"row_count"} | household_count_fields):
         if value is None:
             continue
         try:

--- a/backend/services/databricks_sql_helpers.py
+++ b/backend/services/databricks_sql_helpers.py
@@ -48,6 +48,7 @@ _ALLOWED_RELATIONS: frozenset[tuple[str, str]] = frozenset(
         ("gold", "fn_rate_spread"),
         ("gold", "fn_segment_counts"),
         ("gold", "funnel_snapshot_daily"),
+        ("gold", "household_rollup"),
         ("gold", "lead_population"),
         ("gold", "lead_scores"),
         ("gold", "lockin_cohort"),

--- a/backend/services/repositories/databricks_portfolio.py
+++ b/backend/services/repositories/databricks_portfolio.py
@@ -14,6 +14,7 @@ from backend.schemas.portfolio import (
     CampaignListResponse,
     CampaignStatusPatchRequest,
     CampaignSummary,
+    HouseholdDedupSummary,
     KpiTrend,
     PortfolioCreateRequest,
     PortfolioCreateResponse,
@@ -93,6 +94,52 @@ class DatabricksPortfolioRepository:
         f"FROM {qualify('gold', 'borrower_360')} "
         "{where}"
     )
+
+    _HOUSEHOLD_DEDUP_SUMMARY_SQL_TEMPLATE = """
+    WITH filtered_borrowers AS (
+      SELECT *
+      FROM {borrower_table}
+      {where}
+    ),
+    eligible_candidates AS (
+      SELECT
+        b.borrower_id,
+        b.opportunity_score,
+        COALESCE(
+          h.household_id,
+          CONCAT('HH-', SUBSTR(sha2(CONCAT('singleton:', b.borrower_id), 256), 1, 16))
+        ) AS household_id,
+        COALESCE(h.household_derivation_method, 'singleton') AS household_derivation_method
+      FROM filtered_borrowers AS b
+      LEFT JOIN {household_table} AS h
+        ON h.borrower_id = b.borrower_id
+      WHERE b.marketing_eligible = TRUE
+        AND COALESCE(b.has_unresolved_owner, FALSE) = FALSE
+    ),
+    ranked AS (
+      SELECT
+        *,
+        ROW_NUMBER() OVER (
+          PARTITION BY household_id
+          ORDER BY opportunity_score DESC, borrower_id ASC
+        ) AS campaign_household_rank
+      FROM eligible_candidates
+    )
+    SELECT
+      CAST(COUNT(*) AS INT) AS candidate_borrower_count,
+      CAST(COALESCE(SUM(CASE WHEN campaign_household_rank = 1 THEN 1 ELSE 0 END), 0) AS INT)
+        AS selected_primary_count,
+      CAST(COALESCE(SUM(CASE WHEN campaign_household_rank > 1 THEN 1 ELSE 0 END), 0) AS INT)
+        AS suppressed_co_owner_count,
+      CAST(COUNT(DISTINCT household_id) AS INT) AS household_count,
+      CAST(COUNT(DISTINCT CASE WHEN household_derivation_method = 'owner_link' THEN household_id END) AS INT)
+        AS owner_link_household_count,
+      CAST(COUNT(DISTINCT CASE WHEN household_derivation_method = 'mailing_address' THEN household_id END) AS INT)
+        AS mailing_address_household_count,
+      CAST(COUNT(DISTINCT CASE WHEN household_derivation_method = 'singleton' THEN household_id END) AS INT)
+        AS singleton_household_count
+    FROM ranked
+    """
 
     # Translate display labels from the portfolio-builder UI into
     # mip.gold.borrower_360 predicates. Every value is a short enum the
@@ -212,13 +259,14 @@ class DatabricksPortfolioRepository:
       INSERT INTO mip_app.campaigns (
         name, owner_email, status, criteria, suppression_policy,
         message_variants, channel_cascade, send_window, holdout,
-        roi_assumptions, updated_at
+        roi_assumptions, household_dedup, household_summary, updated_at
       )
       VALUES (
         %(name)s, %(owner_email)s, 'draft', %(criteria)s::jsonb,
         %(suppression_policy)s::jsonb, %(message_variants)s::jsonb,
         %(channel_cascade)s::jsonb, %(send_window)s::jsonb,
-        %(holdout)s::jsonb, %(roi_assumptions)s::jsonb, now()
+        %(holdout)s::jsonb, %(roi_assumptions)s::jsonb,
+        %(household_dedup)s::jsonb, %(household_summary)s::jsonb, now()
       )
       RETURNING campaign_id
     ),
@@ -270,7 +318,7 @@ class DatabricksPortfolioRepository:
     _CAMPAIGN_LIST_SQL = """
     SELECT campaign_id::text, name, owner_email, status, criteria,
            suppression_policy, message_variants, channel_cascade, send_window,
-           holdout, roi_assumptions, created_at, updated_at
+           holdout, roi_assumptions, household_dedup, household_summary, created_at, updated_at
     FROM mip_app.campaigns
     WHERE (%(owner_email)s::text IS NULL OR owner_email = %(owner_email)s::text)
       AND (
@@ -286,7 +334,7 @@ class DatabricksPortfolioRepository:
     _CAMPAIGN_GET_SQL = """
     SELECT campaign_id::text, name, owner_email, status, criteria,
            suppression_policy, message_variants, channel_cascade, send_window,
-           holdout, roi_assumptions, created_at, updated_at
+           holdout, roi_assumptions, household_dedup, household_summary, created_at, updated_at
     FROM mip_app.campaigns
     WHERE campaign_id = %(campaign_id)s::uuid
     LIMIT 1
@@ -299,7 +347,7 @@ class DatabricksPortfolioRepository:
       WHERE campaign_id = %(campaign_id)s::uuid
       RETURNING campaign_id::text, name, owner_email, status, criteria,
                 suppression_policy, message_variants, channel_cascade, send_window,
-                holdout, roi_assumptions, created_at, updated_at
+                holdout, roi_assumptions, household_dedup, household_summary, created_at, updated_at
     ),
     inserted_audit AS (
       INSERT INTO mip_app.action_audit (
@@ -556,6 +604,31 @@ class DatabricksPortfolioRepository:
             )
         return build()
 
+    def _load_household_dedup_summary(
+        self,
+        payload: PortfolioCreateRequest,
+    ) -> HouseholdDedupSummary:
+        if not payload.household_dedup.enabled:
+            return HouseholdDedupSummary(enabled=False)
+
+        where_clause, params = self._build_preview_predicates(payload.criteria)
+        sql = self._HOUSEHOLD_DEDUP_SUMMARY_SQL_TEMPLATE.format(
+            borrower_table=qualify("gold", "borrower_360"),
+            household_table=qualify("gold", "household_rollup"),
+            where=where_clause,
+        )
+        row = self._client.execute_one(sql, params) or {}
+        return HouseholdDedupSummary(
+            enabled=True,
+            candidate_borrower_count=int(row.get("candidate_borrower_count") or 0),
+            selected_primary_count=int(row.get("selected_primary_count") or 0),
+            suppressed_co_owner_count=int(row.get("suppressed_co_owner_count") or 0),
+            household_count=int(row.get("household_count") or 0),
+            owner_link_household_count=int(row.get("owner_link_household_count") or 0),
+            mailing_address_household_count=int(row.get("mailing_address_household_count") or 0),
+            singleton_household_count=int(row.get("singleton_household_count") or 0),
+        )
+
     def create(
         self,
         payload: PortfolioCreateRequest,
@@ -563,6 +636,9 @@ class DatabricksPortfolioRepository:
         actor: str | None = None,
     ) -> PortfolioCreateResponse:
         preview = self.preview(PortfolioPreviewRequest(criteria=payload.criteria))
+        household_summary = self._load_household_dedup_summary(payload)
+        household_summary_dict = household_summary.model_dump()
+        household_dedup_dict = payload.household_dedup.model_dump()
         row = _get_lakebase_client().fetchone(
             self._CAMPAIGN_INSERT_SQL,
             {
@@ -579,6 +655,8 @@ class DatabricksPortfolioRepository:
                 "roi_assumptions": json.dumps(payload.roi_assumptions, sort_keys=True)
                 if payload.roi_assumptions is not None
                 else "null",
+                "household_dedup": json.dumps(household_dedup_dict, sort_keys=True),
+                "household_summary": json.dumps(household_summary_dict, sort_keys=True),
                 "request_id": f"portfolio-create-{uuid.uuid4()}",
                 "correlation_id": get_correlation_id(),
                 "metadata": json.dumps(
@@ -592,6 +670,29 @@ class DatabricksPortfolioRepository:
                             "holdout": payload.holdout,
                             "roi_assumptions": payload.roi_assumptions,
                             "marketable_population": preview.marketable_population,
+                            "dedupe_unit": payload.household_dedup.dedupe_unit,
+                            "household_dedup_enabled": payload.household_dedup.enabled,
+                            "household_primary_strategy": (
+                                payload.household_dedup.primary_contact_strategy
+                            ),
+                            "household_candidate_count": (
+                                household_summary.candidate_borrower_count
+                            ),
+                            "household_primary_count": household_summary.selected_primary_count,
+                            "household_suppressed_count": (
+                                household_summary.suppressed_co_owner_count
+                            ),
+                            "household_household_count": household_summary.household_count,
+                            "household_owner_link_count": (
+                                household_summary.owner_link_household_count
+                            ),
+                            "household_mailing_address_count": (
+                                household_summary.mailing_address_household_count
+                            ),
+                            "household_singleton_count": (
+                                household_summary.singleton_household_count
+                            ),
+                            "source_assets": household_summary.source_assets,
                         },
                         action="portfolio.create",
                     ),
@@ -623,6 +724,7 @@ class DatabricksPortfolioRepository:
             campaign_id=campaign_id,
             name=payload.name,
             marketable_population=preview.marketable_population,
+            household_summary=household_summary,
             audit_event_id=str(row["audit_id"]) if row.get("audit_id") else None,
         )
 
@@ -928,6 +1030,8 @@ def campaign_summary_from_row(row: dict[str, Any]) -> CampaignSummary:
     send_window = json_value(row.get("send_window"), {})
     holdout = json_value(row.get("holdout"), None)
     roi_assumptions = json_value(row.get("roi_assumptions"), None)
+    household_dedup = json_value(row.get("household_dedup"), {})
+    household_summary = json_value(row.get("household_summary"), {})
     return CampaignSummary(
         campaign_id=str(row.get("campaign_id")),
         name=str(row.get("name") or "Campaign"),
@@ -943,6 +1047,12 @@ def campaign_summary_from_row(row: dict[str, Any]) -> CampaignSummary:
             roi_assumptions
             if isinstance(roi_assumptions, dict) or roi_assumptions is None
             else None
+        ),
+        household_dedup=(
+            household_dedup if isinstance(household_dedup, dict) else {}
+        ),
+        household_summary=(
+            household_summary if isinstance(household_summary, dict) else {}
         ),
         created_at=coerce_utc_datetime(row.get("created_at")),
         updated_at=coerce_utc_datetime(row.get("updated_at")),

--- a/backend/services/repositories/databricks_portfolio.py
+++ b/backend/services/repositories/databricks_portfolio.py
@@ -14,6 +14,7 @@ from backend.schemas.portfolio import (
     CampaignListResponse,
     CampaignStatusPatchRequest,
     CampaignSummary,
+    HouseholdDedupConfig,
     HouseholdDedupSummary,
     KpiTrend,
     PortfolioCreateRequest,
@@ -1022,6 +1023,18 @@ def json_value(value: Any, fallback: Any) -> Any:
     return value
 
 
+def household_dedup_config_from_value(value: Any) -> HouseholdDedupConfig:
+    if not isinstance(value, dict):
+        return HouseholdDedupConfig()
+    return HouseholdDedupConfig.model_validate(value)
+
+
+def household_dedup_summary_from_value(value: Any) -> HouseholdDedupSummary:
+    if not isinstance(value, dict):
+        return HouseholdDedupSummary()
+    return HouseholdDedupSummary.model_validate(value)
+
+
 def campaign_summary_from_row(row: dict[str, Any]) -> CampaignSummary:
     criteria = json_value(row.get("criteria"), {})
     suppression_policy = json_value(row.get("suppression_policy"), {})
@@ -1048,12 +1061,8 @@ def campaign_summary_from_row(row: dict[str, Any]) -> CampaignSummary:
             if isinstance(roi_assumptions, dict) or roi_assumptions is None
             else None
         ),
-        household_dedup=(
-            household_dedup if isinstance(household_dedup, dict) else {}
-        ),
-        household_summary=(
-            household_summary if isinstance(household_summary, dict) else {}
-        ),
+        household_dedup=household_dedup_config_from_value(household_dedup),
+        household_summary=household_dedup_summary_from_value(household_summary),
         created_at=coerce_utc_datetime(row.get("created_at")),
         updated_at=coerce_utc_datetime(row.get("updated_at")),
     )

--- a/databricks.yml
+++ b/databricks.yml
@@ -543,6 +543,14 @@ resources:
             warehouse_id: ${resources.sql_warehouses.mip_serverless_sql.id}
             file:
               path: sql/_rendered/transformations/assert_borrower_360_fresh.sql
+        - task_key: ctas_household_rollup
+          description: "Rebuild mip.gold.household_rollup via CTAS for opt-in campaign household dedup."
+          depends_on:
+            - task_key: assert_borrower_360_fresh
+          sql_task:
+            warehouse_id: ${resources.sql_warehouses.mip_serverless_sql.id}
+            file:
+              path: sql/_rendered/transformations/gold_household_rollup.sql
         - task_key: ctas_lead_scores
           description: "Rebuild mip.gold.lead_scores via CTAS."
           depends_on:

--- a/docs/data-contract-module0.md
+++ b/docs/data-contract-module0.md
@@ -530,6 +530,40 @@ Columns = exact superset of what `LeadSummary` needs, plus `rank_overall` and `r
 | `color` | STRING | N | static map | `color` | Hex. |
 | `refreshed_at` | TIMESTAMP | N | latest `mip.ref.refresh_run_state.refresh_at` | — | |
 
+### 3.7 `mip.gold.household_rollup`
+
+- **Grain:** one row per `borrower_360.borrower_id` / CLIP.
+- **Source:** `gold.borrower_360`, S1.1 `silver.property_owners`, and `silver.property_master`.
+- **PK:** `borrower_id`.
+- **Clustering:** `(household_id, borrower_id)`.
+- **Refresh:** daily, downstream of `borrower_360`; read only when campaign household dedup is explicitly enabled.
+- **Default unit:** BORROWER remains the default everywhere. Household is opt-in at campaign creation only.
+
+Deterministic derivation order:
+
+1. **Owner Link:** group CLIPs through shared `silver.property_owners.owner_link_id` rows, including co-owner links on CLIPs reached through one shared Owner-Link hop. The canonical key is the lexicographically smallest reachable Owner Link and is hashed before landing.
+2. **Mailing-address heuristic:** if no Owner Link exists, group by salted `owner_name_hash` plus normalized `mailing_city` / `mailing_state`. `mailing_street_address` never lands in silver or gold, so this heuristic is intentionally conservative.
+3. **Singleton:** if neither signal exists, the borrower is its own household.
+
+Primary-contact ranking is deterministic: contact-eligible members (`marketing_eligible=true` and `has_unresolved_owner=false`) rank before ineligible members, then `opportunity_score DESC`, then `borrower_id ASC`. A campaign can suppress co-owners only after this rank is computed; an ineligible member is never promoted to primary.
+
+| Column | Type | Null | Source | Definition |
+|---|---|---|---|---|
+| `clip` | STRING | N | `borrower_360.clip` | Below API redaction boundary. |
+| `borrower_id` | STRING | N | `borrower_360.borrower_id` | Synthetic `B-[0-9A-Z]{13}` id. |
+| `household_id` | STRING | N | `HH-` + sha2 suffix over the derivation key | Public household id. |
+| `household_derivation_method` | STRING | N | derivation branch | `owner_link`, `mailing_address`, or `singleton`. |
+| `household_derivation_key_hash` | STRING | N | sha2 over non-PII key | Audit reconciliation only; raw Owner Links and mailing city/state are not emitted. |
+| `derivation_source_tables` | ARRAY<STRING> | N | literal UC paths | EvidenceDrawer lineage for surfaced household counts. |
+| `household_member_count` | INT | N | window count | Members assigned to the household id. |
+| `eligible_member_count` | INT | N | window count | Members eligible to be a campaign contact. |
+| `household_rank` | INT | N | window rank | Eligible-first primary rank. |
+| `is_household_primary` | BOOLEAN | N | rank + eligibility | TRUE only for the eligible rank-1 member. |
+| `primary_borrower_id` | STRING | Y | rank result | Synthetic borrower id for the selected primary contact. |
+| `suppressed_by_household_dedup` | BOOLEAN | N | rank + eligibility | TRUE for eligible co-owners suppressed by opt-in household dedup. |
+| `owner_link_reachable_count` | INT | N | `silver.property_owners` | Count of reachable Owner Links used by the owner-link branch. |
+| `refreshed_at` | TIMESTAMP | N | `mip.ref.refresh_run_state.refresh_at` | Shared gold refresh timestamp. |
+
 ---
 
 ## 4. Segment Membership (SQL definitions)

--- a/frontend/src/design-system/components.css
+++ b/frontend/src/design-system/components.css
@@ -3599,6 +3599,13 @@ kbd {
   gap: 2px;
   font-size: var(--fs-12);
 }
+.saved-workspace__proof {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+}
 .saved-workspace__body > span {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -5300,6 +5307,57 @@ kbd {
   text-transform: uppercase;
 }
 .campaign-setup__field--wide { grid-column: 1 / -1; }
+.campaign-setup__toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  padding: var(--sp-3);
+  border: 1px solid var(--line-1);
+  border-radius: var(--r-md);
+  background: var(--bg-2);
+}
+.campaign-setup__toggle-copy {
+  display: grid;
+  gap: var(--sp-1);
+  min-width: 0;
+}
+.campaign-setup__toggle-copy p {
+  margin: 0;
+  color: var(--text-3);
+  font-size: var(--fs-12);
+  line-height: 1.45;
+}
+.campaign-setup__toggle .switch {
+  position: relative;
+  flex: 0 0 auto;
+  width: var(--sp-10);
+  height: var(--sp-6);
+  border-radius: var(--r-pill);
+  background: var(--bg-3);
+  border: 1px solid var(--line-1);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease);
+}
+.campaign-setup__toggle .switch::after {
+  content: '';
+  position: absolute;
+  top: calc(var(--sp-1) / 2);
+  left: calc(var(--sp-1) / 2);
+  width: var(--sp-5);
+  height: var(--sp-5);
+  border-radius: var(--r-pill);
+  background: var(--text-3);
+  transition: left var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease);
+}
+.campaign-setup__toggle .switch.on {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+.campaign-setup__toggle .switch.on::after {
+  left: calc(var(--sp-10) - var(--sp-5) - (var(--sp-1) / 2));
+  background: var(--accent);
+}
 .campaign-setup__textarea {
   min-height: calc(var(--sp-12) + var(--sp-8));
   resize: vertical;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -760,6 +760,7 @@ export const api = {
       send_window: Record<string, unknown>;
       holdout: Record<string, unknown>;
       roi_assumptions: Record<string, unknown>;
+      household_dedup: Record<string, unknown>;
     }> = {},
     signal?: AbortSignal,
   ) =>
@@ -772,6 +773,7 @@ export const api = {
       send_window: Record<string, unknown>;
       holdout: Record<string, unknown>;
       roi_assumptions: Record<string, unknown>;
+      household_dedup: Record<string, unknown>;
     }>(
       '/api/portfolio/create',
       {
@@ -787,6 +789,11 @@ export const api = {
         send_window: config.send_window ?? { days: ['Tuesday', 'Wednesday', 'Thursday'], start_local: '09:00', end_local: '16:00' },
         holdout: config.holdout ?? { method: 'hash_modulo', size_pct: 10 },
         roi_assumptions: config.roi_assumptions ?? { source: 'operator_required_before_live_send' },
+        household_dedup: config.household_dedup ?? {
+          enabled: false,
+          dedupe_unit: 'borrower',
+          primary_contact_strategy: 'highest_opportunity_eligible',
+        },
       },
       signal,
     ),

--- a/frontend/src/lib/drawerSources.test.ts
+++ b/frontend/src/lib/drawerSources.test.ts
@@ -106,6 +106,7 @@ describe('descriptorFor', () => {
     expect(assetKeyForSource('mip.gold.borrower_dossier')).toBe('borrower_dossier');
     expect(assetHrefForSource('mip.gold.borrower_dossier')).toBe('/data-estate/assets/borrower_dossier');
     expect(drawerForAsset('mip.gold.evidence_events')).toBe(DRAWER_SOURCES.evidenceStream);
+    expect(drawerForAsset('mip.gold.household_rollup')).toBe(DRAWER_SOURCES.householdRollup);
     expect(drawerForAsset('mip.gold.source_readiness')).toBe(DRAWER_SOURCES.sourceReadiness);
     expect(drawerForAsset('mip.gold.lockin_cohort')).toBe(DRAWER_SOURCES.lockinCohort);
     expect(drawerForAsset('mip.gold.fn_rate_spread')).toBe(DRAWER_SOURCES.marketRate);
@@ -157,6 +158,7 @@ describe('descriptorFor', () => {
       DRAWER_SOURCES.evidenceStream,
       DRAWER_SOURCES.sourceReadiness,
       DRAWER_SOURCES.borrowerDossier,
+      DRAWER_SOURCES.householdRollup,
       DRAWER_SOURCES.itm,
       DRAWER_SOURCES.marketRate,
       DRAWER_SOURCES.leadScore,

--- a/frontend/src/lib/drawerSources.ts
+++ b/frontend/src/lib/drawerSources.ts
@@ -7,6 +7,7 @@ const ASSET_KEYS_BY_SOURCE: Record<string, string> = {
   'mip.gold.borrower_360': 'borrower_360',
   'mip.gold.borrower_dossier': 'borrower_dossier',
   'mip.gold.evidence_events': 'evidence_events',
+  'mip.gold.household_rollup': 'household_rollup',
   'mip.gold.source_readiness': 'source_readiness',
   'mip.gold.lockin_cohort': 'lockin_cohort',
   'mip.gold.funnel_snapshot_daily': 'funnel_snapshot_daily',
@@ -85,6 +86,7 @@ export function drawerForAsset(rawSource: string): DrawerSource | null {
   if (key.includes('lead_population')) return enrichAsset(DRAWER_SOURCES.leadPopulation);
   if (key.includes('segment_population')) return enrichAsset(DRAWER_SOURCES.segmentPopulation);
   if (key.includes('borrower_dossier')) return enrichAsset(DRAWER_SOURCES.borrowerDossier);
+  if (key.includes('household_rollup')) return enrichAsset(DRAWER_SOURCES.householdRollup);
   if (key.includes('borrower_360')) return enrichAsset(DRAWER_SOURCES.borrower360);
   if (key.includes('evidence_events')) return enrichAsset(DRAWER_SOURCES.evidenceStream);
   if (key.includes('source_readiness')) return enrichAsset(DRAWER_SOURCES.sourceReadiness);
@@ -263,6 +265,29 @@ export const DRAWER_SOURCES: Record<string, DrawerSource> = {
       { label: 'Property identity', source: 'mip.silver.property_master.clip', value: 'masked CLIP ref' },
       { label: 'Owner relationship', source: 'mip.gold.property_owner_bridge.owner_link_id', value: 'masked Owner Link ref' },
       { label: 'Investor signal', source: 'borrower_360.related_property_count', value: '2+ related properties' },
+    ],
+  },
+
+  householdRollup: {
+    title: 'Household rollup',
+    short: 'Household rollup',
+    assetKey: 'household_rollup',
+    assetPath: 'mip.gold.household_rollup',
+    usedIn: ['Portfolio Builder campaign summary'],
+    notExposed: 'Raw CLIPs, Owner Links, owner names, mailing street addresses, emails, phones, and destination send paths.',
+    description:
+      'Opt-in campaign-time household grouping. Borrower remains the default unit; this rollup supplies one eligible primary contact per household only when the campaign builder enables household dedup.',
+    lineage: [
+      { layer: 'SILVER', name: 'mip.silver.property_owners', meta: 'S1.1 owner slots and shared Owner Links' },
+      { layer: 'SILVER', name: 'mip.silver.property_master', meta: 'mailing city/state heuristic; no mailing street address' },
+      { layer: 'FEATURES', name: 'mip.gold.borrower_360', meta: 'synthetic borrower ids, score, marketing eligibility' },
+      { layer: 'GOLD', name: 'mip.gold.household_rollup', meta: 'household id, eligible primary rank, suppression count source' },
+    ],
+    signals: [
+      { label: 'Default unit', source: 'campaign.household_dedup.enabled', value: 'borrower unless explicitly enabled' },
+      { label: 'Primary contact', source: 'household_rollup.household_rank', value: 'eligible first, score desc, borrower id asc' },
+      { label: 'Suppressed co-owners', source: 'household_rollup.suppressed_by_household_dedup', value: 'counted in campaign summary' },
+      { label: 'Derivation evidence', source: 'household_rollup.derivation_source_tables', value: 'UC row lineage' },
     ],
   },
 

--- a/frontend/src/routes/portfolio-builder.logic.test.ts
+++ b/frontend/src/routes/portfolio-builder.logic.test.ts
@@ -140,6 +140,24 @@ describe('portfolio campaign config', () => {
       budget_usd: null,
       source: 'operator_configured',
     });
+    expect(config.household_dedup).toEqual({
+      enabled: false,
+      dedupe_unit: 'borrower',
+      primary_contact_strategy: 'highest_opportunity_eligible',
+    });
+  });
+
+  it('makes household dedup opt-in at campaign time only', () => {
+    const config = buildCampaignConfig({
+      ...DEFAULT_CAMPAIGN_SETUP,
+      marketHouseholdTogether: true,
+    });
+
+    expect(config.household_dedup).toEqual({
+      enabled: true,
+      dedupe_unit: 'household',
+      primary_contact_strategy: 'highest_opportunity_eligible',
+    });
   });
 
   it('summarizes saved lender-overlay campaigns with the target lien holder', () => {

--- a/frontend/src/routes/portfolio-builder.logic.ts
+++ b/frontend/src/routes/portfolio-builder.logic.ts
@@ -83,6 +83,7 @@ export type CampaignSetupState = {
   emailCost: string;
   smsCost: string;
   mailCost: string;
+  marketHouseholdTogether: boolean;
 };
 
 export function buildDefaultCampaignSetup(
@@ -101,6 +102,7 @@ export function buildDefaultCampaignSetup(
     emailCost: '1.20',
     smsCost: '0.08',
     mailCost: '0.86',
+    marketHouseholdTogether: false,
   };
 }
 
@@ -267,6 +269,7 @@ export function buildCampaignConfig(setup: CampaignSetupState): {
   send_window: Record<string, unknown>;
   holdout: Record<string, unknown>;
   roi_assumptions: Record<string, unknown>;
+  household_dedup: Record<string, unknown>;
 } {
   const holdoutPct = boundedNumber(setup.holdoutPct, 10, 0, 50);
   return {
@@ -307,6 +310,11 @@ export function buildCampaignConfig(setup: CampaignSetupState): {
         direct_mail: nullableMoney(setup.mailCost),
       },
       source: 'operator_configured',
+    },
+    household_dedup: {
+      enabled: setup.marketHouseholdTogether,
+      dedupe_unit: setup.marketHouseholdTogether ? 'household' : 'borrower',
+      primary_contact_strategy: 'highest_opportunity_eligible',
     },
   };
 }

--- a/frontend/src/routes/portfolio-builder.save.test.tsx
+++ b/frontend/src/routes/portfolio-builder.save.test.tsx
@@ -227,6 +227,7 @@ describe('PortfolioBuilder save-build flow', () => {
       'utf-8',
     );
     expect(source).not.toContain('window.prompt');
+    expect(source).toContain('market the household together');
   });
 
   it('bans the blocking-dialog class repo-wide via eslint config', () => {

--- a/frontend/src/routes/portfolio-builder.tsx
+++ b/frontend/src/routes/portfolio-builder.tsx
@@ -9,6 +9,7 @@ import { PageShell } from '../components/layout/PageShell';
 import { KpiCard } from '../components/mortgage/KpiCard';
 import { Button } from '../components/Primitives';
 import { Icon } from '../components/Icon';
+import { useApp } from '../components/AppContext';
 import { FilterSelect } from '../components/ui/FilterSelect';
 import { WarmingUpBlock } from '../components/ui/WarmingUpBlock';
 import { DRAWER_SOURCES } from '../lib/drawerSources';
@@ -46,6 +47,7 @@ import {
 
 export default function PortfolioBuilder() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { setDrawer } = useApp();
   const footprint = useFootprint();
   const configOptionsQuery = useConfigOptionsQuery();
   const targetLenderOptions = useMemo(() => {
@@ -159,9 +161,15 @@ export default function PortfolioBuilder() {
     : null;
 
   const setFilter = (key: string) => (next: string) => setFilters((f) => ({ ...f, [key]: next }));
-  const setCampaignField = (key: keyof CampaignSetupState) => (
+  const setCampaignField = (key: Exclude<keyof CampaignSetupState, 'marketHouseholdTogether'>) => (
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => setCampaignSetup((current) => ({ ...current, [key]: event.target.value }));
+  const toggleHouseholdDedup = useCallback(() => {
+    setCampaignSetup((current) => ({
+      ...current,
+      marketHouseholdTogether: !current.marketHouseholdTogether,
+    }));
+  }, []);
   const buildDirty = useMemo(
     () =>
       JSON.stringify({ filters, stateCodes }) !==
@@ -674,6 +682,24 @@ export default function PortfolioBuilder() {
                 onChange={setCampaignField('mailCost')}
               />
             </label>
+            <div className="campaign-setup__field campaign-setup__field--wide">
+              <div className="campaign-setup__toggle">
+                <div className="campaign-setup__toggle-copy">
+                  <span>market the household together</span>
+                  <p>
+                    One eligible primary contact per household enters the campaign;
+                    suppressed co-owners are counted in the summary.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className={`switch ${campaignSetup.marketHouseholdTogether ? 'on' : ''}`}
+                  onClick={toggleHouseholdDedup}
+                  aria-pressed={campaignSetup.marketHouseholdTogether}
+                  aria-label="market the household together"
+                />
+              </div>
+            </div>
           </div>
           <div className="campaign-setup__meta">
             <span>Email → SMS after 3 days → direct mail after 10 days</span>
@@ -718,15 +744,35 @@ export default function PortfolioBuilder() {
                 <span>{campaigns.length.toLocaleString()} saved</span>
                 <span>eligible-only policy required before approval</span>
               </div>
-              {campaigns.slice(0, 8).map((campaign) => (
-                <div key={campaign.campaign_id} className="saved-workspace__item">
-                  <span className="status-dot status-dot--ok" aria-hidden="true" />
-                  <div className="saved-workspace__body">
-                    <span className="text-1">{campaign.name}</span>
-                    <span>{campaign.status.replace(/_/g, ' ')} · {campaignCriteriaSummary(campaign)}</span>
+              {campaigns.slice(0, 8).map((campaign) => {
+                const householdEnabled = campaign.household_dedup?.enabled === true;
+                const suppressedCount = campaign.household_summary?.suppressed_co_owner_count ?? 0;
+                return (
+                  <div key={campaign.campaign_id} className="saved-workspace__item">
+                    <span className="status-dot status-dot--ok" aria-hidden="true" />
+                    <div className="saved-workspace__body">
+                      <span className="text-1">{campaign.name}</span>
+                      <span>{campaign.status.replace(/_/g, ' ')} · {campaignCriteriaSummary(campaign)}</span>
+                      {householdEnabled && (
+                        <div className="saved-workspace__proof">
+                          <span className="chip chip--warning">
+                            {suppressedCount.toLocaleString()} co-owner
+                            {suppressedCount === 1 ? '' : 's'} suppressed
+                          </span>
+                          <button
+                            type="button"
+                            className="evidence-chip"
+                            onClick={() => setDrawer(DRAWER_SOURCES.householdRollup)}
+                          >
+                            <Icon name="link" size={9} className="e-ico" />
+                            <span className="evidence-chip__label">household_rollup</span>
+                          </button>
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -463,7 +463,27 @@ export interface PortfolioCreateResponse {
   campaign_id?: string | null;
   name: string;
   marketable_population: number;
+  household_summary?: HouseholdDedupSummary;
   audit_event_id?: string | null;
+}
+
+export interface HouseholdDedupConfig {
+  enabled: boolean;
+  dedupe_unit: 'borrower' | 'household';
+  primary_contact_strategy: 'highest_opportunity_eligible';
+}
+
+export interface HouseholdDedupSummary {
+  enabled: boolean;
+  candidate_borrower_count: number;
+  selected_primary_count: number;
+  suppressed_co_owner_count: number;
+  household_count: number;
+  owner_link_household_count: number;
+  mailing_address_household_count: number;
+  singleton_household_count: number;
+  primary_contact_strategy: 'highest_opportunity_eligible';
+  source_assets: string[];
 }
 
 export interface CampaignSummary {
@@ -478,6 +498,8 @@ export interface CampaignSummary {
   send_window?: Record<string, unknown>;
   holdout?: Record<string, unknown> | null;
   roi_assumptions?: Record<string, unknown> | null;
+  household_dedup?: HouseholdDedupConfig;
+  household_summary?: HouseholdDedupSummary;
   created_at?: string | null;
   updated_at?: string | null;
 }

--- a/lakebase/schema.sql
+++ b/lakebase/schema.sql
@@ -52,6 +52,8 @@ CREATE TABLE IF NOT EXISTS mip_app.campaigns (
     send_window JSONB NOT NULL DEFAULT '{}'::jsonb,
     holdout JSONB,
     roi_assumptions JSONB,
+    household_dedup JSONB NOT NULL DEFAULT '{"enabled": false, "dedupe_unit": "borrower", "primary_contact_strategy": "highest_opportunity_eligible"}'::jsonb,
+    household_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
     updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -67,6 +69,10 @@ ALTER TABLE mip_app.campaigns
     ADD COLUMN IF NOT EXISTS holdout JSONB;
 ALTER TABLE mip_app.campaigns
     ADD COLUMN IF NOT EXISTS roi_assumptions JSONB;
+ALTER TABLE mip_app.campaigns
+    ADD COLUMN IF NOT EXISTS household_dedup JSONB NOT NULL DEFAULT '{"enabled": false, "dedupe_unit": "borrower", "primary_contact_strategy": "highest_opportunity_eligible"}'::jsonb;
+ALTER TABLE mip_app.campaigns
+    ADD COLUMN IF NOT EXISTS household_summary JSONB NOT NULL DEFAULT '{}'::jsonb;
 ALTER TABLE mip_app.campaigns
     ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
 CREATE INDEX IF NOT EXISTS idx_campaigns_owner
@@ -1016,5 +1022,12 @@ INSERT INTO mip_app.schema_migrations (version, description)
 VALUES (
     '2026_06_30_growth_agent_monitor_drafts',
     'Persist Growth Agent Slack/Teams review drafts for scheduled monitor runs; draft-only, no connector send path'
+)
+ON CONFLICT (version) DO NOTHING;
+
+INSERT INTO mip_app.schema_migrations (version, description)
+VALUES (
+    '2026_07_09_campaign_household_dedup',
+    'S1.5: persist default-off household dedup config and evidence-cited suppression summary on campaigns'
 )
 ON CONFLICT (version) DO NOTHING;

--- a/sql/ddl/003_gold_tables.sql
+++ b/sql/ddl/003_gold_tables.sql
@@ -13,6 +13,7 @@
 --   sql/ddl/gold_borrower_360.sql            -- CLIP-grain projection.
 --   sql/ddl/gold_lead_scores.sql             -- Scoring sub-scores + fn_lead_score.
 --   sql/ddl/gold_evidence_events.sql         -- Per-(CLIP, signal) rows.
+--   sql/ddl/gold_household_rollup.sql        -- Opt-in campaign household dedup.
 --   sql/ddl/gold_lead_population.sql         -- Ranked quality-filtered cut for /leads.
 --   sql/ddl/gold_segment_population.sql      -- Segment counts + prior snapshot.
 --
@@ -20,10 +21,11 @@
 --   1. gold.property_owner_bridge     (owner-link-keyed; no deps)
 --   2. gold.evidence_events           (silver-derived; scoped to silver lien_current spine)
 --   3. gold.borrower_360              (depends on property_owner_bridge + evidence_events)
---   4. gold.lead_scores               (depends on borrower_360 + evidence_events)
---   5. gold.lead_population           (depends on borrower_360 + lead_scores)
---   6. gold.segment_population        (depends on borrower_360 + lead_scores)
---   7. gold.source_readiness          (non-PII Admin source summary)
+--   4. gold.household_rollup          (depends on borrower_360 + silver.property_owners)
+--   5. gold.lead_scores               (depends on borrower_360 + evidence_events)
+--   6. gold.lead_population           (depends on borrower_360 + lead_scores)
+--   7. gold.segment_population        (depends on borrower_360 + lead_scores)
+--   8. gold.source_readiness          (non-PII Admin source summary)
 --
 -- Each file uses CREATE TABLE IF NOT EXISTS so re-running is a no-op if the
 -- schema hasn't changed. If a column is added to a per-file DDL, this
@@ -250,7 +252,36 @@ TBLPROPERTIES (
 );
 
 -- -----------------------------------------------------------------------------
--- 3. mip.gold.evidence_events
+-- 3. mip.gold.household_rollup
+--    (see sql/ddl/gold_household_rollup.sql for derivation + PII posture)
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS mip.gold.household_rollup (
+  clip                            STRING    NOT NULL COMMENT 'Cotality CLIP below the API redaction boundary; joins to borrower_360.clip.',
+  borrower_id                     STRING    NOT NULL COMMENT 'Synthetic stable borrower id, B-[0-9A-Z]{13}. No PII.',
+  household_id                    STRING    NOT NULL COMMENT 'Deterministic public household id: HH- + first 16 hex chars of sha2(derivation key).',
+  household_derivation_method     STRING    NOT NULL COMMENT 'owner_link | mailing_address | singleton.',
+  household_derivation_key_hash   STRING    NOT NULL COMMENT 'Full sha2 over the non-PII derivation key. Raw Owner Links, CLIPs, mailing city/state, and owner hashes are not emitted.',
+  derivation_source_tables        ARRAY<STRING> NOT NULL COMMENT 'UC source rows supporting the derivation: mip.silver.property_owners, mip.silver.property_master, and/or mip.gold.borrower_360.',
+  household_member_count          INT       NOT NULL COMMENT 'Count of borrower rows assigned to this household_id.',
+  eligible_member_count           INT       NOT NULL COMMENT 'Count of household members that are campaign-contact eligible: marketing_eligible=true and has_unresolved_owner=false.',
+  household_rank                  INT       NOT NULL COMMENT 'Deterministic rank inside household: eligible borrowers first, then opportunity_score DESC, borrower_id ASC.',
+  is_household_primary            BOOLEAN   NOT NULL COMMENT 'TRUE only for rank 1 when that borrower is contact-eligible.',
+  primary_borrower_id             STRING             COMMENT 'Synthetic borrower id of the selected primary contact, or NULL if no member is contact-eligible.',
+  suppressed_by_household_dedup   BOOLEAN   NOT NULL COMMENT 'TRUE when this eligible borrower would be suppressed by opt-in campaign household dedup.',
+  owner_link_reachable_count      INT       NOT NULL COMMENT 'Number of reachable Owner Links used by the owner_link derivation; 0 for non-owner-link methods.',
+  refreshed_at                    TIMESTAMP NOT NULL COMMENT 'Shared gold refresh timestamp from mip.ref.refresh_run_state.'
+)
+USING DELTA
+CLUSTER BY (household_id, borrower_id)
+COMMENT 'Campaign-time household dedup rollup. Borrower remains the default unit; household grouping is opt-in at campaign creation and evidence-cited through UC lineage.'
+TBLPROPERTIES (
+  'delta.enableChangeDataFeed' = 'false',
+  'delta.autoOptimize.optimizeWrite' = 'true',
+  'delta.autoOptimize.autoCompact'   = 'true'
+);
+
+-- -----------------------------------------------------------------------------
+-- 4. mip.gold.evidence_events
 -- -----------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS mip.gold.evidence_events (
   clip           STRING NOT NULL COMMENT 'Cotality CLIP. Not in Pydantic EvidenceEvent (router strips); used for join / filter.',

--- a/sql/ddl/gold_household_rollup.sql
+++ b/sql/ddl/gold_household_rollup.sql
@@ -1,0 +1,69 @@
+-- =============================================================================
+-- gold_household_rollup.sql
+-- -----------------------------------------------------------------------------
+-- Purpose:   DDL for `mip.gold.household_rollup`, the opt-in campaign-time
+--            deduplication surface. The default unit in Module 0 remains
+--            BORROWER; this table only supplies a governed household grouping
+--            when the campaign builder explicitly enables household dedup.
+--
+-- Grain:     One row per borrower / CLIP from `mip.gold.borrower_360`.
+-- PK:        borrower_id.
+-- Clustering: Liquid cluster on (household_id, borrower_id). Campaign creation
+--            filters borrower_360, joins this table by borrower_id, then ranks
+--            one contact-eligible primary per household.
+--
+-- Deterministic derivation:
+--            1. owner_link: group CLIPs through shared Owner Links from
+--               `mip.silver.property_owners` (S1.1), including co-owner links
+--               on CLIPs reached through one shared owner-link hop. The
+--               canonical key is the lexicographically smallest reachable
+--               Owner Link, hashed before landing.
+--            2. mailing_address: if no Owner Link exists, group by salted
+--               owner_name_hash plus normalized mailing_city / mailing_state
+--               from `mip.silver.property_master`. Street-level mailing address
+--               never lands in silver or gold, so the heuristic is intentionally
+--               conservative and hash-backed.
+--            3. singleton: if neither signal is present, the borrower is its
+--               own household.
+--
+-- PII posture:
+--            No raw names, street addresses, CLIPs, or Owner Links are exposed.
+--            household_id is "HH-" + a sha2 suffix over the derivation key;
+--            household_derivation_key_hash stores the full sha2 for audit
+--            reconciliation only. Borrower ids remain synthetic B-[0-9A-Z]{13}.
+--
+-- Evidence traceability:
+--            derivation_source_tables lists the UC rows used for each method
+--            (`mip.silver.property_owners`, `mip.silver.property_master`,
+--            `mip.gold.borrower_360`). The frontend EvidenceDrawer cites this
+--            gold table and its lineage when campaign summaries surface
+--            household suppression counts.
+--
+-- Idempotency: CREATE TABLE IF NOT EXISTS. Transformation uses
+--            CREATE OR REPLACE TABLE ... AS SELECT for a full gold rebuild.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS mip.gold.household_rollup (
+  clip                            STRING    NOT NULL COMMENT 'Cotality CLIP below the API redaction boundary; joins to borrower_360.clip.',
+  borrower_id                     STRING    NOT NULL COMMENT 'Synthetic stable borrower id, B-[0-9A-Z]{13}. No PII.',
+  household_id                    STRING    NOT NULL COMMENT 'Deterministic public household id: HH- + first 16 hex chars of sha2(derivation key).',
+  household_derivation_method     STRING    NOT NULL COMMENT 'owner_link | mailing_address | singleton.',
+  household_derivation_key_hash   STRING    NOT NULL COMMENT 'Full sha2 over the non-PII derivation key. Raw Owner Links, CLIPs, mailing city/state, and owner hashes are not emitted.',
+  derivation_source_tables        ARRAY<STRING> NOT NULL COMMENT 'UC source rows supporting the derivation: mip.silver.property_owners, mip.silver.property_master, and/or mip.gold.borrower_360.',
+  household_member_count          INT       NOT NULL COMMENT 'Count of borrower rows assigned to this household_id.',
+  eligible_member_count           INT       NOT NULL COMMENT 'Count of household members that are campaign-contact eligible: marketing_eligible=true and has_unresolved_owner=false.',
+  household_rank                  INT       NOT NULL COMMENT 'Deterministic rank inside household: eligible borrowers first, then opportunity_score DESC, borrower_id ASC.',
+  is_household_primary            BOOLEAN   NOT NULL COMMENT 'TRUE only for rank 1 when that borrower is contact-eligible.',
+  primary_borrower_id             STRING             COMMENT 'Synthetic borrower id of the selected primary contact, or NULL if no member is contact-eligible.',
+  suppressed_by_household_dedup   BOOLEAN   NOT NULL COMMENT 'TRUE when this eligible borrower would be suppressed by opt-in campaign household dedup.',
+  owner_link_reachable_count      INT       NOT NULL COMMENT 'Number of reachable Owner Links used by the owner_link derivation; 0 for non-owner-link methods.',
+  refreshed_at                    TIMESTAMP NOT NULL COMMENT 'Shared gold refresh timestamp from mip.ref.refresh_run_state.'
+)
+USING DELTA
+CLUSTER BY (household_id, borrower_id)
+COMMENT 'Campaign-time household dedup rollup. Borrower remains the default unit; household grouping is opt-in at campaign creation and evidence-cited through UC lineage.'
+TBLPROPERTIES (
+  'delta.enableChangeDataFeed' = 'false',
+  'delta.autoOptimize.optimizeWrite' = 'true',
+  'delta.autoOptimize.autoCompact'   = 'true'
+);

--- a/sql/transformations/gold_household_rollup.sql
+++ b/sql/transformations/gold_household_rollup.sql
@@ -1,0 +1,193 @@
+-- =============================================================================
+-- gold_household_rollup.sql (transformation)
+-- -----------------------------------------------------------------------------
+-- Purpose:   Populate `mip.gold.household_rollup` for opt-in campaign-time
+--            household dedup. Module 0 defaults to BORROWER everywhere; this
+--            table is read only when a campaign explicitly enables the
+--            household dedup toggle.
+--
+-- Grain:     One row per borrower / CLIP from `mip.gold.borrower_360`.
+-- Pattern:   CREATE OR REPLACE TABLE ... AS SELECT. Full rebuild follows the
+--            gold refresh posture and is deterministic for the same inputs.
+-- Data contract: docs/data-contract-module0.md §3.7.
+--
+-- Derivation order:
+--   1. owner_link: use S1.1 `mip.silver.property_owners` one-row-per
+--      (clip, owner_link) rows. For each CLIP, look through one shared
+--      Owner-Link hop and its co-owner slots, then choose the lexicographically
+--      smallest reachable owner_link_id as the canonical key. The raw Owner
+--      Link never lands; only sha2-derived household ids do.
+--   2. mailing_address: when no Owner Link exists, use owner_name_hash plus
+--      normalized mailing_city / mailing_state from property_master. This is
+--      intentionally conservative and avoids street-level mailing attributes.
+--   3. singleton: remaining borrowers keep their own household.
+--
+-- Primary-contact ranking:
+--   Eligible members rank before ineligible members, then by opportunity_score
+--   DESC and borrower_id ASC. is_household_primary is TRUE only if the rank-1
+--   borrower is marketing_eligible and has_unresolved_owner=false, so campaign
+--   dedup can never promote an ineligible co-owner.
+--
+-- 2026-07-09 S1.5: CTAS re-declares clustering/comments/properties because
+-- CREATE OR REPLACE TABLE drops DDL metadata on every refresh.
+-- =============================================================================
+
+CREATE OR REPLACE TABLE mip.gold.household_rollup
+CLUSTER BY (household_id, borrower_id)
+TBLPROPERTIES (
+  'delta.enableChangeDataFeed' = 'false',
+  'delta.autoOptimize.optimizeWrite' = 'true',
+  'delta.autoOptimize.autoCompact'   = 'true'
+)
+AS
+WITH refresh_anchor AS (
+  SELECT refresh_at
+  FROM mip.ref.refresh_run_state
+  ORDER BY captured_at DESC
+  LIMIT 1
+),
+clip_owner_links AS (
+  SELECT DISTINCT
+    po.clip,
+    NULLIF(TRIM(po.owner_link_id), '') AS owner_link_id
+  FROM mip.silver.property_owners AS po
+  JOIN mip.gold.borrower_360 AS b
+    ON b.clip = po.clip
+  WHERE po.owner_link_id IS NOT NULL
+),
+owner_link_reach AS (
+  -- One shared-owner hop plus co-owner slots on the reached CLIPs. This keeps
+  -- the derivation deterministic in SQL without requiring a recursive graph
+  -- library, and it handles the common household shape: A+B co-own one CLIP,
+  -- A or B appears on another CLIP.
+  SELECT
+    base.clip,
+    member.owner_link_id AS reachable_owner_link_id
+  FROM clip_owner_links AS base
+  JOIN clip_owner_links AS shared_clip
+    ON shared_clip.owner_link_id = base.owner_link_id
+  JOIN clip_owner_links AS member
+    ON member.clip = shared_clip.clip
+),
+owner_link_households AS (
+  SELECT
+    clip,
+    MIN(reachable_owner_link_id) AS owner_link_household_key,
+    CAST(COUNT(DISTINCT reachable_owner_link_id) AS INT) AS owner_link_reachable_count
+  FROM owner_link_reach
+  GROUP BY clip
+),
+mailing_households AS (
+  SELECT
+    po.clip,
+    MIN(CONCAT(
+      'mail:',
+      po.owner_name_hash,
+      ':',
+      UPPER(TRIM(pm.mailing_city)),
+      ':',
+      UPPER(TRIM(pm.mailing_state))
+    )) AS mailing_household_key
+  FROM mip.silver.property_owners AS po
+  JOIN mip.silver.property_master AS pm
+    ON pm.clip = po.clip
+  LEFT JOIN owner_link_households AS olh
+    ON olh.clip = po.clip
+  WHERE olh.clip IS NULL
+    AND po.owner_name_hash IS NOT NULL
+    AND pm.mailing_city IS NOT NULL
+    AND pm.mailing_state IS NOT NULL
+  GROUP BY po.clip
+),
+assigned AS (
+  SELECT
+    b.clip,
+    b.borrower_id,
+    b.opportunity_score,
+    b.marketing_eligible,
+    b.has_unresolved_owner,
+    CASE
+      WHEN olh.owner_link_household_key IS NOT NULL THEN CONCAT('owner_link:', olh.owner_link_household_key)
+      WHEN mh.mailing_household_key IS NOT NULL THEN mh.mailing_household_key
+      ELSE CONCAT('singleton:', b.borrower_id)
+    END AS household_key,
+    CASE
+      WHEN olh.owner_link_household_key IS NOT NULL THEN 'owner_link'
+      WHEN mh.mailing_household_key IS NOT NULL THEN 'mailing_address'
+      ELSE 'singleton'
+    END AS household_derivation_method,
+    CASE
+      WHEN olh.owner_link_household_key IS NOT NULL THEN ARRAY('mip.silver.property_owners', 'mip.gold.borrower_360')
+      WHEN mh.mailing_household_key IS NOT NULL THEN ARRAY('mip.silver.property_owners', 'mip.silver.property_master', 'mip.gold.borrower_360')
+      ELSE ARRAY('mip.gold.borrower_360')
+    END AS derivation_source_tables,
+    COALESCE(olh.owner_link_reachable_count, 0) AS owner_link_reachable_count
+  FROM mip.gold.borrower_360 AS b
+  LEFT JOIN owner_link_households AS olh
+    ON olh.clip = b.clip
+  LEFT JOIN mailing_households AS mh
+    ON mh.clip = b.clip
+),
+households AS (
+  SELECT
+    *,
+    CONCAT('HH-', SUBSTR(sha2(household_key, 256), 1, 16)) AS household_id,
+    sha2(household_key, 256) AS household_derivation_key_hash,
+    (marketing_eligible = TRUE AND COALESCE(has_unresolved_owner, FALSE) = FALSE) AS is_contact_eligible_for_household
+  FROM assigned
+),
+ranked AS (
+  SELECT
+    *,
+    CAST(COUNT(*) OVER (PARTITION BY household_id) AS INT) AS household_member_count,
+    CAST(COUNT_IF(is_contact_eligible_for_household) OVER (PARTITION BY household_id) AS INT) AS eligible_member_count,
+    ROW_NUMBER() OVER (
+      PARTITION BY household_id
+      ORDER BY
+        CASE WHEN is_contact_eligible_for_household THEN 0 ELSE 1 END,
+        opportunity_score DESC,
+        borrower_id ASC
+    ) AS household_rank,
+    FIRST_VALUE(borrower_id) OVER (
+      PARTITION BY household_id
+      ORDER BY
+        CASE WHEN is_contact_eligible_for_household THEN 0 ELSE 1 END,
+        opportunity_score DESC,
+        borrower_id ASC
+    ) AS ranked_primary_borrower_id
+  FROM households
+)
+SELECT
+  clip,
+  borrower_id,
+  household_id,
+  household_derivation_method,
+  household_derivation_key_hash,
+  derivation_source_tables,
+  household_member_count,
+  eligible_member_count,
+  CAST(household_rank AS INT) AS household_rank,
+  (household_rank = 1 AND is_contact_eligible_for_household) AS is_household_primary,
+  CASE
+    WHEN eligible_member_count > 0 THEN ranked_primary_borrower_id
+    ELSE NULL
+  END AS primary_borrower_id,
+  (is_contact_eligible_for_household AND household_rank > 1) AS suppressed_by_household_dedup,
+  owner_link_reachable_count,
+  (SELECT refresh_at FROM refresh_anchor) AS refreshed_at
+FROM ranked;
+
+COMMENT ON COLUMN mip.gold.household_rollup.clip IS 'Cotality CLIP below the API redaction boundary; joins to borrower_360.clip.';
+COMMENT ON COLUMN mip.gold.household_rollup.borrower_id IS 'Synthetic stable borrower id, B-[0-9A-Z]{13}. No PII.';
+COMMENT ON COLUMN mip.gold.household_rollup.household_id IS 'Deterministic public household id: HH- + first 16 hex chars of sha2(derivation key).';
+COMMENT ON COLUMN mip.gold.household_rollup.household_derivation_method IS 'owner_link | mailing_address | singleton.';
+COMMENT ON COLUMN mip.gold.household_rollup.household_derivation_key_hash IS 'Full sha2 over the non-PII derivation key. Raw Owner Links, CLIPs, mailing city/state, and owner hashes are not emitted.';
+COMMENT ON COLUMN mip.gold.household_rollup.derivation_source_tables IS 'UC source rows supporting the derivation: mip.silver.property_owners, mip.silver.property_master, and/or mip.gold.borrower_360.';
+COMMENT ON COLUMN mip.gold.household_rollup.household_member_count IS 'Count of borrower rows assigned to this household_id.';
+COMMENT ON COLUMN mip.gold.household_rollup.eligible_member_count IS 'Count of household members that are campaign-contact eligible: marketing_eligible=true and has_unresolved_owner=false.';
+COMMENT ON COLUMN mip.gold.household_rollup.household_rank IS 'Deterministic rank inside household: eligible borrowers first, then opportunity_score DESC, borrower_id ASC.';
+COMMENT ON COLUMN mip.gold.household_rollup.is_household_primary IS 'TRUE only for rank 1 when that borrower is contact-eligible.';
+COMMENT ON COLUMN mip.gold.household_rollup.primary_borrower_id IS 'Synthetic borrower id of the selected primary contact, or NULL if no member is contact-eligible.';
+COMMENT ON COLUMN mip.gold.household_rollup.suppressed_by_household_dedup IS 'TRUE when this eligible borrower would be suppressed by opt-in campaign household dedup.';
+COMMENT ON COLUMN mip.gold.household_rollup.owner_link_reachable_count IS 'Number of reachable Owner Links used by the owner_link derivation; 0 for non-owner-link methods.';
+COMMENT ON COLUMN mip.gold.household_rollup.refreshed_at IS 'Shared gold refresh timestamp from mip.ref.refresh_run_state.';

--- a/tests/unit/test_gold_ddl_contract.py
+++ b/tests/unit/test_gold_ddl_contract.py
@@ -35,6 +35,7 @@ GOLD_DDL_FILES: tuple[str, ...] = (
     "gold_borrower_360.sql",
     "gold_lead_scores.sql",
     "gold_evidence_events.sql",
+    "gold_household_rollup.sql",
     "gold_lead_population.sql",
     "gold_segment_population.sql",
     # slice13-accuracy-validation: geography rollups for the USChoroplethMap drill.
@@ -49,6 +50,7 @@ GOLD_TRANSFORMATION_FILES: tuple[str, ...] = (
     "gold_borrower_360.sql",
     "gold_lead_scores.sql",
     "gold_evidence_events.sql",
+    "gold_household_rollup.sql",
     "gold_lead_population.sql",
     "gold_segment_population.sql",
     "gold_county_rollup.sql",
@@ -67,6 +69,7 @@ GOLD_TABLE_PATHS: tuple[str, ...] = (
     "mip.gold.borrower_360",
     "mip.gold.lead_scores",
     "mip.gold.evidence_events",
+    "mip.gold.household_rollup",
     "mip.gold.lead_population",
     "mip.gold.segment_population",
     "mip.gold.borrower_dossier",
@@ -342,6 +345,7 @@ def test_borrower_360_transformation_enforces_zip5_or_null_boundary() -> None:
 _TIMESTAMP_SHARED_CTAS_FILES: tuple[str, ...] = (
     "gold_property_owner_bridge.sql",
     "gold_borrower_360.sql",
+    "gold_household_rollup.sql",
     "gold_lead_scores.sql",
     "gold_segment_population.sql",
     "gold_lockin_cohort.sql",

--- a/tests/unit/test_household_rollup.py
+++ b/tests/unit/test_household_rollup.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from backend.schemas.portfolio import HouseholdDedupSummary, PortfolioCreateRequest
+from backend.services.audit_store import AuditMetadataValueViolation, build_safe_audit_metadata
+from backend.services.repositories.databricks_repo import DatabricksPortfolioRepository
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _HouseholdStubClient:
+    def __init__(self) -> None:
+        self.sql: str | None = None
+        self.params: dict[str, Any] | None = None
+
+    def execute_one(self, sql: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.sql = sql
+        self.params = params
+        return {
+            "candidate_borrower_count": 12,
+            "selected_primary_count": 9,
+            "suppressed_co_owner_count": 3,
+            "household_count": 9,
+            "owner_link_household_count": 6,
+            "mailing_address_household_count": 2,
+            "singleton_household_count": 1,
+        }
+
+
+def test_household_dedup_defaults_to_borrower_unit() -> None:
+    payload = PortfolioCreateRequest(name="Q3 household test")
+
+    assert payload.household_dedup.enabled is False
+    assert payload.household_dedup.dedupe_unit == "borrower"
+    assert payload.household_dedup.primary_contact_strategy == "highest_opportunity_eligible"
+
+
+def test_household_dedup_enabled_normalizes_to_household_unit() -> None:
+    payload = PortfolioCreateRequest(
+        name="Q3 household test",
+        household_dedup={"enabled": True, "dedupe_unit": "borrower"},
+    )
+
+    assert payload.household_dedup.enabled is True
+    assert payload.household_dedup.dedupe_unit == "household"
+
+
+def test_household_summary_counts_are_bounded() -> None:
+    with pytest.raises(ValidationError):
+        HouseholdDedupSummary(enabled=True, suppressed_co_owner_count=-1)
+
+    with pytest.raises(ValidationError):
+        HouseholdDedupSummary(
+            enabled=True,
+            source_assets=["mip.silver.property_owners"],
+        )
+
+
+def test_household_audit_metadata_allows_bounded_counts_only() -> None:
+    metadata = build_safe_audit_metadata(
+        {
+            "source": "portfolio_builder",
+            "portfolio_criteria": {"marketing_eligibility": "Eligible only"},
+            "dedupe_unit": "household",
+            "household_dedup_enabled": True,
+            "household_primary_strategy": "highest_opportunity_eligible",
+            "household_candidate_count": 12,
+            "household_primary_count": 9,
+            "household_suppressed_count": 3,
+            "household_household_count": 9,
+            "household_owner_link_count": 6,
+            "household_mailing_address_count": 2,
+            "household_singleton_count": 1,
+            "source_assets": ["mip.gold.household_rollup", "mip.gold.borrower_360"],
+        },
+        action="portfolio.create",
+    )
+
+    assert metadata["dedupe_unit"] == "household"
+    assert metadata["household_suppressed_count"] == 3
+
+    with pytest.raises(AuditMetadataValueViolation):
+        build_safe_audit_metadata(
+            {
+                "source": "portfolio_builder",
+                "dedupe_unit": "neighborhood",
+                "household_dedup_enabled": True,
+            },
+            action="portfolio.create",
+        )
+
+    with pytest.raises(AuditMetadataValueViolation):
+        build_safe_audit_metadata(
+            {
+                "source": "portfolio_builder",
+                "dedupe_unit": "household",
+                "household_dedup_enabled": True,
+                "household_suppressed_count": -1,
+            },
+            action="portfolio.create",
+        )
+
+
+def test_household_summary_query_forces_primary_contact_eligibility() -> None:
+    client = _HouseholdStubClient()
+    repo = DatabricksPortfolioRepository(client)  # type: ignore[arg-type]
+    payload = PortfolioCreateRequest(
+        name="Q3 household test",
+        household_dedup={"enabled": True},
+    )
+
+    summary = repo._load_household_dedup_summary(payload)
+
+    assert summary.suppressed_co_owner_count == 3
+    assert client.sql is not None
+    assert "mip.gold.household_rollup" in client.sql
+    assert "ROW_NUMBER() OVER" in client.sql
+    assert "b.marketing_eligible = TRUE" in client.sql
+    assert "COALESCE(b.has_unresolved_owner, FALSE) = FALSE" in client.sql
+    assert "campaign_household_rank > 1" in client.sql
+    assert client.params == {}
+
+
+def test_household_rollup_sql_documents_deterministic_non_pii_derivation() -> None:
+    ddl = (REPO_ROOT / "sql" / "ddl" / "gold_household_rollup.sql").read_text(
+        encoding="utf-8"
+    )
+    transform = (
+        REPO_ROOT / "sql" / "transformations" / "gold_household_rollup.sql"
+    ).read_text(encoding="utf-8")
+
+    assert "mip.silver.property_owners" in ddl
+    assert "mip.silver.property_master" in ddl
+    assert "owner_link_reach AS" in transform
+    assert "mailing_households AS" in transform
+    assert "mailing_street_address" not in transform
+    assert "owner_full_name" not in transform
+    assert "CONCAT('HH-'" in transform
+    assert "marketing_eligible = TRUE" in transform
+    assert "has_unresolved_owner" in transform
+
+
+def test_household_rollup_is_deployable_and_lakebase_persisted() -> None:
+    bundle = (REPO_ROOT / "databricks.yml").read_text(encoding="utf-8")
+    lakebase = (REPO_ROOT / "lakebase" / "schema.sql").read_text(encoding="utf-8")
+
+    assert "task_key: ctas_household_rollup" in bundle
+    assert "sql/_rendered/transformations/gold_household_rollup.sql" in bundle
+    assert "household_dedup JSONB" in lakebase
+    assert "household_summary JSONB" in lakebase
+    assert "2026_07_09_campaign_household_dedup" in lakebase


### PR DESCRIPTION
## Summary
- add deterministic gold household rollup from shared owner links plus conservative mailing heuristics
- persist default-off campaign household dedup config, evidence-cited summary counts, and audit metadata
- surface the campaign-time toggle and saved-campaign household suppression proof in the portfolio builder

## Validation
- env -u PYTHONPATH .venv/bin/python -m pytest -q -k "household"
- env -u PYTHONPATH .venv/bin/python -m pytest -q
- env -u PYTHONPATH .venv/bin/python -m ruff check backend tests tools
- npm --prefix frontend run lint
- npm --prefix frontend run build
- npm --prefix frontend run test
- env -u PYTHONPATH .venv/bin/python tools/render_sql.py
- databricks bundle validate -t dev