### PR TITLE
S3: daily headline-KPI snapshots + throttled visit tracking + last-login delta service

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -63,6 +63,7 @@ from backend.services.observability import (
     set_correlation_id,
 )
 from backend.services.static_assets import select_asset_variant
+from backend.services.visit_tracking import VisitTrackingMiddleware
 from backend.version import api_version
 
 log = logging.getLogger("mip-runtime")
@@ -451,6 +452,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 _backpressure_controller = BackpressureController()
 
 app.add_middleware(BackpressureMiddleware, controller=_backpressure_controller)
+# S3: throttled authenticated-visit ledger (one mip_app.user_visits row per
+# actor per window; the Lakebase write happens off the request path).
+# Added before CorrelationIdMiddleware so it sits INSIDE it in the stack
+# (last add_middleware call = outermost) and its structured log lines carry
+# the request's correlation id.
+app.add_middleware(VisitTrackingMiddleware)
 app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 # compresslevel=6 (not the library default 9): dynamic JSON responses sit on

--- a/backend/schemas/kpi_deltas.py
+++ b/backend/schemas/kpi_deltas.py
@@ -1,0 +1,75 @@
+"""Typed contracts for S3 KPI snapshots and last-login deltas.
+
+The measure vocabulary is EXACTLY the S1 headline set defined by
+``mip.semantics.portfolio_headline_metric_view`` (see the header of
+``sql/metric_views/portfolio_headline_metric_view.sql``): marketable
+population, refi economics screen (in-the-money), high opportunity
+(canonical ``fn_high_opportunity`` threshold), offers available, offers
+recommended, and average opportunity score. ``mip_app.kpi_snapshots``
+persists the same names, so snapshot rows deserialize into these models
+without a mapping layer.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+# Ordered list of the counted headline measures (everything except the
+# average). Shared by the delta service and the parity contract test.
+HEADLINE_COUNT_MEASURES: tuple[str, ...] = (
+    "marketable_population",
+    "refi_economics_screen",
+    "high_opportunity",
+    "offers_available",
+    "offers_recommended",
+)
+
+
+class HeadlineKpis(BaseModel):
+    """One reading of the S1 headline aggregates (live or snapshotted)."""
+
+    marketable_population: int = Field(ge=0)
+    refi_economics_screen: int = Field(ge=0)
+    high_opportunity: int = Field(ge=0)
+    offers_available: int = Field(ge=0)
+    offers_recommended: int = Field(ge=0)
+    avg_opportunity_score: float | None = Field(default=None, ge=0, le=100)
+
+
+class KpiSnapshot(HeadlineKpis):
+    """A persisted ``mip_app.kpi_snapshots`` row."""
+
+    snapshot_date: datetime | None = None
+    snapshot_at: datetime
+    source_view: str = "portfolio_headline_metric_view"
+
+
+class KpiDeltas(BaseModel):
+    """Signed current-minus-baseline differences per headline measure."""
+
+    marketable_population: int
+    refi_economics_screen: int
+    high_opportunity: int
+    offers_available: int
+    offers_recommended: int
+    avg_opportunity_score: float | None = None
+
+
+class KpiDeltaResult(BaseModel):
+    """The S4 contract: current metrics vs the snapshot nearest the
+    actor's previous visit.
+
+    ``baseline`` / ``deltas`` are ``None`` when no anchor exists yet --
+    either the actor has no recorded previous visit (first login) or the
+    snapshot table is empty (pre-backfill install). ``current`` is always
+    populated from the live metric view so S4 can render the headline
+    numbers even without a comparison.
+    """
+
+    actor_email: str
+    previous_visit_at: datetime | None = None
+    baseline_snapshot_at: datetime | None = None
+    current: HeadlineKpis
+    baseline: HeadlineKpis | None = None
+    deltas: KpiDeltas | None = None

--- a/backend/services/kpi_deltas.py
+++ b/backend/services/kpi_deltas.py
@@ -1,0 +1,254 @@
+"""Last-login KPI delta primitives over ``mip_app.kpi_snapshots``.
+
+S3: the small typed service S4's personalized home summary consumes.
+Given an actor, it anchors on the actor's PREVIOUS visit (from the
+throttled ``mip_app.user_visits`` ledger), finds the persisted headline
+snapshot NEAREST that timestamp, reads the now-ish headline metrics live
+from ``mip.semantics.portfolio_headline_metric_view`` (real UC read,
+short-TTL cached like the portfolio preview), and returns the signed
+per-measure deltas.
+
+Edge contract (pinned by tests/unit/test_kpi_deltas.py):
+
+* no previous visit  -> ``previous_visit_at``/``baseline``/``deltas`` are
+  ``None``; ``current`` still carries the live numbers (first login).
+* zero snapshots     -> ``baseline``/``deltas`` are ``None`` even when a
+  previous visit exists (pre-backfill install; the deploy script's
+  backfill step makes this state transient).
+* one snapshot       -> it is the nearest snapshot regardless of which
+  side of the visit it falls on.
+* two or more        -> the closer of (latest at-or-before, earliest
+  after); exact ties resolve to the at-or-before row.
+
+The "previous" visit is the most recent ``user_visits`` row older than
+``now - visit dedupe window``: the middleware writes at most one row per
+actor per window, so anything inside the window is the CURRENT session's
+row, not the last login.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from threading import Lock
+from typing import Any
+
+from backend.schemas.kpi_deltas import (
+    HEADLINE_COUNT_MEASURES,
+    HeadlineKpis,
+    KpiDeltaResult,
+    KpiDeltas,
+    KpiSnapshot,
+)
+from backend.services.databricks_sql_helpers import qualify
+from backend.services.resilience import TTLCache
+from backend.services.visit_tracking import DEFAULT_VISIT_DEDUPE_WINDOW_S
+
+log = logging.getLogger(__name__)
+
+# Live headline aggregates. Aliases match mip_app.kpi_snapshots columns and
+# jobs/kpi_snapshot.py 1:1 (parity pinned by
+# tests/unit/test_kpi_snapshot_contract.py).
+_CURRENT_METRICS_SQL_TEMPLATE = (
+    "SELECT "
+    "  COUNT(*)                                                    AS marketable_population, "
+    "  COALESCE(SUM(CASE WHEN in_the_money THEN 1 ELSE 0 END), 0)  AS refi_economics_screen, "
+    "  COALESCE(SUM(CASE WHEN is_high_opportunity THEN 1 ELSE 0 END), 0) AS high_opportunity, "
+    "  COALESCE(SUM(CASE WHEN offer_available THEN 1 ELSE 0 END), 0)     AS offers_available, "
+    "  COALESCE(SUM(CASE WHEN offer_recommended THEN 1 ELSE 0 END), 0)   AS offers_recommended, "
+    "  AVG(opportunity_score)                                      AS avg_opportunity_score "
+    "FROM {metric_view}"
+)
+
+_SNAPSHOT_COLUMNS = (
+    "snapshot_date, snapshot_at, source_view, "
+    "marketable_population, refi_economics_screen, high_opportunity, "
+    "offers_available, offers_recommended, avg_opportunity_score"
+)
+
+_PREVIOUS_VISIT_SQL = """
+SELECT visited_at
+FROM mip_app.user_visits
+WHERE actor_email = %(actor_email)s
+  AND visited_at < %(before)s
+ORDER BY visited_at DESC
+LIMIT 1
+"""
+
+# Both sides of the nearest-snapshot lookup ride the snapshot_at index as
+# ORDER BY ... LIMIT 1 scans.
+_SNAPSHOT_AT_OR_BEFORE_SQL = f"""
+SELECT {_SNAPSHOT_COLUMNS}
+FROM mip_app.kpi_snapshots
+WHERE snapshot_at <= %(ts)s
+ORDER BY snapshot_at DESC
+LIMIT 1
+"""
+
+_SNAPSHOT_AFTER_SQL = f"""
+SELECT {_SNAPSHOT_COLUMNS}
+FROM mip_app.kpi_snapshots
+WHERE snapshot_at > %(ts)s
+ORDER BY snapshot_at ASC
+LIMIT 1
+"""
+
+_CURRENT_METRICS_CACHE_KEY = "kpi_deltas.current_metrics"
+
+
+def _snapshot_from_row(row: dict[str, Any]) -> KpiSnapshot:
+    return KpiSnapshot.model_validate(row)
+
+
+def _headline_from_row(row: dict[str, Any]) -> HeadlineKpis:
+    values: dict[str, Any] = {
+        measure: int(row.get(measure) or 0) for measure in HEADLINE_COUNT_MEASURES
+    }
+    avg_score = row.get("avg_opportunity_score")
+    values["avg_opportunity_score"] = float(avg_score) if avg_score is not None else None
+    return HeadlineKpis.model_validate(values)
+
+
+def compute_deltas(current: HeadlineKpis, baseline: HeadlineKpis) -> KpiDeltas:
+    """Signed current-minus-baseline differences (pure; golden-fixture pinned)."""
+    counts = {
+        measure: getattr(current, measure) - getattr(baseline, measure)
+        for measure in HEADLINE_COUNT_MEASURES
+    }
+    avg_delta: float | None = None
+    if current.avg_opportunity_score is not None and baseline.avg_opportunity_score is not None:
+        avg_delta = round(current.avg_opportunity_score - baseline.avg_opportunity_score, 2)
+    return KpiDeltas(avg_opportunity_score=avg_delta, **counts)
+
+
+class KpiDeltaService:
+    """Typed read-side over ``user_visits`` + ``kpi_snapshots`` + the live
+    headline metric view. All Lakebase reads go through the injected
+    client (resilient singleton in production, fakes in unit tests)."""
+
+    def __init__(
+        self,
+        lakebase_client: Any | None = None,
+        sql_client: Any | None = None,
+        *,
+        cache: TTLCache | None = None,
+        cache_ttl_s: float = 30.0,
+        current_session_grace_s: float = DEFAULT_VISIT_DEDUPE_WINDOW_S,
+        now: Callable[[], datetime] = lambda: datetime.now(UTC),
+    ) -> None:
+        self._lakebase_client = lakebase_client
+        self._sql_client = sql_client
+        self._cache = cache if cache is not None else TTLCache()
+        self._cache_ttl_s = cache_ttl_s
+        self._current_session_grace_s = current_session_grace_s
+        self._now = now
+
+    # -- dependency accessors (lazy so unit tests never touch factories) --
+
+    def _lakebase(self) -> Any:
+        if self._lakebase_client is None:
+            from backend.services.lakebase import get_lakebase_client
+
+            self._lakebase_client = get_lakebase_client()
+        return self._lakebase_client
+
+    def _sql(self) -> Any:
+        if self._sql_client is None:
+            from backend.services.databricks_sql import get_sql_client
+
+            self._sql_client = get_sql_client()
+        return self._sql_client
+
+    # -- primitives ------------------------------------------------------
+
+    def current_metrics(self) -> HeadlineKpis:
+        """Now-ish headline aggregates from the live S1 metric view."""
+
+        def _load() -> HeadlineKpis:
+            statement = _CURRENT_METRICS_SQL_TEMPLATE.format(
+                metric_view=qualify("semantics", "portfolio_headline_metric_view")
+            )
+            row = self._sql().execute_one(statement) or {}
+            return _headline_from_row(row)
+
+        return self._cache.get_or_set(
+            _CURRENT_METRICS_CACHE_KEY, _load, ttl_s=self._cache_ttl_s
+        )
+
+    def previous_visit(self, actor_email: str, *, before: datetime) -> datetime | None:
+        """Most recent recorded visit strictly earlier than ``before``."""
+        row = self._lakebase().fetchone(
+            _PREVIOUS_VISIT_SQL,
+            {"actor_email": actor_email, "before": before},
+        )
+        return row["visited_at"] if row else None
+
+    def nearest_snapshot(self, ts: datetime) -> KpiSnapshot | None:
+        """Snapshot with the smallest |snapshot_at - ts|; ties prefer the
+        at-or-before row. Returns None only when the table is empty."""
+        client = self._lakebase()
+        before_row = client.fetchone(_SNAPSHOT_AT_OR_BEFORE_SQL, {"ts": ts})
+        after_row = client.fetchone(_SNAPSHOT_AFTER_SQL, {"ts": ts})
+        if before_row is None and after_row is None:
+            return None
+        if before_row is None:
+            assert after_row is not None
+            return _snapshot_from_row(after_row)
+        if after_row is None:
+            return _snapshot_from_row(before_row)
+        before_gap = abs((ts - before_row["snapshot_at"]).total_seconds())
+        after_gap = abs((after_row["snapshot_at"] - ts).total_seconds())
+        return _snapshot_from_row(before_row if before_gap <= after_gap else after_row)
+
+    # -- the S4 surface ----------------------------------------------------
+
+    def deltas_for_actor(self, actor_email: str) -> KpiDeltaResult:
+        """Current metrics vs the snapshot nearest the actor's previous visit."""
+        now = self._now()
+        before = now - timedelta(seconds=self._current_session_grace_s)
+        previous_visit_at = self.previous_visit(actor_email, before=before)
+        current = self.current_metrics()
+
+        baseline_snapshot: KpiSnapshot | None = None
+        if previous_visit_at is not None:
+            baseline_snapshot = self.nearest_snapshot(previous_visit_at)
+
+        if baseline_snapshot is None:
+            return KpiDeltaResult(
+                actor_email=actor_email,
+                previous_visit_at=previous_visit_at,
+                current=current,
+            )
+        baseline = HeadlineKpis.model_validate(
+            baseline_snapshot.model_dump(
+                include=set(HEADLINE_COUNT_MEASURES) | {"avg_opportunity_score"}
+            )
+        )
+        return KpiDeltaResult(
+            actor_email=actor_email,
+            previous_visit_at=previous_visit_at,
+            baseline_snapshot_at=baseline_snapshot.snapshot_at,
+            current=current,
+            baseline=baseline,
+            deltas=compute_deltas(current, baseline),
+        )
+
+
+_SERVICE: KpiDeltaService | None = None
+_SERVICE_LOCK = Lock()
+
+
+def get_kpi_delta_service() -> KpiDeltaService:
+    """Process-singleton accessor (mirrors the other service factories)."""
+    global _SERVICE
+    if _SERVICE is None:
+        with _SERVICE_LOCK:
+            if _SERVICE is None:
+                _SERVICE = KpiDeltaService()
+    return _SERVICE
+
+
+def _reset_service_for_tests() -> None:
+    global _SERVICE
+    with _SERVICE_LOCK:
+        _SERVICE = None

--- a/backend/services/visit_tracking.py
+++ b/backend/services/visit_tracking.py
@@ -1,0 +1,249 @@
+"""Throttled authenticated-visit tracking for ``mip_app.user_visits``.
+
+S3: the personalized home summary (S4) needs "when did this actor last
+open the app" to anchor its "since your last login" KPI deltas. This
+module records that signal with deliberately low overhead:
+
+* **Identity**: only the existing actor identity model -- the
+  ``X-Forwarded-Email`` / ``X-Forwarded-User`` headers the Databricks
+  Apps edge injects. Requests without a forwarded identity (platform
+  health probes, local curl, untrusted-edge deploys) are skipped
+  entirely; we never attribute a visit to the ``default_actor``
+  fallback the audit ledger uses.
+* **Throttle**: a browsing session must not write a row per request.
+  An in-process per-actor window (default 15 minutes) gates the write,
+  and the INSERT itself re-checks the window in SQL (``WHERE NOT
+  EXISTS`` within the window) so multiple app replicas cannot stack
+  rows either.
+* **Off the request path**: the middleware claims the throttle slot
+  synchronously (a dict lookup) and pushes the actual Lakebase INSERT
+  to a background thread. A Lakebase outage therefore costs requests
+  nothing -- the write failure is logged, the throttle slot is
+  released, and the next request past the window retries.
+
+No PII beyond the actor email, no routes, no IPs, no user agents.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections.abc import Callable
+from threading import Lock, Thread
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request as StarletteRequest
+from starlette.responses import Response as StarletteResponse
+from starlette.types import ASGIApp
+
+from backend.config.settings import _running_under_pytest, settings
+from backend.services.observability import emit
+
+log = logging.getLogger(__name__)
+
+# One row per actor per window. A module constant (not a Settings field)
+# because no deployment has needed to tune it yet; tests inject their own
+# window through the constructor.
+DEFAULT_VISIT_DEDUPE_WINDOW_S: float = 900.0
+
+# Bound the in-process throttle map. Workspace user counts are tiny next to
+# this; the sweep exists so a header-fuzzing probe can't grow the dict forever.
+_MAX_TRACKED_ACTORS = 10_000
+
+# SQL-side dedupe mirrors the in-process window so multiple app processes
+# (or a process restart mid-window) still can't write more than one row per
+# actor per window. Named-parameter binding only, per the Lakebase client
+# contract.
+_INSERT_VISIT_SQL = """
+INSERT INTO mip_app.user_visits (actor_email, visited_at)
+SELECT %(actor_email)s, now()
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM mip_app.user_visits
+    WHERE actor_email = %(actor_email)s
+      AND visited_at > now() - make_interval(secs => %(window_s)s)
+)
+"""
+
+
+def forwarded_actor(request: StarletteRequest) -> str | None:
+    """Return the edge-forwarded identity, or ``None`` when unauthenticated.
+
+    Unlike ``audit_store.resolve_actor`` this NEVER falls back to
+    ``settings.default_actor`` -- a visit row attributed to a placeholder
+    identity would poison the "since your last login" anchor for every
+    unauthenticated probe. When ``trust_forwarded_headers`` is off the
+    headers are attacker-writable, so visits are not recorded at all.
+    """
+    if not settings.trust_forwarded_headers:
+        return None
+    email = request.headers.get("X-Forwarded-Email")
+    if email:
+        return email
+    user = request.headers.get("X-Forwarded-User")
+    if user:
+        return user
+    return None
+
+
+class VisitTracker:
+    """Per-actor throttled writer for ``mip_app.user_visits``.
+
+    ``client_factory`` defaults to the process Lakebase client; when the
+    default is in use, writes are additionally gated on the same
+    connection hints ``backend.main._warm_lakebase`` checks, so local
+    dev / pytest processes without Lakebase configuration never attempt
+    a connection. Tests inject a fake client factory, which bypasses the
+    hint gate.
+    """
+
+    def __init__(
+        self,
+        client_factory: Callable[[], Any] | None = None,
+        *,
+        window_s: float = DEFAULT_VISIT_DEDUPE_WINDOW_S,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if window_s <= 0:
+            raise ValueError("visit dedupe window must be > 0 seconds")
+        self._explicit_factory = client_factory
+        self._window_s = window_s
+        self._now = now
+        self._lock = Lock()
+        self._last_claim: dict[str, float] = {}
+
+    @property
+    def window_s(self) -> float:
+        return self._window_s
+
+    def _connection_hints_present(self) -> bool:
+        host = settings.lakebase_host or os.environ.get("PGHOST")
+        user = settings.lakebase_user or os.environ.get("PGUSER")
+        return bool(host and user)
+
+    def maybe_claim(self, actor: str | None) -> bool:
+        """Claim the actor's throttle slot; True when a write should happen.
+
+        Synchronous and cheap (dict + lock) -- safe on the request path.
+        Unauthenticated callers (``actor`` falsy) never claim. When the
+        default Lakebase client would be used but no connection hints are
+        present, the claim is refused so no background write is spawned.
+        """
+        if not actor:
+            return False
+        # Default-factory path only: pytest processes must never open a
+        # background Postgres connection (the conftest Lakebase override is a
+        # FastAPI dependency seam, which this service-level call bypasses),
+        # and processes without connection hints (local dev without Lakebase)
+        # have nothing to write to. Tests exercise the tracker by injecting
+        # an explicit factory.
+        if self._explicit_factory is None and (
+            _running_under_pytest() or not self._connection_hints_present()
+        ):
+            return False
+        now = self._now()
+        with self._lock:
+            last = self._last_claim.get(actor)
+            if last is not None and (now - last) < self._window_s:
+                return False
+            if len(self._last_claim) >= _MAX_TRACKED_ACTORS:
+                # Drop expired claims; if everything is live we still insert
+                # (one actor over the cap beats losing the visit signal).
+                expired = [
+                    key
+                    for key, claimed in self._last_claim.items()
+                    if (now - claimed) >= self._window_s
+                ]
+                for key in expired:
+                    del self._last_claim[key]
+            self._last_claim[actor] = now
+            return True
+
+    def _release_claim(self, actor: str) -> None:
+        with self._lock:
+            self._last_claim.pop(actor, None)
+
+    def record_visit(self, actor: str) -> None:
+        """Write the visit row. Never raises -- visit tracking must not
+        break a request; failures release the throttle slot so the next
+        request past the window retries."""
+        try:
+            if self._explicit_factory is not None:
+                client = self._explicit_factory()
+            else:
+                from backend.services.lakebase import get_lakebase_client
+
+                client = get_lakebase_client()
+            client.execute(
+                _INSERT_VISIT_SQL,
+                {"actor_email": actor, "window_s": self._window_s},
+            )
+        except Exception as exc:  # noqa: BLE001 -- fire-and-forget contract
+            self._release_claim(actor)
+            emit(
+                log,
+                "visit_record_failed",
+                level=logging.WARNING,
+                dependency="lakebase",
+                outcome="error",
+                exc_type=type(exc).__name__,
+                exc_msg=str(exc)[:500],
+            )
+            return
+        emit(log, "visit_recorded", dependency="lakebase", outcome="ok")
+
+
+_TRACKER: VisitTracker | None = None
+_TRACKER_LOCK = Lock()
+
+
+def get_visit_tracker() -> VisitTracker:
+    """Process-singleton accessor (mirrors ``get_lakebase_client``)."""
+    global _TRACKER
+    if _TRACKER is None:
+        with _TRACKER_LOCK:
+            if _TRACKER is None:
+                _TRACKER = VisitTracker()
+    return _TRACKER
+
+
+def _reset_tracker_for_tests() -> None:
+    global _TRACKER
+    with _TRACKER_LOCK:
+        _TRACKER = None
+
+
+class VisitTrackingMiddleware(BaseHTTPMiddleware):
+    """Record one ``mip_app.user_visits`` row per actor per window.
+
+    Only ``/api`` traffic counts as a visit (static asset fetches carry no
+    intent signal). The throttle claim is the only synchronous work; the
+    Lakebase INSERT runs on a short-lived daemon thread (at most one per
+    actor per window) so it survives event-loop teardown and never delays
+    the response.
+    """
+
+    def __init__(self, app: ASGIApp, tracker: VisitTracker | None = None) -> None:
+        super().__init__(app)
+        self._tracker = tracker
+
+    def _resolve_tracker(self) -> VisitTracker:
+        return self._tracker if self._tracker is not None else get_visit_tracker()
+
+    async def dispatch(
+        self, request: StarletteRequest, call_next: Any
+    ) -> StarletteResponse:
+        response = await call_next(request)
+        path = request.url.path
+        if path == "/api" or path.startswith("/api/"):
+            tracker = self._resolve_tracker()
+            actor = forwarded_actor(request)
+            if actor and tracker.maybe_claim(actor):
+                Thread(
+                    target=tracker.record_visit,
+                    args=(actor,),
+                    name="mip-visit-write",
+                    daemon=True,
+                ).start()
+        return response

--- a/databricks.yml
+++ b/databricks.yml
@@ -853,6 +853,52 @@ resources:
             file:
               path: sql/_rendered/transformations/gold_funnel_snapshot_daily.sql
 
+    # S3: daily headline-KPI snapshot. Aggregates the S1 headline measures
+    # over <catalog>.semantics.portfolio_headline_metric_view (real UC read;
+    # the view is landed by mip_refresh_scores task refresh_semantics_views)
+    # and upserts ONE row per day into Lakebase mip_app.kpi_snapshots via
+    # ON CONFLICT (snapshot_date) DO UPDATE -- re-runs refresh the day's row,
+    # never duplicate it. S4 reads this table for "since your last login"
+    # deltas via backend/services/kpi_deltas.py.
+    #
+    # Daily 05:30 America/Chicago cron (after the 04:00 lifecycle-sync slot
+    # when an operator enables both). Ships PAUSED like every scheduled job
+    # in this bundle (cost-control posture ratified on
+    # mip_sync_lifecycle_state / mip_fred_rates_ingest above); freshness on
+    # the dev cadence comes from ./scripts/deploy.sh, which runs this job
+    # after every gold refresh -- that run is also the first-install
+    # backfill, so kpi_snapshots is never empty after a zero-click deploy.
+    mip_kpi_snapshot:
+      name: mip_kpi_snapshot
+      tags:
+        solution: mortgage-intelligence-platform
+        module: module0
+        owner: entrada
+        slice: s3-kpi-snapshots
+      max_concurrent_runs: 1
+      schedule:
+        quartz_cron_expression: "0 30 5 ? * * *"
+        timezone_id: America/Chicago
+        pause_status: PAUSED
+      environments:
+        - environment_key: py_default
+          spec:
+            # Serverless Python env version 5 -- see comment on the
+            # mip_sync_lifecycle_state job for the upgrade rationale.
+            environment_version: "5"
+            dependencies:
+              - psycopg[binary]==3.2.10
+              - databricks-sdk>=0.30.0
+      tasks:
+        - task_key: snapshot_headline_kpis
+          description: "Aggregate semantics.portfolio_headline_metric_view and upsert today's row into mip_app.kpi_snapshots."
+          environment_key: py_default
+          spark_python_task:
+            python_file: jobs/kpi_snapshot.py
+            parameters: ["--catalog=${var.uc_catalog}"]
+          max_retries: 2
+          retry_on_timeout: true
+
     # Draft-only scheduled Mortgage Growth Agent monitor runner. The job calls
     # the deployed Databricks App through its OAuth proxy and hits the
     # admin-gated /api/v1/growth-agent/monitors/run-due-all endpoint. It replays

--- a/jobs/kpi_snapshot.py
+++ b/jobs/kpi_snapshot.py
@@ -1,0 +1,301 @@
+"""Snapshot the S1 headline KPIs into Lakebase ``mip_app.kpi_snapshots``.
+
+Runs as a Databricks Jobs Spark-Python task (``mip_kpi_snapshot`` in
+``databricks.yml``). Aggregates the S1 headline measures over
+``<catalog>.semantics.portfolio_headline_metric_view`` -- the named
+semantic home for every demoed headline KPI -- and upserts ONE row per
+day into ``mip_app.kpi_snapshots`` so the app can answer "what did the
+headline numbers look like near a past timestamp" (S4's "since your
+last login" deltas) without a warehouse time-travel query.
+
+Idempotency contract:
+    The write is ``INSERT ... ON CONFLICT (snapshot_date) DO UPDATE``.
+    Re-running on the same day (scheduled run + deploy backfill, or a
+    retry after a network flap) refreshes the day's row; it never
+    duplicates. The deploy script (``./scripts/deploy.sh -t dev``) runs
+    this job once after the gold refresh, which doubles as the
+    first-install backfill -- a fresh deploy always leaves at least one
+    snapshot row behind.
+
+Measure parity:
+    The aggregate SELECT below must stay in lockstep with the headline
+    measures documented in sql/metric_views/portfolio_headline_metric_
+    view.sql and consumed by backend/services/kpi_deltas.py
+    (tests/unit/test_kpi_snapshot_contract.py pins the parity).
+
+Auth model (identical to jobs/lakebase_migrate.py):
+    On Databricks the task runs under the workspace identity. We fetch a
+    short-lived Postgres credential via ``POST /api/2.0/database/
+    credentials``. ``LAKEBASE_*`` env-var overrides are honored for
+    local development.
+
+Exit codes:
+    0 -- snapshot upserted.
+    2 -- psycopg / Postgres error (run mip_lakebase_migrate first if the
+         kpi_snapshots table is missing).
+    3 -- SDK / auth error resolving connection parameters.
+    4 -- Spark session not available (not running on Databricks).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from typing import Any, cast
+
+_UC_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# The S1 headline aggregates. Column aliases match the mip_app.kpi_snapshots
+# columns 1:1 so the upsert below is a straight dict pass-through.
+_HEADLINE_AGGREGATE_SQL = """
+SELECT
+  COUNT(*)                                             AS marketable_population,
+  COALESCE(SUM(CASE WHEN in_the_money THEN 1 ELSE 0 END), 0)
+                                                       AS refi_economics_screen,
+  COALESCE(SUM(CASE WHEN is_high_opportunity THEN 1 ELSE 0 END), 0)
+                                                       AS high_opportunity,
+  COALESCE(SUM(CASE WHEN offer_available THEN 1 ELSE 0 END), 0)
+                                                       AS offers_available,
+  COALESCE(SUM(CASE WHEN offer_recommended THEN 1 ELSE 0 END), 0)
+                                                       AS offers_recommended,
+  AVG(opportunity_score)                               AS avg_opportunity_score
+FROM {metric_view}
+"""
+
+# Per-day upsert: snapshot_date/snapshot_at come from the Lakebase clock so
+# a single authority orders visits vs snapshots. ON CONFLICT keys on the
+# idx_kpi_snapshots_snapshot_date unique index declared in lakebase/schema.sql.
+_UPSERT_SQL = """
+INSERT INTO mip_app.kpi_snapshots (
+    snapshot_date,
+    snapshot_at,
+    source_view,
+    marketable_population,
+    refi_economics_screen,
+    high_opportunity,
+    offers_available,
+    offers_recommended,
+    avg_opportunity_score
+) VALUES (
+    (now() AT TIME ZONE 'utc')::date,
+    now(),
+    'portfolio_headline_metric_view',
+    %(marketable_population)s,
+    %(refi_economics_screen)s,
+    %(high_opportunity)s,
+    %(offers_available)s,
+    %(offers_recommended)s,
+    %(avg_opportunity_score)s
+)
+ON CONFLICT (snapshot_date) DO UPDATE SET
+    snapshot_at           = EXCLUDED.snapshot_at,
+    source_view           = EXCLUDED.source_view,
+    marketable_population = EXCLUDED.marketable_population,
+    refi_economics_screen = EXCLUDED.refi_economics_screen,
+    high_opportunity      = EXCLUDED.high_opportunity,
+    offers_available      = EXCLUDED.offers_available,
+    offers_recommended    = EXCLUDED.offers_recommended,
+    avg_opportunity_score = EXCLUDED.avg_opportunity_score
+RETURNING snapshot_id, snapshot_date, snapshot_at
+"""
+
+
+def _catalog_default() -> str:
+    return (os.environ.get("MIP_DEFAULT_CATALOG") or "mip").strip() or "mip"
+
+
+def _quote_uc_identifier(value: str, *, field: str) -> str:
+    """Return a backtick-quoted Unity Catalog identifier, failing closed."""
+    normalized = value.strip()
+    if not _UC_IDENTIFIER_RE.fullmatch(normalized):
+        print(
+            f"[kpi-snapshot] invalid {field} identifier {value!r}; "
+            "expected letters, digits, and underscores.",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+    return f"`{normalized}`"
+
+
+def _resolve_connection() -> dict:
+    """Return psycopg.connect kwargs. Mirrors jobs/lakebase_migrate.py."""
+    instance_name = os.environ.get("LAKEBASE_INSTANCE_NAME", "mip-app-state")
+    host = os.environ.get("LAKEBASE_HOST")
+    user = os.environ.get("LAKEBASE_USER")
+    password = os.environ.get("LAKEBASE_PASSWORD")
+
+    if host and user and password:
+        return {
+            "host": host,
+            "port": int(os.environ.get("LAKEBASE_PORT", "5432")),
+            "dbname": os.environ.get("LAKEBASE_DATABASE", "mip_app_state"),
+            "user": user,
+            "password": password,
+            "sslmode": os.environ.get("LAKEBASE_SSLMODE", "require"),
+        }
+
+    try:
+        from databricks.sdk import WorkspaceClient
+    except ImportError:
+        print(
+            "[kpi-snapshot] databricks-sdk is not installed; install it or "
+            "set LAKEBASE_* env vars explicitly.",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+
+    try:
+        w = WorkspaceClient()
+        me = w.current_user.me()
+        identity = me.user_name or me.display_name
+        if not identity:
+            print(
+                "[kpi-snapshot] could not resolve workspace identity.",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+
+        inst = cast(
+            dict[str, Any],
+            w.api_client.do("GET", f"/api/2.0/database/instances/{instance_name}"),
+        )
+        resolved_host = host or inst.get("read_write_dns")
+        if not resolved_host:
+            print(
+                f"[kpi-snapshot] instance {instance_name!r} has no "
+                f"read_write_dns; check provisioning state.",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+
+        cred = cast(
+            dict[str, Any],
+            w.api_client.do(
+                "POST",
+                "/api/2.0/database/credentials",
+                body={
+                    "request_id": (
+                        f"mip-kpi-snapshot-"
+                        f"{os.environ.get('DATABRICKS_JOB_RUN_ID','local')}"
+                    ),
+                    "instance_names": [instance_name],
+                },
+            ),
+        )
+        cred_token = cred.get("token")
+        if not cred_token:
+            print(
+                f"[kpi-snapshot] credential response missing token: {cred}",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 -- operator-facing
+        print(f"[kpi-snapshot] SDK auth/resolution failed: {exc}", file=sys.stderr)
+        sys.exit(3)
+
+    return {
+        "host": resolved_host,
+        "port": int(os.environ.get("LAKEBASE_PORT", "5432")),
+        "dbname": os.environ.get("LAKEBASE_DATABASE", "mip_app_state"),
+        "user": user or identity,
+        "password": password or cred_token,
+        "sslmode": os.environ.get("LAKEBASE_SSLMODE", "require"),
+    }
+
+
+def _get_spark() -> Any:
+    """Return the active SparkSession. Exits 4 when unavailable."""
+    try:
+        from pyspark.sql import SparkSession
+    except ImportError:
+        print("[kpi-snapshot] pyspark unavailable; must run on Databricks.", file=sys.stderr)
+        sys.exit(4)
+    spark = SparkSession.getActiveSession() or SparkSession.builder.getOrCreate()
+    if spark is None:
+        print("[kpi-snapshot] no active SparkSession.", file=sys.stderr)
+        sys.exit(4)
+    return spark
+
+
+def _read_headline_aggregates(catalog: str) -> dict[str, Any]:
+    """Aggregate the headline measures from the S1 metric view (real UC read)."""
+    spark = _get_spark()
+    metric_view = ".".join(
+        [
+            _quote_uc_identifier(catalog, field="catalog"),
+            _quote_uc_identifier("semantics", field="schema"),
+            _quote_uc_identifier("portfolio_headline_metric_view", field="view"),
+        ]
+    )
+    row = spark.sql(_HEADLINE_AGGREGATE_SQL.format(metric_view=metric_view)).collect()[0]
+    aggregates = row.asDict()
+    return {
+        "marketable_population": int(aggregates["marketable_population"] or 0),
+        "refi_economics_screen": int(aggregates["refi_economics_screen"] or 0),
+        "high_opportunity": int(aggregates["high_opportunity"] or 0),
+        "offers_available": int(aggregates["offers_available"] or 0),
+        "offers_recommended": int(aggregates["offers_recommended"] or 0),
+        "avg_opportunity_score": (
+            float(aggregates["avg_opportunity_score"])
+            if aggregates["avg_opportunity_score"] is not None
+            else None
+        ),
+    }
+
+
+def _upsert_snapshot(conn_kwargs: dict, aggregates: dict[str, Any]) -> None:
+    import psycopg
+
+    try:
+        with psycopg.connect(**conn_kwargs, autocommit=True) as conn, conn.cursor() as cur:
+            cur.execute(_UPSERT_SQL, aggregates)
+            written = cur.fetchone()
+    except psycopg.errors.UndefinedTable:
+        print(
+            "[kpi-snapshot] mip_app.kpi_snapshots does not exist; run the "
+            "mip_lakebase_migrate job (deploy step 4b) first.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    except psycopg.Error as exc:
+        print(f"[kpi-snapshot] Lakebase upsert failed: {exc}", file=sys.stderr)
+        sys.exit(2)
+    print(f"[kpi-snapshot] upserted snapshot {written}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kpi_snapshot",
+        description=(
+            "Upsert today's S1 headline KPI aggregates from "
+            "semantics.portfolio_headline_metric_view into "
+            "mip_app.kpi_snapshots."
+        ),
+    )
+    parser.add_argument(
+        "--catalog",
+        default=_catalog_default(),
+        help=(
+            "Unity Catalog catalog owning the semantics schema "
+            "(default: MIP_DEFAULT_CATALOG or mip)."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_parser().parse_args(argv)
+    aggregates = _read_headline_aggregates(args.catalog)
+    print(
+        "[kpi-snapshot] headline aggregates: "
+        + ", ".join(f"{k}={v}" for k, v in aggregates.items())
+    )
+    conn_kwargs = _resolve_connection()
+    _upsert_snapshot(conn_kwargs, aggregates)
+
+
+if __name__ == "__main__":
+    main()

--- a/lakebase/schema.sql
+++ b/lakebase/schema.sql
@@ -1031,3 +1031,64 @@ VALUES (
     'S1.5: persist default-off household dedup config and evidence-cited suppression summary on campaigns'
 )
 ON CONFLICT (version) DO NOTHING;
+
+-- KPI snapshots ---------------------------------------------------------
+-- S3: one row per day capturing the S1 headline aggregates measured over
+-- mip.semantics.portfolio_headline_metric_view (the named semantic home for
+-- every demoed headline KPI). Written by the mip_kpi_snapshot bundle job
+-- (jobs/kpi_snapshot.py) with a per-day upsert; the deploy script runs the
+-- job once post-gold-refresh so a fresh install never has an empty table.
+-- S4 ("since your last login" deltas) queries "the snapshot nearest a given
+-- past timestamp" -- the snapshot_at index makes both sides of that lookup
+-- (latest at-or-before / earliest after) an index-ordered LIMIT 1.
+-- Aggregates only: no borrower ids, owner names, or Cotality identifiers
+-- belong in this table.
+CREATE TABLE IF NOT EXISTS mip_app.kpi_snapshots (
+    snapshot_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    snapshot_date          DATE NOT NULL,
+    snapshot_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    source_view            TEXT NOT NULL DEFAULT 'portfolio_headline_metric_view',
+    marketable_population  BIGINT NOT NULL CHECK (marketable_population >= 0),
+    refi_economics_screen  BIGINT NOT NULL CHECK (refi_economics_screen >= 0),
+    high_opportunity       BIGINT NOT NULL CHECK (high_opportunity >= 0),
+    offers_available       BIGINT NOT NULL CHECK (offers_available >= 0),
+    offers_recommended     BIGINT NOT NULL CHECK (offers_recommended >= 0),
+    avg_opportunity_score  DOUBLE PRECISION CHECK (
+        avg_opportunity_score IS NULL
+        OR (avg_opportunity_score >= 0 AND avg_opportunity_score <= 100)
+    ),
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+-- Per-day idempotency: jobs upsert via ON CONFLICT (snapshot_date), so a
+-- re-run (or a deploy backfill on a day the scheduled job already ran)
+-- updates the day's row instead of duplicating it.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_kpi_snapshots_snapshot_date
+    ON mip_app.kpi_snapshots (snapshot_date);
+CREATE INDEX IF NOT EXISTS idx_kpi_snapshots_snapshot_at
+    ON mip_app.kpi_snapshots (snapshot_at DESC);
+COMMENT ON TABLE mip_app.kpi_snapshots IS
+    'Daily aggregates of mip.semantics.portfolio_headline_metric_view headline KPIs; upserted per day by the mip_kpi_snapshot job. No borrower-level data.';
+
+-- User visits -----------------------------------------------------------
+-- S3: authenticated app visits recorded by the backend visit-tracking
+-- middleware (backend/services/visit_tracking.py). One row per actor per
+-- dedupe window (default 15 minutes), never one row per request. Stores
+-- ONLY the existing actor identity model (workspace email forwarded by the
+-- Databricks Apps edge) + a timestamp -- no routes, IPs, user agents, or
+-- any borrower-linked data.
+CREATE TABLE IF NOT EXISTS mip_app.user_visits (
+    actor_email TEXT NOT NULL,
+    visited_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (actor_email, visited_at)
+);
+CREATE INDEX IF NOT EXISTS idx_user_visits_actor_visited
+    ON mip_app.user_visits (actor_email, visited_at DESC);
+COMMENT ON TABLE mip_app.user_visits IS
+    'Throttled authenticated-visit ledger (actor email + timestamp only) backing "since your last login" KPI deltas.';
+
+INSERT INTO mip_app.schema_migrations (version, description)
+VALUES (
+    '2026_07_10_s3_kpi_snapshots_user_visits',
+    'S3: daily headline-KPI snapshot table (per-day upsert target for mip_kpi_snapshot job) and throttled user_visits ledger for last-login deltas'
+)
+ON CONFLICT (version) DO NOTHING;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,6 +19,8 @@
 #       metric views Genie depends on.
 #   9.  Sync lifecycle state + funnel snapshot so the delta_vs_prior_*
 #       view columns resolve on the first dashboard render.
+#   9b. Backfill today's headline-KPI snapshot into mip_app.kpi_snapshots
+#       (idempotent per-day upsert; S4's last-login deltas never start empty).
 #   10. Provision / rebind the Genie space via
 #       tools/databricks/provision_genie_space.py.
 #   11. Provision MIP-owned agentic resources: Lakebase synced tables,
@@ -676,6 +678,17 @@ run_job_with_retry databricks bundle run mip_refresh_scores -t "$TARGET"
 # -----------------------------------------------------------------------------
 step "sync lifecycle state from Lakebase + record daily funnel snapshot"
 run "$PYTHON" tools/sync_lifecycle_warehouse.py --catalog "${MIP_DEFAULT_CATALOG:-mip}"
+
+# -----------------------------------------------------------------------------
+# Step 9b: KPI snapshot backfill (S3)
+# -----------------------------------------------------------------------------
+# Upsert today's headline-KPI snapshot into Lakebase mip_app.kpi_snapshots so
+# S4's "since your last login" deltas never see an empty table on a fresh
+# install. Requires step 4b (Lakebase schema) + step 8 (gold refresh landed
+# semantics.portfolio_headline_metric_view). Idempotent: the job keys on
+# snapshot_date, so re-deploying the same day refreshes the day's row.
+step "record headline KPI snapshot — mip_app.kpi_snapshots backfill (idempotent per-day)"
+run_job_with_retry databricks bundle run mip_kpi_snapshot -t "$TARGET"
 
 # -----------------------------------------------------------------------------
 # Step 10: rebind the Genie space after gold/semantic assets exist

--- a/tests/integration/test_kpi_snapshots_live.py
+++ b/tests/integration/test_kpi_snapshots_live.py
@@ -1,0 +1,126 @@
+"""Live S3 checks against a real Lakebase instance.
+
+Gated exactly like tests/integration/test_lakebase_round_trip.py: set
+``LAKEBASE_INTEGRATION=1`` plus either static ``LAKEBASE_*`` credentials
+or Databricks workspace credentials.
+
+Proves, against the deployed instance:
+
+1. **Backfill** -- after ``./scripts/deploy.sh -t dev`` (step 9b runs the
+   ``mip_kpi_snapshot`` job), ``mip_app.kpi_snapshots`` has at least one
+   row, so S4 never renders against an empty snapshot table.
+2. **Round-trip** -- the delta service's nearest-snapshot lookup reads the
+   real row back with sane invariants, and a visit written through the
+   real ``VisitTracker`` INSERT is visible to ``previous_visit``.
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from backend.services.kpi_deltas import KpiDeltaService
+from backend.services.lakebase import (
+    LakebaseClient,
+    _reset_client_for_tests,
+    get_lakebase_client,
+)
+from backend.services.visit_tracking import VisitTracker
+
+_HAS_STATIC_CREDS = all(
+    os.environ.get(k)
+    for k in ("LAKEBASE_HOST", "LAKEBASE_USER", "LAKEBASE_PASSWORD")
+)
+_HAS_WORKSPACE_CREDS = all(
+    os.environ.get(k)
+    for k in ("DATABRICKS_HOST", "DATABRICKS_TOKEN")
+)
+_HAS_CREDS = os.environ.get("LAKEBASE_INTEGRATION") == "1" and (
+    _HAS_STATIC_CREDS or _HAS_WORKSPACE_CREDS
+)
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_CREDS,
+    reason="Set LAKEBASE_INTEGRATION=1 + LAKEBASE_HOST/USER/PASSWORD to run",
+)
+
+
+def _client_from_env() -> LakebaseClient:
+    if not _HAS_STATIC_CREDS:
+        _reset_client_for_tests()
+        return get_lakebase_client()
+    return LakebaseClient(
+        host=os.environ["LAKEBASE_HOST"],
+        port=int(os.environ.get("LAKEBASE_PORT", "5432")),
+        database=os.environ.get("LAKEBASE_DATABASE") or "mip_app_state",
+        user=os.environ["LAKEBASE_USER"],
+        password=os.environ["LAKEBASE_PASSWORD"],
+        sslmode=os.environ.get("LAKEBASE_SSLMODE", "require"),
+    )
+
+
+def _apply_schema(client: LakebaseClient) -> None:
+    schema_path = Path(__file__).resolve().parents[2] / "lakebase" / "schema.sql"
+    client.execute(schema_path.read_text(encoding="utf-8"))
+
+
+def test_kpi_snapshots_backfilled_after_deploy() -> None:
+    """Backfill proof: the deploy path leaves at least one snapshot row."""
+    client = _client_from_env()
+    _apply_schema(client)
+
+    row = client.fetchone("SELECT COUNT(*) AS n FROM mip_app.kpi_snapshots")
+    assert row is not None
+    assert int(row["n"]) >= 1, (
+        "mip_app.kpi_snapshots is empty -- deploy step 9b "
+        "(databricks bundle run mip_kpi_snapshot) did not run or failed"
+    )
+
+    service = KpiDeltaService(lakebase_client=client)
+    snapshot = service.nearest_snapshot(datetime.now(UTC))
+    assert snapshot is not None
+    assert snapshot.snapshot_at.tzinfo is not None
+    assert snapshot.marketable_population >= 0
+    assert snapshot.refi_economics_screen <= snapshot.marketable_population
+    assert snapshot.high_opportunity <= snapshot.marketable_population
+    assert snapshot.offers_recommended <= snapshot.offers_available
+    assert snapshot.source_view == "portfolio_headline_metric_view"
+
+
+def test_user_visit_write_and_previous_visit_round_trip() -> None:
+    """Visit ledger round-trip through the production INSERT + lookup SQL."""
+    client = _client_from_env()
+    _apply_schema(client)
+
+    actor = f"integration-s3+{uuid4().hex[:12]}@entrada.ai"
+    tracker = VisitTracker(lambda: client, window_s=60.0)
+    assert tracker.maybe_claim(actor) is True
+    tracker.record_visit(actor)
+
+    try:
+        service = KpiDeltaService(lakebase_client=client)
+        visited_at = service.previous_visit(
+            actor, before=datetime.now(UTC) + timedelta(minutes=5)
+        )
+        assert visited_at is not None
+        assert abs((datetime.now(UTC) - visited_at).total_seconds()) < 300
+
+        # SQL-side window guard: an immediate second INSERT inside the
+        # window must be a no-op even without the in-process throttle.
+        tracker.record_visit(actor)
+        rows = client.fetchall(
+            "SELECT visited_at FROM mip_app.user_visits "
+            "WHERE actor_email = %(actor)s",
+            {"actor": actor},
+        )
+        assert len(rows) == 1
+    finally:
+        with contextlib.suppress(Exception):
+            client.execute(
+                "DELETE FROM mip_app.user_visits WHERE actor_email = %(actor)s",
+                {"actor": actor},
+            )

--- a/tests/unit/test_kpi_deltas.py
+++ b/tests/unit/test_kpi_deltas.py
@@ -1,0 +1,276 @@
+"""KPI delta service contracts: 0/1/2+ snapshot edges + golden delta math.
+
+The Lakebase and warehouse clients are pure in-memory fakes that answer the
+service's three SQL shapes (previous visit, snapshot at-or-before, snapshot
+after) so no test touches a network. Delta arithmetic is pinned by golden
+fixtures -- if the math or the measure vocabulary drifts, these fail loudly.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from backend.schemas.kpi_deltas import HEADLINE_COUNT_MEASURES, HeadlineKpis
+from backend.services.kpi_deltas import KpiDeltaService, compute_deltas
+
+_NOW = datetime(2026, 7, 10, 18, 0, 0, tzinfo=UTC)
+
+# Golden current/baseline readings. Deltas asserted digit-for-digit below.
+_CURRENT_ROW: dict[str, Any] = {
+    "marketable_population": 5_240_100,
+    "refi_economics_screen": 261_400,
+    "high_opportunity": 88_210,
+    "offers_available": 402_330,
+    "offers_recommended": 310_450,
+    "avg_opportunity_score": 61.5,
+}
+_BASELINE_MEASURES: dict[str, Any] = {
+    "marketable_population": 5_212_000,
+    "refi_economics_screen": 259_150,
+    "high_opportunity": 86_900,
+    "offers_available": 398_210,
+    "offers_recommended": 305_925,
+    "avg_opportunity_score": 60.75,
+}
+_GOLDEN_DELTAS: dict[str, Any] = {
+    "marketable_population": 28_100,
+    "refi_economics_screen": 2_250,
+    "high_opportunity": 1_310,
+    "offers_available": 4_120,
+    "offers_recommended": 4_525,
+    "avg_opportunity_score": 0.75,
+}
+
+
+def _snapshot_row(snapshot_at: datetime, **overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "snapshot_date": snapshot_at.date(),
+        "snapshot_at": snapshot_at,
+        "source_view": "portfolio_headline_metric_view",
+        **_BASELINE_MEASURES,
+    }
+    row.update(overrides)
+    return row
+
+
+class _FakeLakebase:
+    """Answers the service's three fetchone shapes from in-memory rows."""
+
+    def __init__(
+        self,
+        visits: list[datetime] | None = None,
+        snapshots: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.visits = visits or []
+        self.snapshots = snapshots or []
+        self.fetchones: list[tuple[str, dict[str, Any]]] = []
+
+    def fetchone(
+        self, sql: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any] | None:
+        p = params or {}
+        self.fetchones.append((sql, p))
+        if "mip_app.user_visits" in sql:
+            older = [v for v in self.visits if v < p["before"]]
+            return {"visited_at": max(older)} if older else None
+        if "snapshot_at <=" in sql:
+            side = [s for s in self.snapshots if s["snapshot_at"] <= p["ts"]]
+            return max(side, key=lambda s: s["snapshot_at"]) if side else None
+        if "snapshot_at >" in sql:
+            side = [s for s in self.snapshots if s["snapshot_at"] > p["ts"]]
+            return min(side, key=lambda s: s["snapshot_at"]) if side else None
+        raise AssertionError(f"unexpected fetchone: {sql}")
+
+
+class _FakeSql:
+    def __init__(self, row: dict[str, Any] | None = None) -> None:
+        self.row = dict(_CURRENT_ROW) if row is None else row
+        self.statements: list[str] = []
+
+    def execute_one(
+        self, statement: str, parameters: Any = None
+    ) -> dict[str, Any] | None:
+        self.statements.append(statement)
+        return dict(self.row)
+
+
+def _service(
+    lakebase: _FakeLakebase,
+    sql: _FakeSql | None = None,
+    *,
+    grace_s: float = 900.0,
+) -> KpiDeltaService:
+    return KpiDeltaService(
+        lakebase_client=lakebase,
+        sql_client=sql if sql is not None else _FakeSql(),
+        current_session_grace_s=grace_s,
+        now=lambda: _NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Golden delta math (pure).
+# ---------------------------------------------------------------------------
+
+
+def test_compute_deltas_golden_fixture() -> None:
+    current = HeadlineKpis.model_validate(_CURRENT_ROW)
+    baseline = HeadlineKpis.model_validate(_BASELINE_MEASURES)
+
+    deltas = compute_deltas(current, baseline)
+
+    for measure, expected in _GOLDEN_DELTAS.items():
+        assert getattr(deltas, measure) == expected, measure
+
+
+def test_compute_deltas_are_signed_and_avg_none_propagates() -> None:
+    current = HeadlineKpis.model_validate(
+        {**_BASELINE_MEASURES, "high_opportunity": 86_000, "avg_opportunity_score": None}
+    )
+    baseline = HeadlineKpis.model_validate(_BASELINE_MEASURES)
+
+    deltas = compute_deltas(current, baseline)
+
+    assert deltas.high_opportunity == -900  # declines are signed, not clamped
+    assert deltas.avg_opportunity_score is None
+
+
+# ---------------------------------------------------------------------------
+# Edge case: zero snapshots (pre-backfill install).
+# ---------------------------------------------------------------------------
+
+
+def test_zero_snapshots_yields_current_only_no_deltas() -> None:
+    lakebase = _FakeLakebase(visits=[_NOW - timedelta(days=1)], snapshots=[])
+    result = _service(lakebase).deltas_for_actor("lo@summit.example")
+
+    assert result.previous_visit_at == _NOW - timedelta(days=1)
+    assert result.baseline is None
+    assert result.baseline_snapshot_at is None
+    assert result.deltas is None
+    assert result.current.marketable_population == _CURRENT_ROW["marketable_population"]
+
+
+# ---------------------------------------------------------------------------
+# Edge case: no previous visit (first login).
+# ---------------------------------------------------------------------------
+
+
+def test_no_previous_visit_yields_no_baseline_even_with_snapshots() -> None:
+    lakebase = _FakeLakebase(
+        visits=[], snapshots=[_snapshot_row(_NOW - timedelta(days=1))]
+    )
+    result = _service(lakebase).deltas_for_actor("lo@summit.example")
+
+    assert result.previous_visit_at is None
+    assert result.baseline is None
+    assert result.deltas is None
+    assert result.actor_email == "lo@summit.example"
+
+
+def test_previous_visit_excludes_current_session_window() -> None:
+    """The row the middleware wrote for the CURRENT session (inside the
+    dedupe window) must not masquerade as the last login."""
+    current_session_visit = _NOW - timedelta(minutes=5)
+    last_login = _NOW - timedelta(days=2)
+    lakebase = _FakeLakebase(
+        visits=[last_login, current_session_visit],
+        snapshots=[_snapshot_row(_NOW - timedelta(days=2, hours=1))],
+    )
+
+    result = _service(lakebase, grace_s=900.0).deltas_for_actor("lo@summit.example")
+
+    assert result.previous_visit_at == last_login
+    visit_sql, visit_params = lakebase.fetchones[0]
+    assert "mip_app.user_visits" in visit_sql
+    assert visit_params["before"] == _NOW - timedelta(seconds=900)
+
+
+# ---------------------------------------------------------------------------
+# Edge case: exactly one snapshot -- nearest from either side.
+# ---------------------------------------------------------------------------
+
+
+def test_single_snapshot_after_visit_is_still_nearest() -> None:
+    visit = _NOW - timedelta(days=3)
+    only_snapshot = _snapshot_row(_NOW - timedelta(days=1))  # after the visit
+    lakebase = _FakeLakebase(visits=[visit], snapshots=[only_snapshot])
+
+    result = _service(lakebase).deltas_for_actor("lo@summit.example")
+
+    assert result.baseline_snapshot_at == only_snapshot["snapshot_at"]
+    assert result.deltas is not None
+
+
+def test_single_snapshot_before_visit_is_still_nearest() -> None:
+    visit = _NOW - timedelta(days=1)
+    only_snapshot = _snapshot_row(_NOW - timedelta(days=4))  # before the visit
+    lakebase = _FakeLakebase(visits=[visit], snapshots=[only_snapshot])
+
+    result = _service(lakebase).deltas_for_actor("lo@summit.example")
+
+    assert result.baseline_snapshot_at == only_snapshot["snapshot_at"]
+
+
+# ---------------------------------------------------------------------------
+# Normal case: two or more snapshots.
+# ---------------------------------------------------------------------------
+
+
+def test_two_plus_snapshots_pick_the_closer_side() -> None:
+    visit = _NOW - timedelta(days=1)
+    far_before = _snapshot_row(visit - timedelta(hours=20))
+    near_after = _snapshot_row(visit + timedelta(hours=2))
+    lakebase = _FakeLakebase(visits=[visit], snapshots=[far_before, near_after])
+
+    result = _service(lakebase).deltas_for_actor("lo@summit.example")
+
+    assert result.baseline_snapshot_at == near_after["snapshot_at"]
+
+
+def test_snapshot_tie_resolves_to_at_or_before_row() -> None:
+    visit = _NOW - timedelta(days=1)
+    before = _snapshot_row(visit - timedelta(hours=6))
+    after = _snapshot_row(visit + timedelta(hours=6))
+    lakebase = _FakeLakebase(visits=[visit], snapshots=[before, after])
+
+    result = _service(lakebase).deltas_for_actor("lo@summit.example")
+
+    assert result.baseline_snapshot_at == before["snapshot_at"]
+
+
+def test_deltas_for_actor_end_to_end_golden() -> None:
+    visit = _NOW - timedelta(days=1)
+    baseline_at = visit - timedelta(hours=1)
+    lakebase = _FakeLakebase(
+        visits=[visit],
+        snapshots=[
+            _snapshot_row(baseline_at),
+            _snapshot_row(visit - timedelta(days=6)),
+        ],
+    )
+    sql = _FakeSql()
+
+    result = _service(lakebase, sql).deltas_for_actor("lo@summit.example")
+
+    assert result.previous_visit_at == visit
+    assert result.baseline_snapshot_at == baseline_at
+    assert result.deltas is not None
+    for measure, expected in _GOLDEN_DELTAS.items():
+        assert getattr(result.deltas, measure) == expected, measure
+    # The live read went to the S1 headline metric view, catalog-qualified.
+    assert any(
+        "semantics.portfolio_headline_metric_view" in stmt for stmt in sql.statements
+    )
+
+
+def test_headline_measure_vocabulary_is_the_s1_set() -> None:
+    """The count-measure list is the S4 wire vocabulary; renames here are
+    breaking changes for snapshots already persisted in Lakebase."""
+    assert HEADLINE_COUNT_MEASURES == (
+        "marketable_population",
+        "refi_economics_screen",
+        "high_opportunity",
+        "offers_available",
+        "offers_recommended",
+    )

--- a/tests/unit/test_kpi_snapshot_contract.py
+++ b/tests/unit/test_kpi_snapshot_contract.py
@@ -1,0 +1,113 @@
+"""S3 packaging + parity contracts for the KPI snapshot pipeline.
+
+Grep-style lockstep pins (same family as test_score_threshold_guard.py):
+
+1. The bundle declares the ``mip_kpi_snapshot`` job inline (no YAML
+   mirrors) with the jobs/kpi_snapshot.py task source.
+2. The deploy script backfills the table (zero-click contract: a fresh
+   install never leaves ``mip_app.kpi_snapshots`` empty for S4).
+3. The Lakebase migration declares the snapshot + visit tables with the
+   per-day unique index the job's upsert keys on.
+4. The job, the delta service, and the persisted schema agree on the S1
+   headline measure vocabulary, and the job's write is a per-day upsert.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from backend.schemas.kpi_deltas import HEADLINE_COUNT_MEASURES
+
+REPO = Path(__file__).resolve().parents[2]
+BUNDLE = (REPO / "databricks.yml").read_text(encoding="utf-8")
+DEPLOY = (REPO / "scripts" / "deploy.sh").read_text(encoding="utf-8")
+SCHEMA = (REPO / "lakebase" / "schema.sql").read_text(encoding="utf-8")
+JOB = (REPO / "jobs" / "kpi_snapshot.py").read_text(encoding="utf-8")
+SERVICE = (REPO / "backend" / "services" / "kpi_deltas.py").read_text(encoding="utf-8")
+METRIC_VIEW = (
+    REPO / "sql" / "metric_views" / "portfolio_headline_metric_view.sql"
+).read_text(encoding="utf-8")
+
+_ALL_SNAPSHOT_MEASURES = (*HEADLINE_COUNT_MEASURES, "avg_opportunity_score")
+
+
+def test_bundle_declares_kpi_snapshot_job_inline() -> None:
+    job_block = re.search(
+        r"(?ms)^    mip_kpi_snapshot:\n(.*?)(?=^    \w|\Z)", BUNDLE
+    )
+    assert job_block, "databricks.yml must declare the mip_kpi_snapshot job inline"
+    block = job_block.group(1)
+    assert "jobs/kpi_snapshot.py" in block
+    assert "--catalog=${var.uc_catalog}" in block
+    assert "psycopg[binary]" in block
+    assert "max_concurrent_runs: 1" in block
+    # Daily cadence declared; ships PAUSED per the bundle-wide cost posture
+    # (freshness on dev comes from the deploy-script backfill run).
+    assert "quartz_cron_expression" in block
+    assert "pause_status: PAUSED" in block
+
+
+def test_deploy_script_backfills_kpi_snapshots() -> None:
+    assert "bundle run mip_kpi_snapshot" in DEPLOY, (
+        "deploy.sh must run the snapshot job so a fresh install never has an "
+        "empty mip_app.kpi_snapshots table"
+    )
+    assert re.search(
+        r"run_job_with_retry databricks bundle run mip_kpi_snapshot", DEPLOY
+    ), "the backfill must use the network-flap-tolerant job runner"
+    # Ordering: backfill after the gold refresh (the metric view must exist
+    # and be fresh) and before the deploy completes.
+    assert DEPLOY.index("bundle run mip_refresh_scores") < DEPLOY.index(
+        "bundle run mip_kpi_snapshot"
+    )
+
+
+def test_schema_declares_snapshot_table_with_per_day_upsert_key() -> None:
+    assert "CREATE TABLE IF NOT EXISTS mip_app.kpi_snapshots" in SCHEMA
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS idx_kpi_snapshots_snapshot_date" in SCHEMA
+    assert "idx_kpi_snapshots_snapshot_at" in SCHEMA  # nearest-timestamp lookup
+    for measure in _ALL_SNAPSHOT_MEASURES:
+        assert measure in SCHEMA, f"kpi_snapshots is missing column {measure}"
+    assert "2026_07_10_s3_kpi_snapshots_user_visits" in SCHEMA
+
+
+def test_schema_declares_user_visits_ledger() -> None:
+    assert "CREATE TABLE IF NOT EXISTS mip_app.user_visits" in SCHEMA
+    assert "idx_user_visits_actor_visited" in SCHEMA
+    # PII posture: the ledger is actor email + timestamp ONLY.
+    visits_block = SCHEMA.split("CREATE TABLE IF NOT EXISTS mip_app.user_visits", 1)[1]
+    visits_block = visits_block.split(";", 1)[0]
+    assert "actor_email" in visits_block
+    assert "visited_at" in visits_block
+    forbidden = ("borrower", "clip", "address", "phone", "ip_", "user_agent", "route")
+    for token in forbidden:
+        assert token not in visits_block.lower(), f"user_visits must not carry {token}"
+
+
+def test_job_upsert_is_idempotent_per_day() -> None:
+    assert "ON CONFLICT (snapshot_date) DO UPDATE" in JOB, (
+        "re-running the snapshot job on the same day must upsert, not duplicate"
+    )
+    assert "semantics" in JOB and "portfolio_headline_metric_view" in JOB, (
+        "the snapshot must aggregate the S1 headline metric view (real UC read)"
+    )
+
+
+def test_job_service_and_view_agree_on_measure_vocabulary() -> None:
+    """The job's aggregate aliases, the delta service's live-read aliases,
+    and the persisted snapshot columns are one vocabulary."""
+    for measure in _ALL_SNAPSHOT_MEASURES:
+        assert re.search(rf"AS {measure}\b", JOB), f"job missing alias {measure}"
+        assert re.search(rf"AS {measure}\b", SERVICE), f"service missing alias {measure}"
+    # And the aliases derive from the metric view's documented indicator
+    # columns, so a view refactor that renames an indicator breaks here.
+    for indicator in (
+        "in_the_money",
+        "is_high_opportunity",
+        "offer_available",
+        "offer_recommended",
+        "opportunity_score",
+    ):
+        assert indicator in METRIC_VIEW
+        assert indicator in JOB
+        assert indicator in SERVICE

--- a/tests/unit/test_visit_tracking.py
+++ b/tests/unit/test_visit_tracking.py
@@ -1,0 +1,230 @@
+"""Visit-tracking contracts: dedupe window, unauthenticated skip, resilience.
+
+The tracker is exercised directly with fake clocks/clients; the middleware
+is exercised on a minimal FastAPI app so the assertions cover the actual
+request-path wiring (claim on /api traffic only, header-derived actor,
+fire-and-forget write).
+"""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.config.settings import settings
+from backend.services.visit_tracking import (
+    DEFAULT_VISIT_DEDUPE_WINDOW_S,
+    VisitTracker,
+    VisitTrackingMiddleware,
+)
+
+
+class _RecordingClient:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.fail = fail
+
+    def execute(self, sql: str, params: dict[str, Any] | None = None) -> None:
+        if self.fail:
+            raise RuntimeError("lakebase down")
+        self.calls.append((sql, params or {}))
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.t = 1_000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _wait_until(predicate: Any, timeout_s: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return bool(predicate())
+
+
+# ---------------------------------------------------------------------------
+# Tracker throttle contract
+# ---------------------------------------------------------------------------
+
+
+def test_visit_claim_dedupes_within_window() -> None:
+    clock = _FakeClock()
+    client = _RecordingClient()
+    tracker = VisitTracker(lambda: client, window_s=600.0, now=clock)
+
+    assert tracker.maybe_claim("lo@summit.example") is True
+    # A browsing session inside the window never claims again.
+    clock.t += 599.0
+    assert tracker.maybe_claim("lo@summit.example") is False
+    # Past the window a new claim (one new row) is allowed.
+    clock.t += 2.0
+    assert tracker.maybe_claim("lo@summit.example") is True
+
+
+def test_visit_claims_are_per_actor() -> None:
+    clock = _FakeClock()
+    tracker = VisitTracker(lambda: _RecordingClient(), window_s=600.0, now=clock)
+
+    assert tracker.maybe_claim("a@summit.example") is True
+    assert tracker.maybe_claim("b@summit.example") is True
+    assert tracker.maybe_claim("a@summit.example") is False
+
+
+def test_unauthenticated_actor_never_claims() -> None:
+    tracker = VisitTracker(lambda: _RecordingClient(), window_s=600.0)
+    assert tracker.maybe_claim(None) is False
+    assert tracker.maybe_claim("") is False
+
+
+def test_default_factory_tracker_refuses_claims_under_pytest() -> None:
+    """The default-factory path must never open a background Postgres
+    connection from a pytest process (the conftest Lakebase override is a
+    FastAPI dependency seam this service-level call would bypass)."""
+    tracker = VisitTracker()
+    assert tracker.maybe_claim("lo@summit.example") is False
+
+
+def test_record_visit_inserts_with_sql_side_window_guard() -> None:
+    client = _RecordingClient()
+    tracker = VisitTracker(lambda: client, window_s=450.0)
+
+    assert tracker.maybe_claim("lo@summit.example") is True
+    tracker.record_visit("lo@summit.example")
+
+    assert len(client.calls) == 1
+    sql, params = client.calls[0]
+    assert "INSERT INTO mip_app.user_visits" in sql
+    assert "WHERE NOT EXISTS" in sql  # replica-safe dedupe re-check in SQL
+    assert params == {"actor_email": "lo@summit.example", "window_s": 450.0}
+
+
+def test_failed_write_releases_claim_and_never_raises() -> None:
+    clock = _FakeClock()
+    client = _RecordingClient(fail=True)
+    tracker = VisitTracker(lambda: client, window_s=600.0, now=clock)
+
+    assert tracker.maybe_claim("lo@summit.example") is True
+    tracker.record_visit("lo@summit.example")  # swallows the failure
+    # The slot was released, so the very next request retries the write
+    # instead of silently losing the visit for a whole window.
+    assert tracker.maybe_claim("lo@summit.example") is True
+
+
+def test_window_must_be_positive() -> None:
+    with pytest.raises(ValueError):
+        VisitTracker(lambda: _RecordingClient(), window_s=0)
+
+
+def test_default_window_is_minutes_not_seconds() -> None:
+    """The 'at most one row per actor per N minutes' contract: the default
+    window is a multi-minute span, so a browsing session can never write a
+    row per request."""
+    assert DEFAULT_VISIT_DEDUPE_WINDOW_S >= 300.0
+
+
+# ---------------------------------------------------------------------------
+# Middleware wiring
+# ---------------------------------------------------------------------------
+
+
+def _make_app(tracker: VisitTracker) -> FastAPI:
+    test_app = FastAPI()
+    test_app.add_middleware(VisitTrackingMiddleware, tracker=tracker)
+
+    @test_app.get("/api/ping")
+    def _ping() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @test_app.get("/assets/app.js")
+    def _asset() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return test_app
+
+
+def test_middleware_records_one_visit_per_actor_per_window() -> None:
+    client_fake = _RecordingClient()
+    tracker = VisitTracker(lambda: client_fake, window_s=600.0)
+    http = TestClient(_make_app(tracker))
+
+    for _ in range(5):
+        response = http.get(
+            "/api/ping", headers={"X-Forwarded-Email": "lo@summit.example"}
+        )
+        assert response.status_code == 200
+
+    assert _wait_until(lambda: len(client_fake.calls) == 1)
+    time.sleep(0.05)  # would catch a stray second write racing in
+    assert len(client_fake.calls) == 1
+    assert client_fake.calls[0][1]["actor_email"] == "lo@summit.example"
+
+
+def test_middleware_records_distinct_actors_separately() -> None:
+    client_fake = _RecordingClient()
+    tracker = VisitTracker(lambda: client_fake, window_s=600.0)
+    http = TestClient(_make_app(tracker))
+
+    http.get("/api/ping", headers={"X-Forwarded-Email": "a@summit.example"})
+    http.get("/api/ping", headers={"X-Forwarded-Email": "b@summit.example"})
+
+    assert _wait_until(lambda: len(client_fake.calls) == 2)
+    actors = {params["actor_email"] for _, params in client_fake.calls}
+    assert actors == {"a@summit.example", "b@summit.example"}
+
+
+def test_middleware_skips_unauthenticated_requests() -> None:
+    client_fake = _RecordingClient()
+    tracker = VisitTracker(lambda: client_fake, window_s=600.0)
+    http = TestClient(_make_app(tracker))
+
+    response = http.get("/api/ping")  # no forwarded identity headers
+    assert response.status_code == 200
+
+    time.sleep(0.05)
+    assert client_fake.calls == []
+
+
+def test_middleware_skips_non_api_paths() -> None:
+    client_fake = _RecordingClient()
+    tracker = VisitTracker(lambda: client_fake, window_s=600.0)
+    http = TestClient(_make_app(tracker))
+
+    http.get("/assets/app.js", headers={"X-Forwarded-Email": "lo@summit.example"})
+
+    time.sleep(0.05)
+    assert client_fake.calls == []
+
+
+def test_middleware_accepts_forwarded_user_fallback_header() -> None:
+    client_fake = _RecordingClient()
+    tracker = VisitTracker(lambda: client_fake, window_s=600.0)
+    http = TestClient(_make_app(tracker))
+
+    http.get("/api/ping", headers={"X-Forwarded-User": "user-id-42"})
+
+    assert _wait_until(lambda: len(client_fake.calls) == 1)
+    assert client_fake.calls[0][1]["actor_email"] == "user-id-42"
+
+
+def test_middleware_skips_when_forwarded_headers_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With trust disabled the identity headers are attacker-writable, so
+    no visit is attributed at all (mirrors resolve_actor's R5-09 posture)."""
+    monkeypatch.setattr(settings, "trust_forwarded_headers", False)
+    client_fake = _RecordingClient()
+    tracker = VisitTracker(lambda: client_fake, window_s=600.0)
+    http = TestClient(_make_app(tracker))
+
+    http.get("/api/ping", headers={"X-Forwarded-Email": "spoof@evil.example"})
+
+    time.sleep(0.05)
+    assert client_fake.calls == []


### PR DESCRIPTION
## What

Closes demo-gap slice S3 (depends on S1's `portfolio_headline_metric_view`, PR #95 — this PR is stacked on `polly/s1-canonical-score`).

- **`mip_app.kpi_snapshots`** (lakebase/schema.sql): one row/day of the S1 headline aggregates, unique-indexed on `snapshot_date` (per-day upsert key) and indexed on `snapshot_at` so "snapshot nearest a past timestamp" is two index-ordered LIMIT 1s.
- **`mip_kpi_snapshot` job** (databricks.yml inline + jobs/kpi_snapshot.py): Spark aggregates `semantics.portfolio_headline_metric_view` (real UC read) and upserts today's row via `ON CONFLICT (snapshot_date) DO UPDATE` — idempotent per day. Daily cron declared, shipped PAUSED per the bundle-wide cost posture.
- **Deploy backfill** (scripts/deploy.sh step 9b): runs the job after the gold refresh, so a fresh zero-click install never leaves the table empty for S4.
- **`mip_app.user_visits` + middleware** (backend/services/visit_tracking.py): at most one row per actor per 15-min window; claim is a dict lookup on the request path, INSERT runs on a daemon thread with an SQL-side window re-check for replica safety. Unauthenticated / untrusted-edge requests are never recorded.
- **KPI delta service** (backend/services/kpi_deltas.py + schemas/kpi_deltas.py): the S4 surface — previous visit (excluding the current session's row) → nearest snapshot (tie → at-or-before) → live metrics from the same view → signed deltas.

## Testing

- Unit: dedupe window / unauth skip / failure-releases-claim; delta edges (0, 1, 2+ snapshots, ties, no previous visit) with golden-fixture math; contract tests pinning job↔service↔schema measure parity, bundle/job declaration, deploy backfill ordering, and the user_visits PII posture.
- Live (LAKEBASE_INTEGRATION-gated): kpi_snapshots has rows post-deploy (backfill proof) + visit write/read round-trip incl. SQL-side dedupe.
- Gates: ruff ✅ · pytest 2599 passed ✅ · eslint/vitest/build ✅ · render_sql + `bundle validate -t dev` ✅ (independently re-verified by orchestrator).

## Notes for reviewers

- Dedupe window is a constructor-injectable module constant (not a Settings field) — lifting it to Settings needs an `.env.example` line, deferred.
- No API route: S4 consumes `get_kpi_delta_service().deltas_for_actor(actor)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
