### PR TITLE
fix(frontend): make segment-card selection a stretched button, not the card

### DIFF
--- a/frontend/src/components/mortgage/SegmentCard.test.tsx
+++ b/frontend/src/components/mortgage/SegmentCard.test.tsx
@@ -143,18 +143,94 @@ describe('SegmentCard', () => {
     expect(container.querySelector('.seg-card__facets')).toBeNull();
   });
 
-  it('keeps the card on the div role-button composition and wraps facet controls in spans', () => {
-    render({
-      code: 'itm',
-      count: 12,
-      loan_product_mix: [{ value: 'fha', count: 1240 }],
-    });
+  it('puts selection on a dedicated button instead of the card element', () => {
+    render(
+      {
+        code: 'itm',
+        count: 12,
+        loan_product_mix: [{ value: 'fha', count: 1240 }],
+      },
+      vi.fn(),
+    );
     const card = container.querySelector('.seg-card');
     expect(card?.tagName).toBe('DIV');
-    expect(card?.getAttribute('role')).toBe('button');
+    // The card element itself is no longer a widget — it holds interactive
+    // children, and a role="button" host containing buttons is an ARIA
+    // violation as well as the click-routing trap this composition replaced.
+    expect(card?.getAttribute('role')).toBeNull();
+    expect(card?.hasAttribute('tabindex')).toBe(false);
+
+    const select = container.querySelector<HTMLButtonElement>('.seg-card__select');
+    expect(select?.tagName).toBe('BUTTON');
+    // type="button" + a native <button> is the whole keyboard contract:
+    // Enter/Space activation comes from the platform, not a keydown handler.
+    expect(select?.getAttribute('type')).toBe('button');
+    expect(select?.getAttribute('aria-pressed')).toBe('false');
+    expect(select?.getAttribute('aria-label')).toBe(
+      'Select Prime Refi Candidates segment — 12 borrowers',
+    );
+
     const chip = container.querySelector('.seg-card__facet-chip');
     expect(chip?.tagName).toBe('SPAN');
     expect(chip?.querySelector('.evidence-chip')).not.toBeNull();
+  });
+
+  it('keeps every evidence control outside the selection button', () => {
+    render(
+      {
+        code: 'itm',
+        count: 12,
+        loan_product_mix: [{ value: 'fha', count: 1240 }],
+        origination_channel_mix: [{ value: 'digital', count: 620 }],
+      },
+      vi.fn(),
+    );
+    const select = container.querySelector('.seg-card__select');
+    expect(select).not.toBeNull();
+    const chips = Array.from(container.querySelectorAll('.evidence-chip'));
+    // Segment evidence chip + product chip + channel chip.
+    expect(chips).toHaveLength(3);
+    for (const chip of chips) {
+      // Nothing needs stopPropagation() because nothing nests: a chip click
+      // cannot reach the selection button if the button is not its ancestor.
+      expect(select!.contains(chip)).toBe(false);
+    }
+  });
+
+  it('selects the segment when the card surface is clicked', () => {
+    const onClick = vi.fn();
+    render({ code: 'itm', count: 12 }, onClick);
+    const select = container.querySelector<HTMLButtonElement>('.seg-card__select');
+    act(() => select!.click());
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(setDrawer).not.toHaveBeenCalled();
+  });
+
+  it('marks the selection button pressed for the active segment', () => {
+    render({ code: 'itm', count: 12 }, vi.fn());
+    expect(
+      container.querySelector('.seg-card__select')?.getAttribute('aria-pressed'),
+    ).toBe('false');
+    act(() =>
+      root.render(
+        <SegmentCard
+          segment={{
+            code: 'itm',
+            name: 'In the Money',
+            count: 12,
+            delta: '+1%',
+            avg_score: 70,
+            description: 'x',
+            color: '#000',
+          }}
+          selected
+          onClick={vi.fn()}
+        />,
+      ),
+    );
+    expect(
+      container.querySelector('.seg-card__select')?.getAttribute('aria-pressed'),
+    ).toBe('true');
   });
 
   it('opens the product-type drawer on chip click without toggling card selection', () => {
@@ -189,19 +265,25 @@ describe('SegmentCard', () => {
   });
 
   it('renders an explicit gated panel for a not-connected source and suppresses the count', () => {
-    render({
-      code: 'permit_activity',
-      count: 0,
-      source_status: 'not_connected',
-      source_name: 'Building Permits',
-    });
+    render(
+      {
+        code: 'permit_activity',
+        count: 0,
+        source_status: 'not_connected',
+        source_name: 'Building Permits',
+      },
+      vi.fn(),
+    );
     expect(container.textContent).toContain('not connected');
     expect(container.textContent).toContain('Building Permits');
     expect(container.textContent).toContain('—');
     expect(container.textContent).not.toContain('no borrowers in current view');
     const card = container.querySelector('.seg-card');
     expect(card?.classList.contains('seg-card--gated')).toBe(true);
-    expect(card?.getAttribute('aria-disabled')).toBe('true');
+    // A gated segment cannot be selected, so it exposes no selection control
+    // at all — stronger than aria-disabled on a non-widget, and it keeps the
+    // card from advertising a click that would do nothing.
+    expect(container.querySelector('.seg-card__select')).toBeNull();
   });
 
   it('labels a permission-denied source as not licensed', () => {

--- a/frontend/src/components/mortgage/SegmentCard.tsx
+++ b/frontend/src/components/mortgage/SegmentCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties, type KeyboardEvent } from 'react';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
 import type { DimensionFacetCount, SegmentSummary } from '../../types';
 import { Icon } from '../Icon';
 import { EvidenceChip } from '../Primitives';
@@ -24,10 +24,25 @@ const FACET_LABELS: Record<string, string> = {
  * Segment color is passed as a CSS variable `--seg-color` so the top accent bar,
  * badge, selection shadow, and hover radial gradient all pick it up.
  *
- * Root element is the prototype's `div role="button"` composition
- * (`design_files/Module 0 Prototype.html` lines 1150–1153) rather than a
- * native <button>, so the S1.3 evidence chip in the meta row can be a real
- * button without nesting interactive elements.
+ * Selection composition: the prototype makes the WHOLE card the selection
+ * target (`design_files/Module 0 Prototype.html` lines 1150–1153) and we keep
+ * that. What we do not keep is making the card element itself the button.
+ * Module 0 added interactive children the prototype never had (the S1.3
+ * evidence chip, the S1.6 product/channel breakdown chips), and a
+ * `role="button"` host containing real buttons is both an ARIA violation
+ * (axe `nested-interactive`) and a click-routing trap: the children have to
+ * `stopPropagation()` to avoid selecting, so any click that lands on one —
+ * including a click on the card's geometric centre once the breakdown rows
+ * render — silently does something other than select.
+ *
+ * Instead the card is a plain container holding `.seg-card__select`: a real
+ * <button> stretched across the card (`position:absolute; inset:0`) that owns
+ * selection, `aria-pressed`, and the keyboard contract. The chips sit above it
+ * in the stacking order (see `.seg-card__evidence` / `.seg-card__facet-chip`
+ * in components.css), so they are click targets in their own right rather than
+ * propagation hazards. Nothing calls `stopPropagation()` any more, the
+ * selection control has a stable accessible name instead of the card's entire
+ * text content, and clicking anywhere that is not a chip selects the segment.
  *
  * S1.3 evidence: every segment count carries an `.evidence-chip` that opens
  * the EvidenceDrawer with the segment's exact membership predicate, its
@@ -94,26 +109,22 @@ export function SegmentCard({ segment, selected, updating, onClick }: SegmentCar
   });
 
   const activate = gated ? undefined : onClick;
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (!activate) return;
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      activate();
-    }
-  };
 
   return (
     <div
       className={`seg-card ${selected ? 'is-selected' : ''} ${updating ? 'is-updating' : ''} ${gated ? 'seg-card--gated' : ''}`}
       style={{ '--seg-color': displayColor } as CSSProperties}
-      onClick={activate}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={0}
-      aria-pressed={gated ? undefined : selected}
-      aria-disabled={gated || undefined}
       aria-busy={updating || undefined}
     >
+      {activate && (
+        <button
+          type="button"
+          className="seg-card__select"
+          onClick={activate}
+          aria-pressed={selected ?? false}
+          aria-label={`Select ${displayName} segment — ${segment.count.toLocaleString()} borrowers`}
+        />
+      )}
       {selected && emanateKey > 0 && (
         <span key={emanateKey} className="seg-card__emanate" aria-hidden="true" />
       )}
@@ -145,11 +156,7 @@ export function SegmentCard({ segment, selected, updating, onClick }: SegmentCar
           </span>
         )}
         {!gated && !hasNoBorrowers && <span>avg {segment.avg_score}</span>}
-        <span
-          className="seg-card__evidence"
-          onClick={(event) => event.stopPropagation()}
-          onKeyDown={(event) => event.stopPropagation()}
-        >
+        <span className="seg-card__evidence">
           <EvidenceChip source={evidenceSource} title={`Evidence for ${displayName}`}>
             evidence
           </EvidenceChip>
@@ -163,12 +170,7 @@ export function SegmentCard({ segment, selected, updating, onClick }: SegmentCar
               {loanProductMix.map((facet) => {
                 const label = FACET_LABELS[facet.value] ?? facet.value;
                 return (
-                  <span
-                    key={`product-${facet.value}`}
-                    className="seg-card__facet-chip"
-                    onClick={(event) => event.stopPropagation()}
-                    onKeyDown={(event) => event.stopPropagation()}
-                  >
+                  <span key={`product-${facet.value}`} className="seg-card__facet-chip">
                     <EvidenceChip source={DRAWER_SOURCES.loanProductType}>
                       {label} {facet.count.toLocaleString()}
                     </EvidenceChip>
@@ -183,12 +185,7 @@ export function SegmentCard({ segment, selected, updating, onClick }: SegmentCar
               {originationChannelMix.map((facet) => {
                 const label = FACET_LABELS[facet.value] ?? facet.value;
                 return (
-                  <span
-                    key={`channel-${facet.value}`}
-                    className="seg-card__facet-chip"
-                    onClick={(event) => event.stopPropagation()}
-                    onKeyDown={(event) => event.stopPropagation()}
-                  >
+                  <span key={`channel-${facet.value}`} className="seg-card__facet-chip">
                     <EvidenceChip source={DRAWER_SOURCES.originationChannel}>
                       {label} {facet.count.toLocaleString()}
                     </EvidenceChip>

--- a/frontend/src/design-system/components.css
+++ b/frontend/src/design-system/components.css
@@ -836,11 +836,17 @@ kbd {
    ============================================================ */
 .seg-card {
   position: relative;
+  display: flex;
+  flex-direction: column;
   background: var(--bg-2);
   border: 1px solid var(--line-1);
   border-radius: var(--r-lg);
   padding: var(--pad-card);
-  cursor: pointer;
+  /* Not `pointer`: the card is a container, not a control. The pointer
+     affordance belongs to `.seg-card__select` (the stretched selection
+     button) and to the chips, so the cursor never promises a click that
+     does nothing — e.g. on a gated card, which has no select button. */
+  cursor: default;
   transition: all var(--dur-base) var(--ease);
   overflow: hidden;
   text-align: left;
@@ -848,6 +854,39 @@ kbd {
   min-block-size: 184px;
   color: inherit;
   font-family: inherit;
+}
+/* Whole-card selection target. See the SegmentCard.tsx header comment: the
+   prototype's "the whole card selects" contract is preserved by stretching a
+   real <button> across the card instead of putting `role="button"` on the
+   card itself. Sits above the card content (z-index 1) so any click that is
+   not on a chip selects; the chips are lifted to z-index 2 below. */
+.seg-card__select {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  appearance: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  border-radius: var(--r-lg);
+  cursor: pointer;
+}
+/* Inset the focus ring: the card clips overflow, so the global
+   `:focus-visible { outline-offset: 2px }` would be cut off. */
+.seg-card__select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -3px;
+  border-radius: var(--r-lg);
+}
+/* Chips keep their own click target above the selection overlay. This is what
+   replaced six `stopPropagation()` handlers: the evidence and breakdown chips
+   are no longer descendants of the selection control, so their clicks cannot
+   reach it in the first place. */
+.seg-card__evidence,
+.seg-card__facet-chip {
+  position: relative;
+  z-index: 2;
 }
 .seg-card::before {
   content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
@@ -869,10 +908,10 @@ kbd {
 }
 /* S1.3 gated segment panel: source not connected / not licensed. The card
    stays in the grid (registry completeness) but reads as inert — dashed
-   border, muted accent, default cursor, no hover lift. Counts are never
-   fabricated; the em-dash count + warning chip say why. */
+   border, muted accent, no hover lift, and no `.seg-card__select` button at
+   all (SegmentCard.tsx renders none), so there is nothing to click. Counts
+   are never fabricated; the em-dash count + warning chip say why. */
 .seg-card--gated {
-  cursor: default;
   border-style: dashed;
   border-color: var(--line-2);
 }
@@ -1005,14 +1044,19 @@ kbd {
 
 /* S1.6 — borrower-dimension facet rows (loan product + origination channel).
  * Sits under the meta row; one row per dimension: a small caps label followed
- * by `.chip chip--neutral` chips. Chips are evidence-clickable spans (not
- * buttons — the card itself is a <button>, so nesting is invalid) that open
- * the EvidenceDrawer without toggling card selection. */
+ * by evidence chips that open the EvidenceDrawer without toggling selection.
+ *
+ * `margin-top: auto` pins the breakdown to the bottom edge of the card (the
+ * card is a column flex container) so the card's slack collects in the middle
+ * instead of pushing chips toward the geometric centre. That matters because
+ * the centre is where an untargeted click — a user's, or Playwright's default
+ * click point — lands: it should hit the selection overlay, not a chip. */
 .seg-card__facets {
   display: flex;
   flex-direction: column;
   gap: var(--sp-2);
-  margin-top: var(--sp-3);
+  margin-top: auto;
+  padding-top: var(--sp-3);
 }
 .seg-card__facet-row {
   display: flex;
@@ -1029,16 +1073,12 @@ kbd {
   color: var(--text-3);
   margin-inline-end: var(--sp-1);
 }
+/* Layout wrapper only. The hover and focus treatments live on the
+   `.evidence-chip` button inside it — the wrapper is a <span> with no border
+   and no tabindex, so styling its own :hover/:focus-visible painted nothing. */
 .seg-card__facet-chip {
-  cursor: pointer;
-}
-.seg-card__facet-chip:hover {
-  border-color: var(--line-2);
-  color: var(--text-1);
-}
-.seg-card__facet-chip:focus-visible {
-  outline: calc(var(--sp-1) / 2) solid var(--accent);
-  outline-offset: calc(var(--sp-1) / 2);
+  display: inline-flex;
+  min-inline-size: 0;
 }
 
 /* ============================================================

--- a/frontend/tests/e2e/demo_visual.spec.ts
+++ b/frontend/tests/e2e/demo_visual.spec.ts
@@ -105,7 +105,9 @@ async function discoverMapDrillTarget(
 }
 
 async function clickSegmentCard(page: Page, label: string) {
-  await page.locator('.seg-card', { hasText: label }).click();
+  // `.seg-card__select` is the card's selection button; clicking the card box
+  // targets its centre, which the breakdown chips can occupy.
+  await page.locator('.seg-card', { hasText: label }).locator('.seg-card__select').click();
 }
 
 async function clickSvgRegion(page: Page, target: Locator, label: string) {

--- a/frontend/tests/e2e/live_hardening_regressions.spec.ts
+++ b/frontend/tests/e2e/live_hardening_regressions.spec.ts
@@ -184,7 +184,9 @@ function leadQueueApiPathFromRoute(route: string): string {
 async function clickSegment(page: Page, label: string): Promise<void> {
   const card = page.locator('.seg-card', { hasText: label }).first();
   await expect(card, `segment card ${label}`).toBeVisible({ timeout: 45_000 });
-  await card.click();
+  // `.seg-card__select` is the card's selection button; clicking the card box
+  // targets its centre, which the breakdown chips can occupy.
+  await card.locator('.seg-card__select').click();
 }
 
 async function expectClearFiltersState(page: Page, disabled: boolean): Promise<void> {
@@ -272,6 +274,67 @@ test('Segment Intelligence stacks selected segments into an any-match cohort and
   expect(url.searchParams.get('segment_codes') ?? url.searchParams.get('segments')).toMatch(/itm/);
   expect(url.searchParams.get('segment_codes') ?? url.searchParams.get('segments')).toMatch(/listed/);
   await expect(page.getByRole('button', { name: /SEGMENT:\s*2 segments selected \(all selected\)/i })).toBeVisible({ timeout: 20_000 });
+});
+
+/**
+ * Regression: clicking a segment card's geometric centre used to open the
+ * Evidence Drawer instead of selecting. The card was a `role="button"` host
+ * whose evidence/breakdown chips called `stopPropagation()`, and on
+ * deployments whose data renders the product/channel rows those chips occupied
+ * the centre — the point an untargeted click (a user's, or Playwright's
+ * default) lands on. Selection now lives on a stretched `.seg-card__select`
+ * button that the chips sit above, so the centre always selects.
+ */
+test('clicking the centre of a segment card selects it instead of opening evidence', async ({ page }) => {
+  await gotoApp(page, '/segment-intelligence');
+  const card = page.locator('.seg-card', { hasText: 'Prime Refi Candidates' }).first();
+  await expect(card, 'segment card should be ready').toBeVisible({ timeout: 45_000 });
+  const select = card.locator('.seg-card__select');
+  await expect(select).toHaveAttribute('aria-pressed', 'false');
+
+  // What is actually under the card's centre point? Anything that is not the
+  // selection button means an untargeted click does something else.
+  const centreOwner = await card.evaluate((node) => {
+    const rect = node.getBoundingClientRect();
+    const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    return {
+      isSelect: hit?.classList.contains('seg-card__select') ?? false,
+      hit: hit ? `${hit.tagName.toLowerCase()}.${hit.className}` : 'none',
+    };
+  });
+  expect(centreOwner.isSelect, `card centre should be the selection button, got ${centreOwner.hit}`).toBe(true);
+
+  const box = await card.boundingBox();
+  expect(box, 'segment card should have a layout box').not.toBeNull();
+  await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
+
+  await expect(select).toHaveAttribute('aria-pressed', 'true', { timeout: 20_000 });
+  await expect(page).toHaveURL(/segment_codes=[^&]*itm/, { timeout: 20_000 });
+  await expect(page.locator('.drawer-scrim.is-open'), 'centre click must not open the Evidence Drawer').toHaveCount(0);
+});
+
+/**
+ * The drawer is modal, so a stray open blocks the page until it is dismissed.
+ * Both dismissal paths must work: the scrim and Escape.
+ */
+test('the Evidence Drawer is dismissible by scrim click and by Escape', async ({ page }) => {
+  await gotoApp(page, '/segment-intelligence');
+  const chip = page.locator('.seg-card .evidence-chip').first();
+  await expect(chip, 'segment evidence chip should be ready').toBeVisible({ timeout: 45_000 });
+
+  await chip.click();
+  await expect(page.locator('.drawer.is-open')).toBeVisible({ timeout: 20_000 });
+  await page.locator('.drawer-scrim.is-open').click({ position: { x: 8, y: 8 } });
+  await expect(page.locator('.drawer-scrim.is-open')).toHaveCount(0, { timeout: 20_000 });
+
+  await chip.click();
+  await expect(page.locator('.drawer.is-open')).toBeVisible({ timeout: 20_000 });
+  await page.keyboard.press('Escape');
+  await expect(page.locator('.drawer-scrim.is-open')).toHaveCount(0, { timeout: 20_000 });
+
+  // Page is usable again: selection still works after the drawer closes.
+  await clickSegment(page, 'Prime Refi Candidates');
+  await expect(page).toHaveURL(/segment_codes=[^&]*itm/, { timeout: 20_000 });
 });
 
 test('segment any/all API counts are de-duplicated and intersection-safe', async ({ request }) => {

--- a/frontend/tests/e2e/real_data.spec.ts
+++ b/frontend/tests/e2e/real_data.spec.ts
@@ -216,10 +216,17 @@ function expectMaskedCotalityIds(payload: unknown, label: string) {
   }
 }
 
+/**
+ * Click the segment card's selection control, not the card box. `.seg-card`
+ * clicks land on the card's geometric centre, which the product/channel
+ * breakdown chips can occupy on deployments whose data renders them — that
+ * click opens the Evidence Drawer instead of selecting. `.seg-card__select`
+ * is the stretched selection button and is environment-independent.
+ */
 async function clickSegmentCard(page: Page, label: string) {
   const card = page.locator('.seg-card', { hasText: label });
   await expect(card, `segment card ${label} should be ready`).toBeVisible({ timeout: 45_000 });
-  await card.click();
+  await card.locator('.seg-card__select').click();
 }
 
 async function chooseFilter(page: Page, label: string, value: string) {


### PR DESCRIPTION
## The bug

Clicking a segment card's **centre** could open the Evidence Drawer instead of selecting the segment. The drawer's modal scrim then intercepted the next click, so the page read as wedged.

Verified live before the fix, on `/segment-intelligence`: a centre click left `aria-pressed="false"`, fired zero API calls, and opened `.drawer-scrim.is-open`. Clicking `.seg-card__title` selected correctly. Pre-existing on `main`, not a regression.

**Mechanism.** `SegmentCard` was a `role="button"` host whose evidence and product/channel breakdown chips called `stopPropagation()` (6 call sites). On deployments whose data renders the breakdown rows, those chips occupy the card's geometric centre — the point an untargeted click lands on.

## The decision

**Keep the whole card selectable.** `design_files/Module 0 Prototype.html:1148-1165` makes the entire card the selection target, and that contract is preserved: a click anywhere that is not a chip selects.

What changed is only *which element carries the button role*. The prototype's card has zero interactive children — its meta row is three plain `<span>`s — so `role="button"` was valid there. Module 0 later added the S1.3 evidence chip and S1.6 breakdown chips inside it, which turned the same markup into an axe `nested-interactive` violation *and* a click-routing trap. The contract wasn't the problem; the composition was.

Selection now lives on `.seg-card__select`: a real `<button>` stretched across the card (`position:absolute; inset:0; z-index:1`) that owns `onClick`, `aria-pressed`, and the native Enter/Space contract. Chips sit above it at `z-index:2`, so they are click targets in their own right — all six `stopPropagation()` calls and the hand-rolled keydown handler are gone. The selection control also gets a stable accessible name (`Select <segment> segment — N borrowers`) instead of the card's entire text content. Gated cards render no selection control at all.

`.seg-card__facets` is now bottom-anchored (`margin-top:auto` on a column-flex card) so the breakdown vacates the card's centre.

## Evidence

Hit-tested in Chromium at 1440×900 against the repo's real `tokens.css` + `components.css`, six cards including a gated one:

| | centre resolves to | centre clicks that selected | that opened evidence |
|---|---|---|---|
| before | `span.evidence-chip__label` on 1 of 5 cards | 4 / 5 | 1 / 5 |
| after | `button.seg-card__select` on 5 of 5 | 5 / 5 | 0 / 5 |

Overlay covers all probe points; every chip is still topmost at its own centre (6/6, 4/4, 1/1, 2/2, 6/6); gated card exposes no selection control.

## Evidence Drawer

No change needed — it already dismisses on scrim click (`EvidenceDrawer.tsx`) and on Escape (`useFocusTrap`), and both are unit-tested. What looked like a wedge was correct modal behaviour. Added a live regression that opens the drawer, closes it each way, and confirms selection still works afterwards.

## Tests

- 4 new/rewritten `SegmentCard` unit tests: selection button composition, chips outside the selection button, card-surface click selects, `aria-pressed` toggles, gated card exposes no control.
- Two new live regressions in `live_hardening_regressions.spec.ts`: centre-click selects rather than opening evidence, and both drawer dismissal paths.
- The three Playwright helpers (`real_data`, `demo_visual`, `live_hardening_regressions`) now click `.seg-card__select` — the actual selection control — instead of the card box.

⚠️ **Merge conflict warning:** branch `codex/intelligence-trust-ux` (commit `5e55d491`) changed `real_data.spec.ts`'s `clickSegmentCard` to click `.seg-card__title` as a workaround for this same bug. Reconcile to `.seg-card__select`; the title-click workaround is no longer needed.

## Validation

695/695 vitest · `npm run lint` clean (eslint + CSS-literal guard) · `npm run build` passes · both new Playwright tests discovered. `tests/e2e/` is covered by neither eslint nor `tsc` in this repo, so the changed specs were typechecked separately — zero errors in the additions.

Deployed and verified on dev (`mip-app` deployment `01f1907d29c01db4ba3731c775d78dd3`): the live route chunk and CSS bundle both carry the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
