### PR TITLE
docs(deploy): ratify prebuilt-dist App source contract after 2026-08-05 rebuild incident

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -2,9 +2,20 @@
 #
 # Command: uvicorn (via backend.runtime) honouring DATABRICKS_APP_PORT.
 # Build:   `scripts/deploy.sh` builds the React bundle under the audited CI
-#          Node version before bundle sync. The uploaded App source deliberately
-#          has no root npm manifest or runtime build command; FastAPI serves the
-#          prebuilt `frontend/dist/` bundle at `/`.
+#          Node version before bundle sync; FastAPI serves the prebuilt
+#          `frontend/dist/` bundle at `/`. The PROMOTED App source must carry
+#          no root npm manifest: if a root package.json reaches the tree, the
+#          Databricks Apps build phase runs its `build` script on every
+#          deployment with the platform Node (22.16 vs the audited 22.22 —
+#          the engines mismatch is only an EBADENGINE warning, so the build
+#          SUCCEEDS) and recompiles frontend/dist from the uploaded
+#          frontend/src, replacing the prebuilt bundle. That silent rebuild
+#          is what kept reverting a dist-only hotfix on 2026-08-05.
+#          Enforced twice: databricks.yml sync.exclude (upload filter +
+#          server-side delete on current CLI) and
+#          tools/databricks/converge_static_app_source.py immediately before
+#          every governed App promotion. Contract details:
+#          docs/deployment.md "App source contract".
 # Env:     workspace identity + resource bindings (see databricks.yml
 #          `resources.apps.mip_app.resources`) are surfaced here as env
 #          vars. Backend reads them via backend/config/settings.py +

--- a/databricks.yml
+++ b/databricks.yml
@@ -58,6 +58,21 @@ sync:
   # audited React Router release requires Node 22.22 for package installation.
   # Keep the repository-level npm wrapper out of the uploaded App source so
   # the managed runtime consumes only the already-validated static build.
+  #
+  # Load-bearing, not hygiene (2026-08-05 incident): a root package.json in
+  # the App source makes the Apps build phase run its `build` script on every
+  # deployment, recompiling frontend/dist from the uploaded sources on the
+  # unaudited platform Node (EBADENGINE demotes the engines mismatch to a
+  # warning, so the rebuild succeeds) and overwriting the prebuilt bundle.
+  # Verified on CLI v1.10.0 (2026-08-05 scratch-bundle experiment): a bundle
+  # deploy honours this exclusion both ways — the manifests are never
+  # uploaded AND previously-uploaded copies are deleted from the target tree,
+  # with or without local sync-snapshot state. Residual exposure is deploys
+  # from checkouts predating this block (that is how the manifests returned
+  # to the paychex tree on 2026-08-05) and App promotions outside
+  # scripts/deploy.sh; the governed path closes both by running
+  # tools/databricks/converge_static_app_source.py right before every
+  # promotion. Full story: docs/deployment.md "App source contract".
   exclude:
     - /package.json
     - /package-lock.json

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,6 +18,57 @@ npm --prefix frontend run build
 
 FastAPI serves `frontend/dist` automatically if present.
 
+## App source contract (prebuilt frontend, no root npm manifest)
+
+The Databricks App serves the **prebuilt** `frontend/dist/` bundle compiled by
+`scripts/deploy.sh` under the audited CI Node version. The promoted App source
+tree must never contain a root `package.json`/`package-lock.json`: when a root
+`package.json` with a `build` script is present, the Databricks Apps build
+phase runs it on every deployment with the platform's own Node (22.16 today,
+vs the audited 22.22 — the engines mismatch is only an EBADENGINE warning, so
+the build *succeeds*) and recompiles `frontend/dist/` from the uploaded
+`frontend/src/**`, silently replacing the prebuilt bundle. This is how a
+dist-only hotfix kept reverting on the paychex dev workspace on 2026-08-05
+(~5 hours of debugging): the tree still carried a stale root manifest, so
+every deployment rebuilt the old sources over the freshly-synced dist.
+
+Enforcement is two-layer, pinned by
+`tests/unit/test_static_app_bundle_contract.py`:
+
+1. **`databricks.yml` `sync.exclude`** keeps `/package.json` and
+   `/package-lock.json` out of bundle uploads. Verified on Databricks CLI
+   v1.10.0 (2026-08-05 scratch-bundle experiment): a bundle deploy with the
+   exclusion not only skips uploading the manifests but also **deletes
+   previously-uploaded copies** from the target tree, with or without local
+   sync-snapshot state. The exclusion cannot protect a tree that only ever
+   receives deploys from checkouts predating it — the 2026-08-05 paychex
+   re-upload came from an old-lineage worktree whose `databricks.yml` had
+   neither this exclusion nor the current workspace-host anchor.
+2. **`tools/databricks/converge_static_app_source.py`** runs inside
+   `scripts/deploy.sh` immediately before the App promotion: it requires a
+   non-empty `frontend/dist/index.html` in the uploaded tree and deletes any
+   root Node manifests that reached it by other means. It is also the
+   governed way to clean a stale tree by hand — it validates the exact
+   bundle-files path shape and touches nothing but the two manifest files.
+
+Two operational facts to know before assembling any ad-hoc App source tree
+(emergency recovery only — the command of record is `./scripts/deploy.sh`):
+
+- **Source lister budget.** The Apps deployment source snapshot has a hard
+  60-second listing budget; the failure reads `Failed to snapshot source
+  code ... list files timed out after 1m0s. Please consider reducing the
+  number of files in your app.` The full repo tree (~2,400 files) can exceed
+  it on slow workspaces, while ~1,400 files listed fine on the same
+  workspace. Keep ad-hoc source trees well under that.
+- **The frontend typecheck reaches outside `frontend/`.** Two src-co-located
+  Vitest specs (`frontend/src/lib/campaignPrefill.test.ts`,
+  `frontend/src/lib/opportunityScore.test.ts`) import
+  `../../../tests/fixtures/campaign_prefill_segment_parity.json` and
+  `../../../tests/fixtures/score_band_golden.json`, and `tsc -b` typechecks
+  all of `src/**`. Any tree that performs (or accidentally triggers) a
+  frontend build must therefore include those root `tests/fixtures/` files,
+  or the build fails with TS2307.
+
 ## Databricks App
 
 1. Fill `.env.local` with workspace, warehouse, lender/runtime values, and the

--- a/tests/unit/test_documentation_contract.py
+++ b/tests/unit/test_documentation_contract.py
@@ -132,6 +132,33 @@ def test_current_operator_docs_never_advertise_bare_mutable_deployment() -> None
         assert "./scripts/deploy.sh -t dev" in text or "make deploy-dev" in text
 
 
+def test_deployment_doc_pins_the_prebuilt_app_source_contract() -> None:
+    deployment = _read(ROOT / "docs" / "deployment.md")
+    app_yaml = _read(ROOT / "app.yaml")
+    bundle = _read(ROOT / "databricks.yml")
+
+    for required in (
+        "## App source contract (prebuilt frontend, no root npm manifest)",
+        "converge_static_app_source.py",
+        "list files timed out after 1m0s",
+        "campaignPrefill.test.ts",
+        "opportunityScore.test.ts",
+        "campaign_prefill_segment_parity.json",
+        "score_band_golden.json",
+        "EBADENGINE",
+    ):
+        assert required in deployment
+    # app.yaml's pre-2026-08-05 claim ("deliberately has no root npm manifest
+    # or runtime build command") was falsified in the field: a stale root
+    # manifest in the promoted tree DOES trigger the platform npm rebuild,
+    # which overwrites the prebuilt dist. Both config surfaces must document
+    # the trigger and point at the contract instead of denying the hazard.
+    assert "deliberately has no root npm manifest" not in app_yaml
+    for surface in (app_yaml, bundle):
+        assert "converge_static_app_source" in surface
+        assert 'docs/deployment.md "App source contract"' in surface
+
+
 def test_otlp_operator_docs_use_the_same_governed_target() -> None:
     for relative in (
         "docs/observability.md",


### PR DESCRIPTION
## Why

`databricks.yml` excludes `/package.json` + `/package-lock.json` from sync, and `app.yaml` claimed the uploaded App source "deliberately has no root npm manifest or runtime build command." Both were false in practice on the paychex dev deployment (discovered 2026-08-05): the tree contained both manifests, and because the root `package.json` has a `build` script, the Databricks Apps build phase rebuilt `frontend/dist` from the uploaded `frontend/src` on every deployment (platform Node 22.16 — EBADENGINE is only a warning), silently reverting a dist-only hotfix for ~5 hours.

## Root cause (established, not guessed)

- The manifests were first synced by the 2026-04-20 scaffold (workspace `created_at` 2026-04-21).
- The sync excludes + the `converge_static_app_source` promotion guard landed 2026-07-24 — but the bundle host anchor had already flipped to pr105-staging on 2026-07-16, so **no post-hardening deploy ever targeted paychex**.
- Workspace `modified_at` 2026-08-05 03:13Z: a bundle deploy from an old-lineage worktree (whose `databricks.yml` had neither the exclude nor the pr105 anchor — which is also why it could still reach paychex) re-uploaded them fresh.
- Empirical check (scratch bundle, CLI v1.10.0, 4-phase matrix): the exclusion works and is even self-healing — a bundle deploy never uploads the excluded manifests **and deletes previously-uploaded copies**, with or without local sync-snapshot state. The fossil survived only because nothing with the exclusion ever deployed to that tree.

## What changed

- **app.yaml** — replaces the falsified claim with the real trigger mechanics + both enforcement layers.
- **databricks.yml** — documents why the exclusion is load-bearing, the verified CLI semantics, and the residual exposure (pre-exclusion checkouts; promotions outside `scripts/deploy.sh`).
- **docs/deployment.md** — new "App source contract" section, also capturing the Apps source-lister 60s budget (`list files timed out after 1m0s`; full repo tree ~2,400 files can exceed it) and the `tsc -b` hard dependency on root `tests/fixtures/` via the two src-co-located specs (`campaignPrefill.test.ts`, `opportunityScore.test.ts` → TS2307 on any rebuild without them).
- **tests/unit/test_documentation_contract.py** — pins the new section and bans the falsified claim from returning.

## Out-of-band remediation (same day)

- Stale `package.json` + `package-lock.json` **deleted from the paychex `dev/files` tree** via the governed `converge_static_app_source` tool (which also verified a non-empty prebuilt `frontend/dist/index.html`). Next promotion from that tree will serve the prebuilt dist with no platform rebuild.
- pr105's CI-governed tree verified **already clean** — the existing exclude + converge machinery works where it runs.

## Validation

- `pytest tests/unit/test_documentation_contract.py tests/unit/test_static_app_bundle_contract.py` — 17 passed.
- Full `pytest tests/unit`: one pre-existing, environment-only failure (`test_first_install_dry_run_executes_no_databricks_operations`, system `python3` lacks `dotenv` on this machine; fails identically on a pristine tree, passes in CI).
- `ruff` clean; `tools/verify_scaffold.py` OK; `databricks bundle validate -t ci` passes after `render_sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)