### PR TITLE
fix(genie): driver-rich answers for all-segments top-candidate questions + drop API plumbing copy

### DIFF
--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -44,9 +44,11 @@ from backend.services.repositories.databricks_genie_canonical import (
     _CANONICAL_RETENTION_COMPETITOR_LIEN_LIST_SQL,
     _CANONICAL_RETENTION_ELIGIBILITY_SUMMARY_BY_STATE_SQL,
     _CANONICAL_RETENTION_ELIGIBILITY_SUMMARY_GLOBAL_SQL,
+    _CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL,
     _CANONICAL_TOP_BORROWERS_BY_STATE_INTENT_SQL,
     _CANONICAL_TOP_BORROWERS_BY_STATE_SQL,
     _CANONICAL_TOP_BORROWERS_GLOBAL_INTENT_SQL,
+    _CANONICAL_TOP_BORROWERS_GLOBAL_SQL,
     _canonical_cash_out_state_scope,
     _canonical_heloc_zip_scope,
     _canonical_in_the_money_count_scope,
@@ -57,6 +59,8 @@ from backend.services.repositories.databricks_genie_canonical import (
     _canonical_msa_score_scope,
     _canonical_specific_top_borrowers_global_scope,
     _canonical_specific_top_borrowers_state_scope,
+    _canonical_top_borrowers_all_segments_scope,
+    _canonical_top_borrowers_global_scope,
     _canonical_top_borrowers_state_scope,
     _current_footprint_label,
     _retention_competitor_lien_list_question,
@@ -964,6 +968,83 @@ def _canonical_genie_answer(
             metric_value=metric_value,
             table_rows=response_rows,
         )
+    if _canonical_top_borrowers_all_segments_scope(question):
+        try:
+            rows = sql_client.execute(_CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL)
+        except DatabricksSqlError as exc:
+            _emit_genie_warning("canonical_genie_top_borrowers_all_segments_failed", exc=exc)
+            return None
+        rows = _redact_genie_rows(rows) or []
+        trusted_assets = [borrower_asset]
+        question_hash = _genie_question_hash(question)
+        proof = _build_genie_proof(
+            sql_query=_CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL,
+            trusted_assets=trusted_assets,
+            rows=rows,
+            question=question,
+            conversation_id=result.conversation_id,
+            message_id=result.message_id,
+            elapsed_ms=result.elapsed_ms,
+        )
+        visualization = _plan_genie_visualization(question, rows)
+        actions = _suggest_genie_actions(
+            question=question,
+            rows=rows,
+            trusted_assets=trusted_assets,
+            visualization=visualization,
+            conversation_id=result.conversation_id,
+            message_id=result.message_id,
+            question_hash=question_hash,
+            sql_query=_CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL,
+            source="trusted_sql",
+        )
+        if rows:
+            top = rows[0]
+            top_offer = offer_display_label(
+                str(top.get("recommended_offer_code") or ""),
+                str(top.get("recommended_offer") or ""),
+            )
+            top_why = str(top.get("why_now") or "").strip()
+            top_why_clause = f" Why now: {top_why}." if top_why else ""
+            answer = (
+                f"I ranked the top {len(rows)} marketing-eligible, opt-in borrowers "
+                f"across every segment from {borrower_asset}, ordered by opportunity "
+                "score with rate-spread economics as the tiebreaker. Each row lists "
+                "the borrower's segments, the live signals that make them a strong "
+                "candidate right now (rate spread, equity, listing, multi-property, "
+                "retention, HELOC propensity), and the governed next-best offer those "
+                "signals drive. The current first borrower is masked "
+                f"{top.get('borrower_id')} in {top.get('city')}, {top.get('state')} "
+                f"with opportunity score {int(top.get('opportunity_score') or 0):,}; "
+                f"the recommended offer is {top_offer}.{top_why_clause} Offers follow "
+                "the governed next-best-offer rules — deep equity favors cash-out, a "
+                "wide positive rate spread favors a rate-improvement refinance, an "
+                "active listing favors purchase financing, and retention risk favors "
+                "recapture outreach — and every recommendation still requires human "
+                "approval in the Lead Queue."
+            )
+        else:
+            answer = (
+                "The trusted borrower table returned no marketing-eligible, opt-in "
+                "borrowers across the segment portfolio for the current refreshed "
+                "coverage."
+            )
+        return GenieMessageResponse(
+            conversation_id=result.conversation_id,
+            message_id=result.message_id,
+            elapsed_ms=result.elapsed_ms,
+            question_hash=question_hash,
+            question=question,
+            answer=answer,
+            source="trusted_sql",
+            trusted_assets=trusted_assets,
+            sql_query=_CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL,
+            row_count=len(rows),
+            proof=proof,
+            visualization=visualization,
+            actions=actions,
+            table_rows=rows,
+        )
     top_borrower_state_scope = _canonical_top_borrowers_state_scope(question)
     if top_borrower_state_scope is not None:
         state_name, state_code = top_borrower_state_scope
@@ -1022,6 +1103,65 @@ def _canonical_genie_answer(
             source="trusted_sql",
             trusted_assets=trusted_assets,
             sql_query=_CANONICAL_TOP_BORROWERS_BY_STATE_SQL,
+            row_count=len(rows),
+            proof=proof,
+            visualization=visualization,
+            actions=actions,
+            table_rows=rows,
+        )
+    if _canonical_top_borrowers_global_scope(question):
+        try:
+            rows = sql_client.execute(_CANONICAL_TOP_BORROWERS_GLOBAL_SQL)
+        except DatabricksSqlError as exc:
+            _emit_genie_warning("canonical_genie_top_borrowers_global_failed", exc=exc)
+            return None
+        rows = _redact_genie_rows(rows) or []
+        trusted_assets = [lead_population_asset]
+        question_hash = _genie_question_hash(question)
+        proof = _build_genie_proof(
+            sql_query=_CANONICAL_TOP_BORROWERS_GLOBAL_SQL,
+            trusted_assets=trusted_assets,
+            rows=rows,
+            question=question,
+            conversation_id=result.conversation_id,
+            message_id=result.message_id,
+            elapsed_ms=result.elapsed_ms,
+        )
+        visualization = _plan_genie_visualization(question, rows)
+        actions = _suggest_genie_actions(
+            question=question,
+            rows=rows,
+            trusted_assets=trusted_assets,
+            visualization=visualization,
+            conversation_id=result.conversation_id,
+            message_id=result.message_id,
+            question_hash=question_hash,
+            sql_query=_CANONICAL_TOP_BORROWERS_GLOBAL_SQL,
+            source="trusted_sql",
+        )
+        if rows:
+            top = rows[0]
+            answer = (
+                f"I ranked the top {len(rows)} marketing-eligible borrowers by lead "
+                f"score from {lead_population_asset}. The current first borrower is "
+                f"masked {top.get('borrower_id')} with lead score "
+                f"{int(top.get('lead_score') or 0):,}."
+            )
+        else:
+            answer = (
+                "The ranked lead population returned no marketing-eligible borrower "
+                "rows for the current refreshed coverage."
+            )
+        return GenieMessageResponse(
+            conversation_id=result.conversation_id,
+            message_id=result.message_id,
+            elapsed_ms=result.elapsed_ms,
+            question_hash=question_hash,
+            question=question,
+            answer=answer,
+            source="trusted_sql",
+            trusted_assets=trusted_assets,
+            sql_query=_CANONICAL_TOP_BORROWERS_GLOBAL_SQL,
             row_count=len(rows),
             proof=proof,
             visualization=visualization,

--- a/backend/services/repositories/databricks_genie_canonical.py
+++ b/backend/services/repositories/databricks_genie_canonical.py
@@ -530,6 +530,48 @@ ORDER BY opportunity_score DESC, rank_overall ASC, borrower_id ASC
 LIMIT 10
 """.strip()
 
+# Driver-rich variant of the global top-borrowers ranking for "top candidates
+# across all segments + what makes each one strong + which offer" questions.
+# Each row carries a SQL-computed ``why_now`` driver summary so the per-borrower
+# rationale is grounded in gold columns, never model prose.
+_CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL = f"""
+SELECT borrower_id
+     , display_name
+     , city
+     , state
+     , zip
+     , array_join(segment_codes, ', ') AS segments
+     , opportunity_score
+     , rate_spread_bps
+     , equity_pct
+     , equity_estimate
+     , concat_ws(' | ',
+         CASE
+           WHEN in_the_money = TRUE AND rate_spread_bps IS NOT NULL
+           THEN concat('In the money: +', CAST(CAST(ROUND(rate_spread_bps, 0) AS BIGINT) AS STRING), ' bps rate spread')
+         END,
+         CASE
+           WHEN equity_pct IS NOT NULL AND equity_pct >= 35
+           THEN concat('Strong equity: ', CAST(CAST(ROUND(equity_pct, 0) AS BIGINT) AS STRING), '%')
+         END,
+         CASE WHEN listed_for_sale = TRUE THEN 'Listed for sale' END,
+         CASE
+           WHEN related_property_count IS NOT NULL AND related_property_count >= 2
+           THEN concat('Investor: ', CAST(related_property_count AS STRING), ' related properties')
+         END,
+         CASE WHEN array_contains(segment_codes, 'retention') THEN 'Retention / recapture risk' END,
+         CASE WHEN has_heloc_propensity_trigger = TRUE THEN 'HELOC propensity trigger' END
+       ) AS why_now
+     , recommended_offer_code
+     , recommended_offer
+     , refreshed_at
+FROM {_BORROWER_360}
+WHERE {_ELIGIBLE}
+  AND consent_status = 'opt_in'
+ORDER BY opportunity_score DESC, rate_spread_bps DESC NULLS LAST, borrower_id ASC
+LIMIT 10
+""".strip()
+
 _CANONICAL_TOP_REFI_BORROWERS_BY_STATE_SQL = f"""
 SELECT borrower_id
      , display_name
@@ -2037,11 +2079,40 @@ def _canonical_top_borrowers_state_scope(question: str) -> tuple[str, str] | Non
     return _canonical_itm_state_scope(question)
 
 
+_ALL_SEGMENTS_SCOPE_TERMS = (
+    "across all segments",
+    "across segments",
+    "across every segment",
+    "all segments",
+    "every segment",
+    "across the portfolio",
+    "entire portfolio",
+    "whole portfolio",
+    "portfolio-wide",
+    "portfolio wide",
+)
+
+# "Why" language that asks for per-borrower rationale, not just a ranking.
+_TOP_BORROWER_WHY_TERMS = (
+    "why",
+    "what makes",
+    "reason",
+    "rationale",
+    "explain",
+    "driver",
+    "justif",
+)
+
+
+def _has_all_segments_scope(q: str) -> bool:
+    return any(term in q for term in _ALL_SEGMENTS_SCOPE_TERMS)
+
+
 def _canonical_top_borrowers_global_scope(question: str) -> bool:
     q = _normalized_question(question)
     if _retention_competitor_lien_list_question(question):
         return False
-    if not _has_global_coverage_scope(q):
+    if not (_has_global_coverage_scope(q) or _has_all_segments_scope(q)):
         return False
     if _canonical_itm_state_scope(question) is not None:
         return False
@@ -2049,12 +2120,41 @@ def _canonical_top_borrowers_global_scope(question: str) -> bool:
         return False
     return (
         _has_rank_intent(q)
-        and any(term in q for term in ("borrower", "borrowers", "lead", "leads"))
+        and any(
+            term in q
+            for term in ("borrower", "borrowers", "lead", "leads", "candidate", "candidates")
+        )
         and (
-            any(term in q for term in ("lead score", "opportunity score", "score", "offer", "any offer"))
+            any(
+                term in q
+                for term in (
+                    "lead score",
+                    "opportunity score",
+                    "score",
+                    "offer",
+                    "any offer",
+                    "candidate",
+                    "candidates",
+                )
+            )
             or "best" in q
         )
     )
+
+
+def _canonical_top_borrowers_all_segments_scope(question: str) -> bool:
+    """Global candidate ranking that also asks WHY each borrower is strong.
+
+    Matches "top borrower candidates across all segments — what makes each one
+    a good candidate and which offer should we make?"-family questions. The
+    per-intent and per-state scopes stay in charge of their narrower shapes.
+    """
+    q = _normalized_question(question)
+    if not _canonical_top_borrowers_global_scope(question):
+        return False
+    if _canonical_listed_purchase_scope(question):
+        return False
+    return any(term in q for term in _TOP_BORROWER_WHY_TERMS)
 
 
 def _specific_top_borrower_intent(q: str) -> str | None:

--- a/backend/services/repositories/databricks_genie_direct.py
+++ b/backend/services/repositories/databricks_genie_direct.py
@@ -64,6 +64,7 @@ from backend.services.repositories.databricks_genie_canonical import (
     _CANONICAL_RETENTION_ELIGIBILITY_SUMMARY_GLOBAL_SQL,
     _CANONICAL_SEGMENT_APPROVAL_RATE_SQL,
     _CANONICAL_STRATEGY_BOARD_SQL,
+    _CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL,
     _CANONICAL_TOP_BORROWERS_BY_STATE_INTENT_SQL,
     _CANONICAL_TOP_BORROWERS_BY_STATE_SQL,
     _CANONICAL_TOP_BORROWERS_GLOBAL_INTENT_SQL,
@@ -112,6 +113,7 @@ from backend.services.repositories.databricks_genie_canonical import (
     _canonical_specific_top_borrowers_global_scope,
     _canonical_specific_top_borrowers_state_scope,
     _canonical_strategy_board_scope,
+    _canonical_top_borrowers_all_segments_scope,
     _canonical_top_borrowers_global_scope,
     _canonical_top_borrowers_state_scope,
     _canonical_top_cash_out_by_equity_scope,
@@ -1014,6 +1016,56 @@ def direct_canonical_response(
             question=question,
             sql_query=_CANONICAL_TOP_BORROWERS_BY_STATE_SQL,
             trusted_assets=[lead_population_asset],
+            rows=rows,
+            answer=answer,
+        )
+
+    if _canonical_top_borrowers_all_segments_scope(question):
+        try:
+            rows = (
+                _redact_genie_rows(sql_client.execute(_CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL))
+                or []
+            )
+        except DatabricksSqlError as exc:
+            _emit_genie_warning(
+                "direct_canonical_genie_top_borrowers_all_segments_failed", exc=exc
+            )
+            return None
+        if rows:
+            top = rows[0]
+            top_offer = offer_display_label(
+                str(top.get("recommended_offer_code") or ""),
+                str(top.get("recommended_offer") or ""),
+            )
+            top_why = str(top.get("why_now") or "").strip()
+            top_why_clause = f" Why now: {top_why}." if top_why else ""
+            answer = (
+                f"I ranked the top {len(rows)} marketing-eligible, opt-in borrowers "
+                f"across every segment from {borrower_asset}, ordered by opportunity "
+                "score with rate-spread economics as the tiebreaker. Each row lists "
+                "the borrower's segments, the live signals that make them a strong "
+                "candidate right now (rate spread, equity, listing, multi-property, "
+                "retention, HELOC propensity), and the governed next-best offer those "
+                "signals drive. The current first borrower is masked "
+                f"{top.get('borrower_id')} in {top.get('city')}, {top.get('state')} "
+                f"with opportunity score {int(top.get('opportunity_score') or 0):,}; "
+                f"the recommended offer is {top_offer}.{top_why_clause} Offers follow "
+                "the governed next-best-offer rules — deep equity favors cash-out, a "
+                "wide positive rate spread favors a rate-improvement refinance, an "
+                "active listing favors purchase financing, and retention risk favors "
+                "recapture outreach — and every recommendation still requires human "
+                "approval in the Lead Queue."
+            )
+        else:
+            answer = (
+                "The trusted borrower table returned no marketing-eligible, opt-in "
+                "borrowers across the segment portfolio for the current refreshed "
+                "coverage."
+            )
+        return trusted_response(
+            question=question,
+            sql_query=_CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL,
+            trusted_assets=[borrower_asset],
             rows=rows,
             answer=answer,
         )

--- a/backend/services/repositories/databricks_genie_policy_helpers.py
+++ b/backend/services/repositories/databricks_genie_policy_helpers.py
@@ -142,7 +142,12 @@ def _trusted_sql_repair_prompt(question: str) -> str:
         "is_current_customer and is_competitor_lien to both be true. For evidence "
         "trigger questions, use the governed signal_type enum exactly as modeled; "
         "competitor-lien evidence is signal_type = 'competitor_lien', never "
-        "'lien-change' or 'competitor'. User question: "
+        "'lien-change' or 'competitor'. For top-borrower or top-candidate ranking "
+        f"questions, return per-borrower rows from {borrower_asset} with "
+        "segment_codes, opportunity_score, rate_spread_bps, equity_pct, and the "
+        "governed recommended_offer columns, filtered to marketing-eligible opt-in "
+        "borrowers and ordered by opportunity_score, so the answer can explain why "
+        "each borrower ranks and which offer applies. User question: "
         f"{question}"
     )
 

--- a/frontend/src/components/mortgage/GenieProgress.test.tsx
+++ b/frontend/src/components/mortgage/GenieProgress.test.tsx
@@ -100,9 +100,9 @@ describe('GenieProgress', () => {
     expect(steps[0].textContent).toContain('Selected the governed mortgage context');
     const sql = container.querySelector('.genie-progress__sql pre');
     expect(sql!.textContent).toBe('SELECT COUNT(*) FROM mip.gold.borrower_360');
-    expect(container.querySelector('.genie-progress__meta')!.textContent).toContain(
-      'Live from the Databricks Genie Conversation API',
-    );
+    // Implementation plumbing ("Live from the Databricks Genie Conversation
+    // API") is not end-user copy — the progress panel renders no meta line.
+    expect(container.querySelector('.genie-progress__meta')).toBeNull();
   });
 
   it('keeps the stage rail indeterminate for an unknown live stage', () => {

--- a/frontend/src/components/mortgage/GenieProgress.tsx
+++ b/frontend/src/components/mortgage/GenieProgress.tsx
@@ -166,14 +166,6 @@ export function GenieProgress({
           <pre className="mono">{sql}</pre>
         </details>
       )}
-
-      <div className="genie-progress__meta">
-        {progress
-          ? 'Live from the Databricks Genie Conversation API.'
-          : dense
-            ? 'The live request is still pending.'
-            : 'The answer will appear after the live request completes.'}
-      </div>
     </div>
   );
 }

--- a/frontend/src/design-system/components.css
+++ b/frontend/src/design-system/components.css
@@ -3021,11 +3021,6 @@ a.lineage-node__chip:focus-visible {
   background: var(--accent);
   box-shadow: 0 0 10px var(--accent-soft);
 }
-.genie-progress__meta {
-  color: var(--text-3);
-  font-size: var(--fs-11);
-  line-height: var(--lh-snug);
-}
 .genie-progress__label { flex: 1; min-width: 0; }
 .genie-progress__elapsed {
   color: var(--text-3);

--- a/genie/mortgage_lead_intelligence_space.yml
+++ b/genie/mortgage_lead_intelligence_space.yml
@@ -582,6 +582,43 @@ example_question_sqls:
         FROM market_scores
         ORDER BY borrowers DESC, avg_score DESC
         LIMIT 5
+  - question: >-
+      What are the top borrower candidates across all segments overall, what
+      makes each one a strong candidate, and which offer should we make to each?
+    sql:
+      - |
+        SELECT
+          borrower_id,
+          city,
+          state,
+          array_join(segment_codes, ', ') AS segments,
+          opportunity_score,
+          rate_spread_bps,
+          equity_pct,
+          concat_ws(' | ',
+            CASE
+              WHEN in_the_money = TRUE AND rate_spread_bps IS NOT NULL
+              THEN concat('In the money: +', CAST(CAST(ROUND(rate_spread_bps, 0) AS BIGINT) AS STRING), ' bps rate spread')
+            END,
+            CASE
+              WHEN equity_pct IS NOT NULL AND equity_pct >= 35
+              THEN concat('Strong equity: ', CAST(CAST(ROUND(equity_pct, 0) AS BIGINT) AS STRING), '%')
+            END,
+            CASE WHEN listed_for_sale = TRUE THEN 'Listed for sale' END,
+            CASE
+              WHEN related_property_count IS NOT NULL AND related_property_count >= 2
+              THEN concat('Investor: ', CAST(related_property_count AS STRING), ' related properties')
+            END,
+            CASE WHEN array_contains(segment_codes, 'retention') THEN 'Retention / recapture risk' END,
+            CASE WHEN has_heloc_propensity_trigger = TRUE THEN 'HELOC propensity trigger' END
+          ) AS why_now,
+          recommended_offer,
+          refreshed_at
+        FROM mip.gold.borrower_360
+        WHERE marketing_eligible = TRUE
+          AND consent_status = 'opt_in'
+        ORDER BY opportunity_score DESC, rate_spread_bps DESC NULLS LAST, borrower_id ASC
+        LIMIT 10
   - question: Which borrowers should I review first for refinance plus HELOC?
     sql:
       - |

--- a/tests/unit/test_genie_direct.py
+++ b/tests/unit/test_genie_direct.py
@@ -154,6 +154,16 @@ class _RetentionEligibilitySqlClient(_UniversalSqlClient):
             "What are the overall best borrowers for any offer?",
             "mip.gold.lead_population",
         ),
+        (
+            "What are the top borrower candidates across all segments overall, what makes "
+            "them such good candidates exactly (for each one), and what is the exact offer "
+            "we should make to each and why?",
+            "mip.gold.borrower_360",
+        ),
+        (
+            "What are the top borrower candidates across all segments?",
+            "mip.gold.lead_population",
+        ),
         ("Show me the top 10 borrowers by lead score in Illinois.", "mip.gold.lead_population"),
         (
             "Top 5 ZIP codes by HELOC-eligible borrowers with equity at least 35%.",

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -27,6 +27,8 @@ from backend.services.genie_client import GenieClientError, GenieResponse
 from backend.services.repositories.databricks_genie_canonical import (
     _CANONICAL_ITM_TOP_LEAD_QUEUE_ZIPS_SQL,
     _CANONICAL_ITM_TOP_ZIPS_SQL,
+    _CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL,
+    _canonical_top_borrowers_all_segments_scope,
 )
 from backend.services.repositories.databricks_genie_policy_helpers import (
     genie_follow_up_questions,
@@ -1127,6 +1129,94 @@ def test_data_question_without_query_gets_generic_sql_repair() -> None:
     assert result.visualization.y == "in_the_money_borrowers"
     assert result.table_rows is not None
     assert result.table_rows[0]["zip"] == 60617
+
+
+_ALL_SEGMENTS_ESSENCE_QUESTION = (
+    "What are the top borrower candidates across all segments overall, what makes "
+    "them such good candidates exactly (for each one), and what is the exact offer "
+    "we should make to each and why?"
+)
+
+
+@pytest.mark.parametrize(
+    ("question", "expected"),
+    [
+        (_ALL_SEGMENTS_ESSENCE_QUESTION, True),
+        (
+            "Show the top borrowers across all segments and explain why each one "
+            "is a good candidate.",
+            True,
+        ),
+        # No why/rationale language -> the thin ranked-lead answer keeps the shape.
+        (
+            "Show me the top 10 borrowers by lead score across the current Cotality "
+            "data coverage.",
+            False,
+        ),
+        # Explicit intent stays with the per-intent canonical ranking.
+        ("What are the top cash-out borrower candidates overall and why?", False),
+        # State-scoped questions stay with the per-state canonical ranking.
+        ("What are the top borrower candidates in Texas and why?", False),
+    ],
+)
+def test_all_segments_top_candidates_scope_matcher(question: str, expected: bool) -> None:
+    assert _canonical_top_borrowers_all_segments_scope(question) is expected
+
+
+def test_text_only_all_segments_top_candidates_returns_driver_rich_answer() -> None:
+    """The product's essence question must never end in a governed refusal.
+
+    A live turn that returns no SQL proof (and a repair turn that also fails)
+    lands on the canonical all-segments repair: driver-rich rows from
+    gold.borrower_360 with a per-borrower ``why_now`` rationale and the
+    governed next-best offer.
+    """
+    text_only = GenieResponse(
+        answer_text="",
+        sql_query=None,
+        sql_result_rows=[],
+        conversation_id="conv-all-seg",
+        message_id="msg-all-seg",
+    )
+    stub = _StubClient(_make_breaker("closed"), response=[text_only, text_only])
+    sql = _StubSqlClient(
+        [
+            {
+                "borrower_id": "B-1ABCDEFGHIJKL",
+                "display_name": "Masked Borrower",
+                "city": "Aurora",
+                "state": "IL",
+                "zip": "60505",
+                "segments": "itm, equity",
+                "opportunity_score": 94,
+                "rate_spread_bps": 183,
+                "equity_pct": 47,
+                "equity_estimate": 312000,
+                "why_now": "In the money: +183 bps rate spread | Strong equity: 47%",
+                "recommended_offer_code": "refi",
+                "recommended_offer": "Rate-improvement refinance",
+                "refreshed_at": "2026-08-05T02:00:00Z",
+            }
+        ]
+    )
+    repo = DatabricksGenieRepository(stub, sql)  # type: ignore[arg-type]
+
+    result = repo.respond(_ALL_SEGMENTS_ESSENCE_QUESTION)
+
+    assert result.source == "trusted_sql"
+    assert result.sql_query == _CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL
+    assert "why_now" in result.sql_query
+    assert "FROM mip.gold.borrower_360" in result.sql_query
+    assert result.trusted_assets == ["mip.gold.borrower_360"]
+    assert result.table_rows
+    assert result.table_rows[0]["why_now"].startswith("In the money")
+    assert "B-1ABCDEFGHIJKL" in result.answer
+    assert "recommended offer is" in result.answer
+    assert "Why now: In the money: +183 bps rate spread" in result.answer
+    assert result.proof is not None
+    assert result.proof.trusted is True
+    # The live path still tried an ask plus one governed SQL-repair retry.
+    assert len(stub.ask_calls) == 2
 
 
 def test_top_zip_question_uses_direct_canonical_gold_sql_without_genie_call() -> None:


### PR DESCRIPTION
## Problem
The essence-of-the-product question — **"What are the top borrower candidates across all segments overall, what makes them such good candidates exactly, and what is the exact offer we should make to each and why?"** — ended in a **Governed refusal** in Ask Genie.

Root cause: under the live-first posture, when the live Genie turn (and its one repair retry) returns no trusted SQL proof, `_canonical_genie_answer` is the last resort — and it had **no global top-borrowers branch**. Only the legacy interceptor (`databricks_genie_direct`) knew that shape, and live-first demoted it to degraded-only. The question fell through to `policy_blocked`.

## Fix
- New **`_CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL`** over `mip.gold.borrower_360`: top 10 marketing-eligible, opt-in borrowers across every segment with a SQL-computed per-borrower **`why_now`** driver summary (in-the-money rate spread, equity %, listed-for-sale, investor related-property count, retention risk, HELOC propensity) and the governed next-best offer — so "what makes each one good" and "which offer and why" are grounded in gold columns, never model prose.
- Dispatched from **both** the live-path canonical repair and the direct interceptor (degraded fallback), via a new `_canonical_top_borrowers_all_segments_scope` (global top-candidates + why/rationale language). The thin global lead-queue ranking branch is also ported to the live path so "top 10 borrowers by lead score overall" can't refuse either.
- Matchers now accept "across all segments" / portfolio phrasing as global scope and "candidates" as ranking language.
- The **Genie space YAML** gains a curated example SQL for this exact shape, so live Genie returns trusted SQL directly (canonical repair becomes the safety net, not the answer path). The SQL-repair prompt now includes per-borrower ranking guidance.
- **Frontend**: removed the "Live from the Databricks Genie Conversation API." progress-meta line — implementation plumbing, not end-user copy.

## Validation
- All genie unit suites green (repository, direct, message policy, guardrail battery, eval, provision-space).
- New tests: matcher truth table incl. the exact user question; live text-only turn → driver-rich `trusted_sql` answer with `why_now` rows; direct parametrize rows for the essence + bare all-segments phrasings.
- `ruff` clean; frontend vitest 872 passed; production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)