### PR TITLE
fix(genie): route-level visible-text gate uses the analytics surface too

### DIFF
--- a/backend/services/genie_message_policy.py
+++ b/backend/services/genie_message_policy.py
@@ -170,6 +170,43 @@ def _without_allowed_literals(value: str, allowed_literals: Sequence[str]) -> st
     return scrubbed
 
 
+# "City Name, ST" / "(City Name, ST)" geography references in Genie prose.
+# Borrower rows carry the same city/state strings, so citing them in a
+# narrative is sanctioned analytics output — but title-case city names
+# ("Lake Forest, CA") pattern-match the human-name-shape guard. Strip the
+# geography shape before the name-shape scan only. No real-person identity
+# can take this shape here: borrower names never render, and display
+# identities are synthetic masked IDs.
+GENIE_GEO_LOCATION_RE = re.compile(
+    r"\(?\b[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){0,3},\s*[A-Z]{2}\b\)?"
+)
+
+
+def genie_visible_text_unsafe(value: str, *, structured_value: bool = False) -> bool:
+    """Fail-closed scan for one Genie-rendered string on the analytics surface.
+
+    Ask Genie output is a read-only analytics narrative, not campaign copy:
+    ranking vocabulary ("candidates are those with the highest opportunity
+    scores") is the product's core language, so the campaign audience-formation
+    criterion machine is bypassed. Every PII, injection, confidential,
+    health-status, and direct protected-class detector stays on.
+
+    ``structured_value`` marks governed table-cell values (already key-redacted
+    gold columns such as city or offer labels). Those keep the mechanical-PII,
+    injection, and protected-class scans but skip the title-case human-name
+    heuristic, which can only false-positive on structured values ("El Paso",
+    "San Antonio", "Purchase Mortgage") — gold rows carry no name columns after
+    redaction.
+    """
+
+    scannable = GENIE_GEO_LOCATION_RE.sub(" ", value)
+    return contains_unsafe_ai_text(
+        scannable,
+        include_titlecase=not structured_value,
+        assume_reviewed_read_only_analytics=True,
+    )
+
+
 def genie_response_has_unsafe_visible_text(
     response: GenieMessageResponse,
     *,
@@ -197,8 +234,14 @@ def genie_response_has_unsafe_visible_text(
             )
             if value
         )
-    values.extend(_visible_text_values(response.table_rows or []))
+    row_values = _visible_text_values(response.table_rows or [])
     return any(
-        contains_unsafe_ai_text(_without_allowed_literals(value, allowed_literals))
+        genie_visible_text_unsafe(_without_allowed_literals(value, allowed_literals))
         for value in values
+    ) or any(
+        genie_visible_text_unsafe(
+            _without_allowed_literals(value, allowed_literals),
+            structured_value=True,
+        )
+        for value in row_values
     )

--- a/backend/services/repositories/databricks_genie_policy_helpers.py
+++ b/backend/services/repositories/databricks_genie_policy_helpers.py
@@ -7,10 +7,10 @@ import re
 from typing import Any
 
 from backend.config.settings import settings
-from backend.schemas._validators import contains_unsafe_ai_text
 from backend.services.databricks_sql_helpers import qualify
 from backend.services.genie_answers import GenieNativeVisualization, GenieReasoningStep
 from backend.services.genie_client import GenieResponse
+from backend.services.genie_message_policy import genie_visible_text_unsafe
 from backend.services.observability import emit
 from backend.services.pii_redaction import _FORBIDDEN_OUTPUT_KEYS, scrub_free_text
 from backend.services.repositories.databricks_genie_canonical import (
@@ -221,36 +221,21 @@ _PII_TEXT_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
-# "City Name, ST" / "(City Name, ST)" geography references in Genie
-# narratives. Borrower rows carry the same city/state strings, so citing them
-# in prose is sanctioned analytics output — but title-case city names
-# ("Lake Forest, CA") pattern-match the human-name-shape guard. Strip the
-# geography shape before the name-shape scan only; the raw text still goes
-# through every PII pattern first. No real-person identity can take this
-# shape here: borrower names never render, and display identities are
-# synthetic masked IDs.
-_GENIE_GEO_LOCATION_RE = re.compile(
-    r"\(?\b[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){0,3},\s*[A-Z]{2}\b\)?"
-)
-
-
 def _answer_text_contains_pii(text: str | None) -> bool:
-    """Return true for any text unsafe to render, retaining the legacy name."""
+    """Return true for any text unsafe to render, retaining the legacy name.
+
+    The raw text goes through every Genie PII pattern first; the shared
+    analytics-surface scanner (geography stripping + campaign criterion-machine
+    bypass, all PII/name/injection/protected detectors intact) then covers the
+    model-authored prose. Kept in lockstep with the router-level
+    ``genie_response_has_unsafe_visible_text`` by reusing the same scanner.
+    """
 
     if not text:
         return False
     if any(pattern.search(text) for pattern in _PII_TEXT_PATTERNS):
         return True
-    # Ask Genie answers are a read-only analytics narrative, not campaign
-    # copy: ranking language ("candidates are those with the highest
-    # opportunity scores") is the product's core vocabulary, so the campaign
-    # audience-formation criterion machine is bypassed. All PII, name-shape,
-    # injection, confidential, and direct protected-class detectors stay on.
-    scannable = _GENIE_GEO_LOCATION_RE.sub(" ", text)
-    return contains_unsafe_ai_text(
-        scannable,
-        assume_reviewed_read_only_analytics=True,
-    )
+    return genie_visible_text_unsafe(text)
 
 
 def _safe_rendered_summary(text: object, *, max_length: int | None = None) -> str | None:

--- a/tests/unit/test_genie_narrative_guard.py
+++ b/tests/unit/test_genie_narrative_guard.py
@@ -15,6 +15,8 @@ phrases ("Purchase Mortgage"). These tests pin the corrected boundary:
 from __future__ import annotations
 
 from backend.schemas._validators import contains_unsafe_ai_text
+from backend.services.genie_answers import GenieMessageResponse
+from backend.services.genie_message_policy import genie_response_has_unsafe_visible_text
 from backend.services.repositories.databricks_genie_policy_helpers import (
     _answer_text_contains_pii,
 )
@@ -81,3 +83,47 @@ def test_campaign_copy_surface_keeps_fail_closed_ranking_grammar() -> None:
         )
         is True
     )
+
+
+def _visible_response(**overrides: object) -> GenieMessageResponse:
+    base: dict[str, object] = {
+        "conversation_id": "conv",
+        "question": "q",
+        "question_hash": "hash",
+        "answer": _LIVE_CAPTURED_NARRATIVE,
+        "source": "genie",
+        "trusted_assets": ["mip.gold.borrower_360"],
+        "table_rows": [
+            {
+                "borrower_id": "B-0N122RBMBT4PK",
+                "city": "Lake Forest",
+                "state": "CA",
+                "recommended_offer": "Purchase Mortgage",
+                "why_now": "Listed for sale",
+            },
+            {
+                "borrower_id": "B-1ABCDEFGHIJKL",
+                "city": "San Antonio",
+                "state": "TX",
+                "recommended_offer": "Cash-Out Refinance",
+                "why_now": "In the money: +204 bps rate spread",
+            },
+        ],
+    }
+    base.update(overrides)
+    return GenieMessageResponse(**base)  # type: ignore[arg-type]
+
+
+def test_router_gate_renders_the_live_answer_with_city_and_offer_rows() -> None:
+    """The route-level visible-text gate must not re-block what the
+    repository boundary allows: analytics narrative plus governed row values
+    (title-case cities, offer labels) render."""
+
+    assert genie_response_has_unsafe_visible_text(_visible_response()) is False
+
+
+def test_router_gate_still_blocks_real_pii_in_prose_and_rows() -> None:
+    named = _visible_response(answer="Call John Smith at 431 Maple Street.")
+    assert genie_response_has_unsafe_visible_text(named) is True
+    leaked_row = _visible_response(table_rows=[{"note": "SSN 123-45-6789"}])
+    assert genie_response_has_unsafe_visible_text(leaked_row) is True


### PR DESCRIPTION
PR #115 fixed the repository-boundary narrative guard, but the deployed
app still refused: genie_response_has_unsafe_visible_text re-scans every
visible field (answer, follow-ups, reasoning, viz labels, table-row
values) with the campaign-default guard, so the same ranking-vocabulary
and title-case false positives re-blocked at the router with 'generated
response blocked by the governed text-output policy'.

- new shared genie_visible_text_unsafe scanner: geography stripping +
  campaign criterion-machine bypass; all PII, injection, confidential,
  health-status, and direct protected-class detectors stay on. The
  repository boundary now reuses it, keeping both layers in lockstep.
- structured table-cell values (key-redacted gold columns) keep the
  mechanical-PII/injection/protected scans but skip the title-case
  human-name heuristic, which can only false-positive on values like
  'El Paso', 'San Antonio', or 'Purchase Mortgage'.

Pinned: the captured live answer with city/offer rows renders through
the route gate; real names in prose and mechanical PII in row values
still fail closed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
