### PR TITLE
feat(genie): per-borrower analyst brief + trusted-SQL no-refusal floor

### DIFF
--- a/backend/schemas/_validators.py
+++ b/backend/schemas/_validators.py
@@ -573,8 +573,14 @@ _MECHANICAL_PII_OR_RAW_IDENTIFIER_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 _CONTEXTUAL_HUMAN_NAME_RE = re.compile(
     r"\b(?:call|contact|email|message|text|ask|target|prioritize|dear|hello|hi)\s+"
-    r"(?!(?:to|the|a|an|and|or|at|about|before|if|when|this|that|your|our|us|me|you|"
+    r"(?!(?:to|the|a|an|and|or|at|about|before|if|when|this|that|these|those|your|our|us|me|you|"
     r"them|him|her|it|then|provider|carrier|system|platform|service|gateway|authorization|consent|permission|outreach|contact|records?|"
+    # Domain population/ranking vocabulary: "prioritize overall", "contact
+    # borrowers", "target top segments" are core product phrasings, not
+    # person-name lookups. Real names never take these words.
+    r"all|any|each|every|only|both|overall|first|next|now|today|top|"
+    r"borrowers?|leads?|candidates?|prospects?|customers?|clients?|"
+    r"segments?|cohorts?|homeowners?|investors?|people|everyone|anyone|someone|"
     r"is|are|was|were|will|would|can|could|may|might|has|have|had)\b)"
     r"[A-Za-z]{2,30}\s+[A-Za-z]{2,30}\b|"
     r"\b[A-Za-z]{2,30}\s+[A-Za-z]{2,30}\s+(?:qualifies?|is the top borrower)\b",

--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -69,12 +69,12 @@ from backend.services.repositories.databricks_genie_canonical import (
     _specific_top_borrower_intent_label,
     _specific_top_borrower_intent_note,
     _specific_top_borrower_sort_label,
+    compose_all_segments_brief,
 )
 from backend.services.repositories.databricks_genie_direct import (
     direct_canonical_response,
 )
 from backend.services.repositories.databricks_genie_numeric import (
-    _numeric_claim_blocked_response,
     _unsupported_answer_numeric_claims,
 )
 from backend.services.repositories.databricks_genie_policy import (
@@ -453,7 +453,7 @@ def _adapt_genie_response(
                 result,
                 narrative_withheld=text_contains_pii,
             )
-    if text_contains_pii or lacks_trusted_proof or unsafe_live_sql or depends_on_pending_feeds:
+    if lacks_trusted_proof or unsafe_live_sql or depends_on_pending_feeds:
         if depends_on_pending_feeds:
             gaps = _known_data_gaps_for_result(
                 question=" ".join([question, "permit listing mls"]),
@@ -496,20 +496,28 @@ def _adapt_genie_response(
         )
     if result.sql_query and trusted_sql and not rows and sql_client is not None:
         rows = _redact_genie_rows(_execute_trusted_genie_sql(sql_client, result.sql_query))
-    unsupported_numeric_claims = _unsupported_answer_numeric_claims(
-        result.answer_text,
-        rows,
-        question,
-    )
-    if unsupported_numeric_claims:
-        return _numeric_claim_blocked_response(
-            conversation_id=result.conversation_id,
-            message_id=result.message_id,
-            elapsed_ms=result.elapsed_ms,
-            question_hash=question_hash,
-            question=question,
-            trusted_assets=trusted_assets,
-            reasoning_trace=[],
+    # Trusted SQL is a floor, not a coin flip: from here the governed query,
+    # rows, proof, and actions ALWAYS ship. Only the model PROSE is
+    # conditionally withheld — when the output safety guard flags its wording,
+    # or when it carries numbers the returned rows cannot verify — and the
+    # withholding is disclosed in proof.known_data_gaps. Unverified model
+    # numbers and guard-flagged prose still never render.
+    prose_withheld_gap: str | None = None
+    prose_withheld_reason: str | None = None
+    if text_contains_pii:
+        prose_withheld_gap = (
+            "Genie's draft narrative was withheld by the output safety guard; "
+            "the governed query results are shown instead."
+        )
+        prose_withheld_reason = "the output safety guard flagged its wording."
+    elif _unsupported_answer_numeric_claims(result.answer_text, rows, question):
+        prose_withheld_gap = (
+            "Genie's draft narrative included numeric or financial claims that "
+            "could not be verified against the returned rows; the prose was "
+            "withheld and the verified rows are shown."
+        )
+        prose_withheld_reason = (
+            "it contained numbers the app could not verify against the returned rows."
         )
     # Genie enhancement fields (2026-07): scrub once, share between the proof
     # trace and the top-level response fields so every emitted string clears
@@ -525,6 +533,10 @@ def _adapt_genie_response(
         elapsed_ms=result.elapsed_ms,
         reasoning_trace=[step.model_dump() for step in reasoning_trace],
     )
+    if prose_withheld_gap and prose_withheld_gap not in proof.known_data_gaps:
+        proof = proof.model_copy(
+            update={"known_data_gaps": [*proof.known_data_gaps, prose_withheld_gap]}
+        )
     visualization = _plan_genie_visualization(question, rows)
     actions = _suggest_genie_actions(
         question=question,
@@ -536,13 +548,23 @@ def _adapt_genie_response(
         question_hash=question_hash,
         sql_query=result.sql_query,
     )
+    if prose_withheld_reason:
+        row_count = len(rows) if rows else 0
+        row_word = "row" if row_count == 1 else "rows"
+        answer_text: str | None = (
+            f"Genie ran a governed query against {trusted_assets[0]} and returned "
+            f"{row_count:,} {row_word}, shown with the generated SQL. The draft "
+            f"narrative was withheld: {prose_withheld_reason}"
+        )
+    else:
+        answer_text = result.answer_text
     return GenieMessageResponse(
         conversation_id=result.conversation_id,
         message_id=result.message_id,
         elapsed_ms=result.elapsed_ms,
         question_hash=question_hash,
         question=question,
-        answer=_ensure_answer_cites_source(result.answer_text, trusted_assets),
+        answer=_ensure_answer_cites_source(answer_text, trusted_assets),
         source="genie",
         trusted_assets=trusted_assets,
         sql_query=result.sql_query,
@@ -717,14 +739,20 @@ def _restore_live_voice(
                     update={"known_data_gaps": [*proof.known_data_gaps, gap]}
                 )
     elif narrative:
-        note = _default_verification_note(
-            canonical.trusted_assets,
-            canonical.metric_value,
-            len(canonical.table_rows or []),
-        )
-        answer = narrative
-        if note and note not in answer:
-            answer = f"{answer}\n\n{note}"
+        if canonical.sql_query == _CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL:
+            # The all-segments brief is the product's deep per-borrower
+            # analysis; a surviving live narrative leads and the verified
+            # brief follows, instead of flattening to a one-line note.
+            answer = f"{narrative}\n\n{canonical.answer}"
+        else:
+            note = _default_verification_note(
+                canonical.trusted_assets,
+                canonical.metric_value,
+                len(canonical.table_rows or []),
+            )
+            answer = narrative
+            if note and note not in answer:
+                answer = f"{answer}\n\n{note}"
         updates["answer"] = _ensure_answer_cites_source(answer, canonical.trusted_assets)
     elif proof is not None and not narrative_withheld:
         gap = "Genie returned no narrative; presenting the verified deterministic summary."
@@ -1015,44 +1043,13 @@ def _canonical_genie_answer(
             sql_query=_CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL,
             source="trusted_sql",
         )
-        if rows:
-            top = rows[0]
-            top_offer = offer_display_label(
-                str(top.get("recommended_offer_code") or ""),
-                str(top.get("recommended_offer") or ""),
-            )
-            top_why = str(top.get("why_now") or "").strip()
-            top_why_clause = f" Why now: {top_why}." if top_why else ""
-            answer = (
-                f"I ranked the top {len(rows)} marketing-eligible, opt-in borrowers "
-                f"across every segment from {borrower_asset}, ordered by opportunity "
-                "score with rate-spread economics as the tiebreaker. Each row lists "
-                "the borrower's segments, the live signals that make them a strong "
-                "candidate right now (rate spread, equity, listing, multi-property, "
-                "retention, HELOC propensity), and the governed next-best offer those "
-                "signals drive. The current first borrower is masked "
-                f"{top.get('borrower_id')} in {top.get('city')}, {top.get('state')} "
-                f"with opportunity score {int(top.get('opportunity_score') or 0):,}; "
-                f"the recommended offer is {top_offer}.{top_why_clause} Offers follow "
-                "the governed next-best-offer rules — deep equity favors cash-out, a "
-                "wide positive rate spread favors a rate-improvement refinance, an "
-                "active listing favors purchase financing, and retention risk favors "
-                "recapture outreach — and every recommendation still requires human "
-                "approval in the Lead Queue."
-            )
-        else:
-            answer = (
-                "The trusted borrower table returned no marketing-eligible, opt-in "
-                "borrowers across the segment portfolio for the current refreshed "
-                "coverage."
-            )
         return GenieMessageResponse(
             conversation_id=result.conversation_id,
             message_id=result.message_id,
             elapsed_ms=result.elapsed_ms,
             question_hash=question_hash,
             question=question,
-            answer=answer,
+            answer=compose_all_segments_brief(rows, borrower_asset),
             source="trusted_sql",
             trusted_assets=trusted_assets,
             sql_query=_CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL,

--- a/backend/services/repositories/databricks_genie_canonical.py
+++ b/backend/services/repositories/databricks_genie_canonical.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from backend.services.databricks_sql_helpers import qualify
 from backend.services.eligibility import eligible_sql_predicate
-from backend.services.scoring import HIGH_OPPORTUNITY_THRESHOLD
+from backend.services.scoring import HIGH_OPPORTUNITY_THRESHOLD, offer_display_label
 
 
 @dataclass(frozen=True)
@@ -571,6 +571,113 @@ WHERE {_ELIGIBLE}
 ORDER BY opportunity_score DESC, rate_spread_bps DESC NULLS LAST, borrower_id ASC
 LIMIT 10
 """.strip()
+
+
+def _brief_offer_reason(code: str, row: dict[str, Any]) -> str:
+    """One clause explaining WHY the governed offer follows from row drivers."""
+
+    equity = row.get("equity_pct")
+    spread = row.get("rate_spread_bps")
+    equity_txt = f"{int(round(float(equity)))}% modeled equity" if equity is not None else "the modeled equity"
+    spread_txt = (
+        f"the +{int(round(float(spread)))} bps rate spread" if spread is not None else "the rate spread"
+    )
+    reasons = {
+        "refi": f"{spread_txt} clears the refinance-economics screen",
+        "refi_plus_heloc": (
+            f"{spread_txt} clears the refinance-economics screen and "
+            f"{equity_txt} supports the home-equity add-on"
+        ),
+        "heloc": f"{equity_txt} supports an equity line without disturbing the first mortgage",
+        "cash_out": f"{equity_txt} supports pulling cash while refinancing",
+        "purchase": "the active listing signals an upcoming purchase and financing need",
+        "investor": "the multi-property profile fits investor financing",
+        "retention": "retention-risk signals favor a recapture touch before a competitor closes",
+        "nurture": "signals are early, so monitor rather than contact",
+    }
+    return reasons.get(code, "the governed next-best-offer rules select it from the row's signals")
+
+
+def _brief_city_label(row: dict[str, Any]) -> str:
+    city = str(row.get("city") or "").strip()
+    state = str(row.get("state") or "").strip()
+    if city and state:
+        return f"{city.title()}, {state}"
+    return city.title() or state or "coverage area"
+
+
+def compose_all_segments_brief(rows: list[dict[str, Any]], borrower_asset: str) -> str:
+    """Deterministic analyst brief for the all-segments top-candidates shape.
+
+    One bullet per candidate — drivers, governed offer, and the reason the
+    offer follows — plus a cohort synthesis. Every number is read from the
+    governed rows, so the brief can never carry an unverifiable claim. Renders
+    through the answer markdown (paragraphs, ``- `` bullets, ``**bold**``).
+    """
+
+    if not rows:
+        return (
+            "The trusted borrower table returned no marketing-eligible, opt-in "
+            "borrowers across the segment portfolio for the current refreshed "
+            "coverage."
+        )
+    refreshed = str(rows[0].get("refreshed_at") or "")[:10]
+    refreshed_txt = f" (refreshed {refreshed})" if refreshed else ""
+    lines: list[str] = [
+        f"I ranked all marketing-eligible, opt-in borrowers across every segment "
+        f"at the unique borrower grain from {borrower_asset}{refreshed_txt}, "
+        "ordered by opportunity score with rate-spread economics as the "
+        f"tiebreaker. Here are the top {len(rows)} candidates, what makes each "
+        "one strong right now, and the governed offer each set of signals "
+        "drives:",
+        "",
+    ]
+    for rank, row in enumerate(rows, start=1):
+        offer_code = str(row.get("recommended_offer_code") or "")
+        offer = offer_display_label(offer_code, str(row.get("recommended_offer") or ""))
+        why_now = str(row.get("why_now") or "").strip()
+        segments = str(row.get("segments") or "").strip()
+        score = row.get("opportunity_score")
+        score_txt = f"score {int(round(float(score)))}" if score is not None else "scored"
+        parts = [
+            f"**#{rank} {row.get('borrower_id')}** — {_brief_city_label(row)} — {score_txt}"
+        ]
+        if segments:
+            parts.append(f"segments: {segments}")
+        if why_now:
+            parts.append(f"why now: {why_now}")
+        parts.append(f"offer: **{offer}** because {_brief_offer_reason(offer_code, row)}")
+        lines.append(f"- {'. '.join(parts)}.")
+    itm_rows = [r for r in rows if "In the money" in str(r.get("why_now") or "")]
+    equity_rows = [r for r in rows if "Strong equity" in str(r.get("why_now") or "")]
+    listed_rows = [r for r in rows if "Listed for sale" in str(r.get("why_now") or "")]
+    investor_rows = [r for r in rows if "Investor:" in str(r.get("why_now") or "")]
+    retention_rows = [r for r in rows if "Retention" in str(r.get("why_now") or "")]
+    cohort_bits: list[str] = []
+    if itm_rows:
+        spreads = [float(r["rate_spread_bps"]) for r in itm_rows if r.get("rate_spread_bps") is not None]
+        avg_txt = f" (average +{int(round(sum(spreads) / len(spreads)))} bps)" if spreads else ""
+        cohort_bits.append(
+            f"{len(itm_rows)} of {len(rows)} pass the refinance-economics screen{avg_txt}"
+        )
+    if equity_rows:
+        cohort_bits.append(f"{len(equity_rows)} carry 35%+ modeled equity")
+    if listed_rows:
+        cohort_bits.append(f"{len(listed_rows)} are actively listed for sale")
+    if investor_rows:
+        cohort_bits.append(f"{len(investor_rows)} show multi-property investor profiles")
+    if retention_rows:
+        cohort_bits.append(f"{len(retention_rows)} carry retention risk")
+    lines.append("")
+    cohort_txt = f"Cohort picture: {'; '.join(cohort_bits)}. " if cohort_bits else ""
+    lines.append(
+        f"{cohort_txt}Offers follow the governed next-best-offer rules, and every "
+        "recommendation still requires human approval in the Lead Queue before "
+        "any outreach."
+    )
+    lines.append("")
+    lines.append(f"Source: {borrower_asset}")
+    return "\n".join(lines)
 
 _CANONICAL_TOP_REFI_BORROWERS_BY_STATE_SQL = f"""
 SELECT borrower_id

--- a/backend/services/repositories/databricks_genie_direct.py
+++ b/backend/services/repositories/databricks_genie_direct.py
@@ -126,6 +126,7 @@ from backend.services.repositories.databricks_genie_canonical import (
     _specific_top_borrower_intent_label,
     _specific_top_borrower_intent_note,
     _specific_top_borrower_sort_label,
+    compose_all_segments_brief,
 )
 from backend.services.repositories.databricks_genie_policy_helpers import (
     _emit_genie_warning,
@@ -1031,43 +1032,12 @@ def direct_canonical_response(
                 "direct_canonical_genie_top_borrowers_all_segments_failed", exc=exc
             )
             return None
-        if rows:
-            top = rows[0]
-            top_offer = offer_display_label(
-                str(top.get("recommended_offer_code") or ""),
-                str(top.get("recommended_offer") or ""),
-            )
-            top_why = str(top.get("why_now") or "").strip()
-            top_why_clause = f" Why now: {top_why}." if top_why else ""
-            answer = (
-                f"I ranked the top {len(rows)} marketing-eligible, opt-in borrowers "
-                f"across every segment from {borrower_asset}, ordered by opportunity "
-                "score with rate-spread economics as the tiebreaker. Each row lists "
-                "the borrower's segments, the live signals that make them a strong "
-                "candidate right now (rate spread, equity, listing, multi-property, "
-                "retention, HELOC propensity), and the governed next-best offer those "
-                "signals drive. The current first borrower is masked "
-                f"{top.get('borrower_id')} in {top.get('city')}, {top.get('state')} "
-                f"with opportunity score {int(top.get('opportunity_score') or 0):,}; "
-                f"the recommended offer is {top_offer}.{top_why_clause} Offers follow "
-                "the governed next-best-offer rules — deep equity favors cash-out, a "
-                "wide positive rate spread favors a rate-improvement refinance, an "
-                "active listing favors purchase financing, and retention risk favors "
-                "recapture outreach — and every recommendation still requires human "
-                "approval in the Lead Queue."
-            )
-        else:
-            answer = (
-                "The trusted borrower table returned no marketing-eligible, opt-in "
-                "borrowers across the segment portfolio for the current refreshed "
-                "coverage."
-            )
         return trusted_response(
             question=question,
             sql_query=_CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL,
             trusted_assets=[borrower_asset],
             rows=rows,
-            answer=answer,
+            answer=compose_all_segments_brief(rows, borrower_asset),
         )
 
     if _canonical_top_borrowers_global_scope(question):

--- a/backend/services/repositories/databricks_genie_numeric.py
+++ b/backend/services/repositories/databricks_genie_numeric.py
@@ -10,10 +10,8 @@ from __future__ import annotations
 import math
 import re
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from typing import Any, Literal
 
-from backend.services.genie_answers import GenieMessageResponse, GenieProof
 from backend.services.repositories.databricks_genie_visualization import (
     _is_genie_identifier_column,
     _row_columns,
@@ -137,48 +135,11 @@ def _unsupported_answer_numeric_claims(
     return unsupported[:5]
 
 
-def _numeric_claim_blocked_response(
-    *,
-    conversation_id: str,
-    message_id: str,
-    elapsed_ms: int,
-    question_hash: str,
-    question: str,
-    trusted_assets: list[str],
-    reasoning_trace: list[dict[str, str]] | None,
-) -> GenieMessageResponse:
-    return GenieMessageResponse(
-        conversation_id=conversation_id,
-        message_id=message_id,
-        elapsed_ms=elapsed_ms,
-        question_hash=question_hash,
-        question=question,
-        answer=(
-            "Genie returned trusted SQL, but the app could not verify one or "
-            "more numeric claims against the returned rows, so the result was "
-            "not displayed. Ask again with a narrower metric or inspect the "
-            "source rows."
-        ),
-        source="policy_blocked",
-        trusted_assets=trusted_assets,
-        sql_query=None,
-        row_count=0,
-        proof=GenieProof(
-            sql_query=None,
-            source_assets=trusted_assets,
-            row_count=0,
-            trusted=False,
-            reasoning_trace=reasoning_trace or [],
-            known_data_gaps=[
-                "Genie returned numeric prose that could not be verified against the returned rows."
-            ],
-            conversation_id=conversation_id,
-            message_id=message_id,
-            elapsed_ms=elapsed_ms,
-            generated_at=datetime.now(UTC).isoformat(),
-        ),
-        table_rows=[],
-    )
+# The former ``_numeric_claim_blocked_response`` hard refusal was retired
+# (2026-08-06): a trusted-SQL turn with unverifiable narrative numbers now
+# ships the governed rows with the prose withheld and the withholding
+# disclosed — see ``_adapt_genie_response``. Unverified model numbers still
+# never render.
 
 
 def _numeric_claims(text: str) -> list[_NumericClaim]:

--- a/backend/services/repositories/databricks_genie_policy_helpers.py
+++ b/backend/services/repositories/databricks_genie_policy_helpers.py
@@ -105,9 +105,12 @@ def _likely_data_question(question: str) -> bool:
 
 
 def _needs_genie_sql_repair(question: str, result: GenieResponse) -> bool:
+    # A guard-flagged narrative no longer suppresses the repair retry: the
+    # repair prompt carries only the user's question (never the flagged
+    # answer text), and recovering a governed SQL attachment lets the
+    # trusted-data floor ship rows with the prose withheld instead of
+    # refusing outright.
     if not _likely_data_question(question):
-        return False
-    if _answer_text_contains_pii(result.answer_text):
         return False
     if _sql_uses_stale_evidence_signal_enum(result.sql_query):
         return True

--- a/genie/mortgage_lead_intelligence_space.yml
+++ b/genie/mortgage_lead_intelligence_space.yml
@@ -178,6 +178,13 @@ instructions: |
       generate an executable SELECT over the trusted assets, do not provide a
       numeric or strategic answer; say you cannot produce a governed SQL
       answer for that question and cite the closest trusted asset or data gap.
+    - For top-N and ranking questions, make the narrative a per-row analysis:
+      for each returned borrower cite its drivers from the result columns
+      (rate spread, equity, listing, related-property count, retention, and
+      propensity signals) and state the recommended offer with the reason those
+      drivers select it. Use ONLY numbers present in the query result rows —
+      never introduce a count, rate, score, or dollar figure that is not in
+      the returned data.
     - For offer, product, and next-best-offer questions, filter on canonical
       `recommended_offer_code` from mip.gold.borrower_360; do not infer product
       cohorts from display labels or segment aliases alone. Use these mappings

--- a/tests/unit/test_genie_no_refusal_battery.py
+++ b/tests/unit/test_genie_no_refusal_battery.py
@@ -1,0 +1,115 @@
+"""No-refusal battery: valid analytical questions must never dead-end.
+
+The product's central promise is an agent that does deep borrower analysis on
+demand. This battery pins two systemic invariants across a representative
+family of VALID questions:
+
+1. **Prompt guards never intercept them.** The deterministic pre-Genie
+   matchers (protected-class, PII lookup, off-topic, scope-bypass,
+   instruction-override, cross-lender) must all pass valid analytics
+   questions through to the live path.
+
+2. **A policy-trusted SQL turn never refuses.** Whatever the model narrative
+   does — clean, guard-flagged, or carrying unverifiable numbers — once the
+   turn holds trusted SQL over trusted assets, the governed rows ship. Only
+   the prose is conditionally withheld (and disclosed). ``policy_blocked``
+   remains reserved for unsafe SQL, missing data, and pending-feed turns.
+
+If a future guard or matcher change breaks either invariant for any question
+here, this file fails before a customer sees a "Governed refusal".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from backend.services.genie_client import GenieResponse
+from backend.services.genie_message_policy import (
+    identity_prompt_match,
+    protected_prompt_match,
+)
+from backend.services.genie_prompt_guardrails import (
+    cross_lender_prompt_match,
+    instruction_override_prompt_match,
+    off_topic_prompt_match,
+    pii_prompt_match,
+    scope_bypass_prompt_match,
+)
+from backend.services.repositories.databricks_repo import _adapt_genie_response
+
+VALID_ANALYTICAL_QUESTIONS: tuple[str, ...] = (
+    # The essence question from the product demo.
+    "What are the top borrower candidates across all segments overall, what makes "
+    "them such good candidates exactly (for each one), and what is the exact offer "
+    "we should make to each and why?",
+    "Show the top borrowers across all segments and explain why each one is a good candidate.",
+    "Which borrowers should we prioritize overall for any offer, and why?",
+    "Show me the top 10 borrowers by lead score across the current Cotality data coverage.",
+    "Which zips have the most in-the-money refi candidates?",
+    "Which state has the most cash-out opportunity right now?",
+    "How many borrowers are currently in-the-money and what is the average rate spread?",
+    "Compare mean lead score by MSA for our top five markets.",
+    "Which borrowers on our retention list have a competitor lien filed in the last 30 days?",
+    "Break down the Investor / Multi-Property segment by state and average current rate.",
+    "Where should we spend our next 10,000 outreach touches this week, and why?",
+)
+
+_PROMPT_MATCHERS = (
+    ("protected", protected_prompt_match),
+    ("identity", identity_prompt_match),
+    ("pii", pii_prompt_match),
+    ("off_topic", off_topic_prompt_match),
+    ("scope_bypass", scope_bypass_prompt_match),
+    ("instruction_override", instruction_override_prompt_match),
+    ("cross_lender", cross_lender_prompt_match),
+)
+
+
+@pytest.mark.parametrize("question", VALID_ANALYTICAL_QUESTIONS)
+def test_prompt_guards_pass_valid_analytical_questions_through(question: str) -> None:
+    intercepted = [name for name, matcher in _PROMPT_MATCHERS if matcher(question)]
+    assert intercepted == [], f"prompt guard(s) {intercepted} intercepted: {question!r}"
+
+
+_TRUSTED_TURN_ROWS: list[dict[str, Any]] = [
+    {"state": "IL", "borrowers": 70939},
+    {"state": "TX", "borrowers": 54210},
+]
+
+_NARRATIVE_VARIANTS: tuple[tuple[str, str], ...] = (
+    ("clean", "IL leads the returned cohort ahead of TX."),
+    # Output-guard flag (a real name) — prose withheld, data ships.
+    ("guard_flagged", "Call John Smith about the IL cohort."),
+    # Unverifiable numeric claim — prose withheld, data ships.
+    ("claims_mismatch", "There are 999,999 borrowers in the returned cohort."),
+    # No narrative at all — data still ships.
+    ("empty", ""),
+)
+
+
+@pytest.mark.parametrize("variant_name,narrative", _NARRATIVE_VARIANTS)
+@pytest.mark.parametrize("question", VALID_ANALYTICAL_QUESTIONS)
+def test_trusted_sql_turn_never_refuses(question: str, variant_name: str, narrative: str) -> None:
+    live = GenieResponse(
+        answer_text=narrative,
+        sql_query=(
+            "SELECT state, COUNT(*) AS borrowers FROM mip.gold.borrower_360 "
+            "WHERE marketing_eligible = TRUE GROUP BY state ORDER BY borrowers DESC"
+        ),
+        sql_result_rows=list(_TRUSTED_TURN_ROWS),
+        conversation_id="conv-battery",
+        message_id=f"msg-battery-{variant_name}",
+    )
+
+    result = _adapt_genie_response(question, live, sql_client=None)
+
+    assert result.source != "policy_blocked", (
+        f"{variant_name!r} narrative refused a trusted-SQL turn for: {question!r}"
+    )
+    assert result.table_rows, "governed rows must always ship on a trusted turn"
+    if variant_name == "guard_flagged":
+        assert "John Smith" not in result.answer
+    if variant_name == "claims_mismatch":
+        assert "999,999" not in result.answer

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -1210,9 +1210,13 @@ def test_text_only_all_segments_top_candidates_returns_driver_rich_answer() -> N
     assert result.trusted_assets == ["mip.gold.borrower_360"]
     assert result.table_rows
     assert result.table_rows[0]["why_now"].startswith("In the money")
-    assert "B-1ABCDEFGHIJKL" in result.answer
-    assert "recommended offer is" in result.answer
-    assert "Why now: In the money: +183 bps rate spread" in result.answer
+    # The analyst brief: a bullet per candidate with drivers + offer + reason.
+    assert "**#1 B-1ABCDEFGHIJKL**" in result.answer
+    assert "Aurora, IL" in result.answer
+    assert "why now: In the money: +183 bps rate spread | Strong equity: 47%" in result.answer
+    assert "offer: **Refinance review** because" in result.answer
+    assert "human approval in the Lead Queue" in result.answer
+    assert "Source: mip.gold.borrower_360" in result.answer
     assert result.proof is not None
     assert result.proof.trusted is True
     # The live path still tried an ask plus one governed SQL-repair retry.
@@ -1255,12 +1259,13 @@ def test_pii_flagged_narrative_is_withheld_not_refused_for_canonical_shape() -> 
 
     assert result.source == "trusted_sql"
     assert "John Smith" not in result.answer
-    assert "B-1ABCDEFGHIJKL" in result.answer
+    assert "**#1 B-1ABCDEFGHIJKL**" in result.answer
     assert result.proof is not None
     assert any("withheld by the output safety guard" in gap for gap in result.proof.known_data_gaps)
     assert not any("returned no narrative" in gap for gap in result.proof.known_data_gaps)
-    # PII narratives are excluded from the SQL-repair retry; one live ask only.
-    assert len(stub.ask_calls) == 1
+    # The repair retry now runs even for guard-flagged narratives (the repair
+    # prompt carries only the question), so the live path made two asks.
+    assert len(stub.ask_calls) == 2
 
 
 def test_top_zip_question_uses_direct_canonical_gold_sql_without_genie_call() -> None:
@@ -1850,7 +1855,13 @@ def test_raw_cotality_identifier_literals_are_policy_blocked(sql_query: str) -> 
         "OwnerLink ID 1100000134187756 matched.",
     ],
 )
-def test_raw_owner_identifier_answer_text_is_policy_blocked(answer_text: str) -> None:
+def test_raw_owner_identifier_answer_text_withholds_prose_ships_governed_rows(
+    answer_text: str,
+) -> None:
+    """Raw-identifier lookups are refused at the PROMPT guard in production;
+    this repository-level defence now withholds the flagged prose while the
+    governed count rows still ship. The raw identifier never renders."""
+
     live = GenieResponse(
         answer_text=answer_text,
         sql_query="SELECT count(*) AS borrowers FROM mip.gold.borrower_360",
@@ -1863,10 +1874,13 @@ def test_raw_owner_identifier_answer_text_is_policy_blocked(answer_text: str) ->
 
     result = repo.respond("Tell me about Owner Link 1100000134187756.")
 
-    assert result.source == "policy_blocked"
-    assert result.sql_query is None
-    assert result.table_rows == []
+    assert result.source == "genie"
+    assert result.sql_query == live.sql_query
+    assert result.table_rows == [{"borrowers": 2}]
     assert "1100000134187756" not in result.answer
+    assert "withheld" in result.answer
+    assert result.proof is not None
+    assert any("withheld by the output safety guard" in gap for gap in result.proof.known_data_gaps)
 
 
 def test_zip_map_prompt_does_not_emit_state_map_without_state_column() -> None:
@@ -2205,7 +2219,10 @@ def test_raw_gold_pii_column_sql_is_policy_blocked(column: str) -> None:
     assert result.table_rows == []
 
 
-def test_pii_answer_text_is_policy_blocked() -> None:
+def test_pii_answer_text_is_withheld_and_governed_rows_still_ship() -> None:
+    """A PII-bearing narrative on a trusted-SQL turn withholds the prose but
+    keeps the governed data; the email never renders anywhere."""
+
     live = GenieResponse(
         answer_text="The top borrower email is raw@example.com.",
         sql_query="SELECT count(*) FROM mip.gold.borrower_360",
@@ -2218,10 +2235,13 @@ def test_pii_answer_text_is_policy_blocked() -> None:
 
     result = repo.respond("show the top borrower email")
 
-    assert result.source == "policy_blocked"
-    assert result.sql_query is None
-    assert result.table_rows == []
+    assert result.source == "genie"
+    assert result.sql_query == live.sql_query
+    assert result.table_rows == [{"count": 1}]
     assert "raw@example.com" not in result.answer
+    assert "withheld" in result.answer
+    assert result.proof is not None
+    assert any("withheld by the output safety guard" in gap for gap in result.proof.known_data_gaps)
 
 
 def test_trusted_genie_answer_with_matching_numeric_claim_passes() -> None:
@@ -2262,7 +2282,10 @@ def test_trusted_genie_answer_does_not_duplicate_existing_source_line() -> None:
     assert result.answer.count("Source: mip.gold.borrower_360") == 1
 
 
-def test_trusted_genie_answer_with_unsupported_numeric_claim_is_policy_blocked() -> None:
+def test_trusted_genie_answer_with_unsupported_numeric_claim_withholds_prose() -> None:
+    """Unverifiable narrative numbers withhold the prose; the governed rows,
+    SQL, and proof still ship. The hallucinated number never renders."""
+
     live = GenieResponse(
         answer_text="There are 999 borrowers in this trusted cohort.",
         sql_query="SELECT 123 AS borrowers FROM mip.gold.borrower_360",
@@ -2281,16 +2304,17 @@ def test_trusted_genie_answer_with_unsupported_numeric_claim_is_policy_blocked()
 
     result = repo.respond("Summarize the trusted cohort.")
 
-    assert result.source == "policy_blocked"
-    assert result.sql_query is None
-    assert result.table_rows == []
-    assert result.visualization is None
-    assert result.actions == []
+    assert result.source == "genie"
+    assert result.sql_query == live.sql_query
+    assert result.table_rows == [{"borrowers": 123}]
     assert "999" not in result.answer
+    assert "withheld" in result.answer
     assert result.proof is not None
-    assert result.proof.trusted is False
-    assert result.proof.reasoning_trace == []
-    assert result.proof.known_data_gaps
+    assert result.proof.trusted is True
+    assert any(
+        "could not be verified against the returned rows" in gap
+        for gap in result.proof.known_data_gaps
+    )
 
 
 def test_numeric_claim_cannot_use_unrelated_matching_count_as_financial_support() -> None:
@@ -2305,8 +2329,10 @@ def test_numeric_claim_cannot_use_unrelated_matching_count_as_financial_support(
         _StubClient(_make_breaker("closed"), response=live)
     ).respond("Summarize the trusted cohort.")
 
-    assert result.source == "policy_blocked"
+    assert result.source == "genie"
+    assert result.table_rows == [{"borrowers": 123}]
     assert "$123" not in result.answer
+    assert "withheld" in result.answer
 
 
 def test_numeric_claim_is_not_waived_by_unbound_snapshot_date_language() -> None:
@@ -2321,8 +2347,10 @@ def test_numeric_claim_is_not_waived_by_unbound_snapshot_date_language() -> None
         _StubClient(_make_breaker("closed"), response=live)
     ).respond("Summarize the trusted cohort.")
 
-    assert result.source == "policy_blocked"
+    assert result.source == "genie"
+    assert result.table_rows == [{"borrowers": 123}]
     assert "2026" not in result.answer
+    assert "withheld" in result.answer
 
 
 def test_trusted_genie_numeric_check_accepts_rounded_percent_claim() -> None:
@@ -2501,8 +2529,10 @@ def test_trusted_genie_numeric_check_rejects_unscaled_word_suffix_claims() -> No
 
     result = repo.respond("Summarize the returned cohort.")
 
-    assert result.source == "policy_blocked"
-    assert result.table_rows == []
+    assert result.source == "genie"
+    assert result.table_rows == [{"avg_score": 1.2}]
+    assert "1.2 million" not in result.answer
+    assert "withheld" in result.answer
 
 
 def test_trusted_genie_numeric_check_ignores_identifier_dates_and_query_limits() -> None:
@@ -2537,9 +2567,10 @@ def test_trusted_genie_numeric_check_blocks_nonzero_claim_on_empty_rows() -> Non
 
     result = repo.respond("Summarize this empty cohort.")
 
-    assert result.source == "policy_blocked"
+    assert result.source == "genie"
     assert result.table_rows == []
     assert "10" not in result.answer
+    assert "withheld" in result.answer
 
 
 def test_backtick_quoted_trusted_sql_is_accepted() -> None:

--- a/tools/genie_eval_questions.yml
+++ b/tools/genie_eval_questions.yml
@@ -275,3 +275,54 @@ questions:
       - mip.gold.borrower_360
     min_rows: 5
     max_latency_s: 8
+
+  # ---------------------------------------------------------------------------
+  # Deep-analysis family (2026-08-06). The product's central promise: an agent
+  # that ranks candidates across all segments and explains each one plus its
+  # offer. These questions previously ended in governed refusals (missing
+  # canonical shape + campaign-grade output guard on analytics narrative).
+  # The canonical all-segments brief is the deterministic floor, so a refusal
+  # on any of these is a release-gating regression, not a model mood.
+  # ---------------------------------------------------------------------------
+  - id: deep_analysis_all_segments_offers_why
+    category: deep-analysis
+    question: >-
+      What are the top borrower candidates across all segments overall, what
+      makes them such good candidates exactly (for each one), and what is the
+      exact offer we should make to each and why?
+    must_cite:
+      - mip.gold.borrower_360
+    forbid_keywords:
+      - did not display the result
+      - not pass the governed output policy
+      - ask a scoped question
+    require_keywords:
+      - offer
+    min_rows: 5
+    max_latency_s: 60
+
+  - id: deep_analysis_explain_each_candidate
+    category: deep-analysis
+    question: >-
+      Show the top borrowers across all segments and explain why each one is a
+      good candidate.
+    must_cite:
+      - mip.gold.borrower_360
+    forbid_keywords:
+      - did not display the result
+      - not pass the governed output policy
+      - ask a scoped question
+    min_rows: 5
+    max_latency_s: 60
+
+  - id: deep_analysis_prioritize_overall_why
+    category: deep-analysis
+    question: Which borrowers should we prioritize overall for any offer, and why?
+    must_cite:
+      - mip.gold.borrower_360
+    forbid_keywords:
+      - did not display the result
+      - not pass the governed output policy
+      - ask a scoped question
+    min_rows: 5
+    max_latency_s: 60


### PR DESCRIPTION
Deep-analysis answers, made systemic:

1. compose_all_segments_brief: the all-segments top-candidates shape now
   answers with a real analyst brief — one bullet per candidate carrying
   its drivers (rate spread, equity, listing, multi-property, retention,
   HELOC propensity), the governed offer, and the reason those drivers
   select it, plus a cohort synthesis. Every number reads from the
   governed rows, so the brief can never be claims-blocked. When Genie's
   live narrative survives verification it leads and the brief follows;
   when it fails, the brief stands alone. Shared by the live repair path
   and the direct fallback; renders through the answer markdown.

2. Trusted SQL is now a floor, not a coin flip: once a turn holds
   policy-trusted SQL over trusted assets, the governed rows, SQL,
   proof, and actions ALWAYS ship. Only the model prose is conditionally
   withheld — output-guard flag or unverifiable numbers — and the
   withholding is disclosed in proof.known_data_gaps. The
   _numeric_claim_blocked_response hard refusal is retired; unverified
   model numbers and flagged prose still never render (pinned).
   The SQL-repair retry also runs for guard-flagged narratives (the
   repair prompt carries only the question).

3. No-refusal battery (tests/unit/test_genie_no_refusal_battery.py):
   11 representative valid analytical questions x prompt-guard
   non-interception, and x4 adversarial narrative variants over a
   trusted turn asserting policy_blocked never fires. First run caught
   a real interceptor: the contextual-name regex read 'prioritize
   overall for' as a person lookup — domain vocabulary added to its
   stop-word lookahead.

4. Genie space instructions now require per-row driver narration using
   only result-row numbers; the release-gating eval pack gains a
   deep-analysis category (3 questions) where any refusal is a gating
   regression.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
