### PR TITLE
fix(genie): live-probe fixes — HELOC ranking false refusal, age-proxy template, call-N strategy routing

### DIFF
--- a/backend/schemas/_validators.py
+++ b/backend/schemas/_validators.py
@@ -94,6 +94,7 @@ _PROTECTED_CLASS_MARKETING_RE = re.compile(
 
 _PROTECTED_AGE_CITIZENSHIP_MARKETING_RE = re.compile(
     r"\b(?:baby\s+boomers?|boomers?|gen(?:eration)?\s*[xyz]|millennials?|retirees?|"
+    r"retired\s+(?:homeowners?|borrowers?|households?|couples?|residents?|owners?|people|persons?)|"
     r"retirement[- ]age|young\s+families|foreign[- ]born|non[- ]?citizens?|"
     r"citizenship\s+status|citizens?|naturalized\s+(?:citizens?|homeowners?|"
     r"borrowers?|people|persons?)|"
@@ -573,7 +574,10 @@ _MECHANICAL_PII_OR_RAW_IDENTIFIER_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 _CONTEXTUAL_HUMAN_NAME_RE = re.compile(
     r"\b(?:call|contact|email|message|text|ask|target|prioritize|dear|hello|hi)\s+"
-    r"(?!(?:to|the|a|an|and|or|at|about|before|if|when|this|that|these|those|your|our|us|me|you|"
+    # Prepositions after the verb ("target for reverse mortgages", "call with
+    # an offer") are sentence structure, never a person's first name.
+    r"(?!(?:for|with|on|in|by|from|into|over|under|near|toward|towards|across|during|after|against|without|"
+    r"to|the|a|an|and|or|at|about|before|if|when|this|that|these|those|your|our|us|me|you|"
     r"them|him|her|it|then|provider|carrier|system|platform|service|gateway|authorization|consent|permission|outreach|contact|records?|"
     # Domain population/ranking vocabulary: "prioritize overall", "contact
     # borrowers", "target top segments" are core product phrasings, not

--- a/backend/services/genie_message_policy.py
+++ b/backend/services/genie_message_policy.py
@@ -111,6 +111,14 @@ _SAFE_PHRASE_PATTERNS: tuple[re.Pattern[str], ...] = (
         r"sands?|house|hall|bear|fish|hawk|diamond)(?![a-z0-9])",
         re.IGNORECASE,
     ),
+    # Governed offer connectors (live probe 2026-08-06): "candidates with
+    # offers" / "with what offer" is core product phrasing, but the trailing
+    # "with" reads as an audience-criterion connector to the campaign clause
+    # machine and refused a plain HELOC ranking ask. Masking only these
+    # literal offer connectors keeps unknown-term laundering ("carry zyrplax")
+    # fully scannable.
+    re.compile(r"(?<![a-z0-9])with (?:what )?offers?(?![a-z0-9])", re.IGNORECASE),
+    re.compile(r"(?<![a-z0-9])heloc[- ]eligible(?![a-z0-9])", re.IGNORECASE),
 )
 
 

--- a/backend/services/repositories/databricks_genie_canonical.py
+++ b/backend/services/repositories/databricks_genie_canonical.py
@@ -2138,14 +2138,28 @@ def _canonical_itm_top_tier_compare_scope(question: str) -> bool:
 def _canonical_strategy_board_scope(question: str) -> bool:
     q = re.sub(r"[^a-z0-9\s]+", " ", question.lower())
     q = re.sub(r"\s+", " ", q).strip()
-    spend_terms = ("spend", "allocate", "prioritize", "focus", "deploy")
-    touch_terms = ("outreach touch", "outreach touches", "touches", "contacts", "campaign")
+    # "call/contact N borrowers — which segments, states, offers?" is the
+    # same capacity-allocation ask as "spend N outreach touches"; both route
+    # to the state-segment-offer strategy board.
+    spend_terms = ("spend", "allocate", "prioritize", "focus", "deploy", "call", "contact", "reach")
+    touch_terms = (
+        "outreach touch",
+        "outreach touches",
+        "touches",
+        "contacts",
+        "campaign",
+        "borrowers",
+        "leads",
+        "calls",
+        "people",
+    )
     strategy_terms = ("strategy", "where should", "which state", "which segment")
-    has_touch_count = "10000" in q or "10 000" in q or "10k" in q
+    has_touch_count = bool(re.search(r"\b\d{2,7}\b", q)) or "10k" in q
     return (
         any(term in q for term in spend_terms)
         and any(term in q for term in touch_terms)
         and (has_touch_count or any(term in q for term in strategy_terms))
+        and any(term in q for term in (*strategy_terms, "offer", "offers", "touches", "campaign"))
     )
 
 

--- a/tests/unit/test_genie_no_refusal_battery.py
+++ b/tests/unit/test_genie_no_refusal_battery.py
@@ -54,6 +54,10 @@ VALID_ANALYTICAL_QUESTIONS: tuple[str, ...] = (
     "Which borrowers on our retention list have a competitor lien filed in the last 30 days?",
     "Break down the Investor / Multi-Property segment by state and average current rate.",
     "Where should we spend our next 10,000 outreach touches this week, and why?",
+    # Live-probe catches (2026-08-06): both previously refused.
+    "Take the best ZIP for HELOC-eligible borrowers and show its top candidates with offers.",
+    "If we can only call 500 borrowers this week, which segments and states should the "
+    "list come from, with what offers, and why?",
 )
 
 _PROMPT_MATCHERS = (
@@ -113,3 +117,15 @@ def test_trusted_sql_turn_never_refuses(question: str, variant_name: str, narrat
         assert "John Smith" not in result.answer
     if variant_name == "claims_mismatch":
         assert "999,999" not in result.answer
+
+
+def test_fair_lending_asks_refuse_with_the_protected_class_reason() -> None:
+    """Genuine protected-class asks refuse via the protected matcher — the
+    fair-lending template, not a misfired PII/name-lookup template (live
+    probe 2026-08-06: the age-proxy ask drew the PII refusal instead)."""
+
+    age_proxy = "Which neighborhoods with mostly retired homeowners should we target for reverse mortgages?"
+    assert protected_prompt_match(age_proxy) is not None
+    assert identity_prompt_match(age_proxy) is False
+    assert protected_prompt_match("Target Hispanic neighborhoods with this offer.") is not None
+    assert protected_prompt_match("Focus outreach on elderly borrowers.") is not None


### PR DESCRIPTION
Ten-question live probe of the deployed app (2026-08-06) caught three
product bugs; each is fixed at the narrowest correct layer:

1. 'Take the best ZIP for HELOC-eligible borrowers and show its top
   candidates with offers.' refused as protected-class language: the
   campaign clause machine read the trailing 'candidates with' as an
   audience-criterion connector. Fix: mask the governed offer connectors
   ('with offers', 'with what offer', 'HELOC-eligible') in the prompt
   safe-phrase pre-masker. The unknown-term laundering battery ('carry
   zyrplax', round18) stays fully armed — an earlier blunt analytics
   bypass was reverted in favor of this surgical mask.

2. 'Which neighborhoods with mostly retired homeowners should we target
   for reverse mortgages?' refused with the PII template instead of the
   fair-lending one: 'target for reverse' tripped the contextual-name
   regex (verb + preposition read as a person), and 'retired homeowners'
   was missing from the age-proxy vocabulary. Prepositions added to the
   name-regex stoplist; 'retired <population>' added to the age proxies.

3. 'If we can only call 500 borrowers this week, which segments and
   states...' fell to the governed refusal: the strategy-board scope
   only knew 'spend N outreach touches'. call/contact/reach + any
   2-7-digit capacity + an allocation signal now route to the
   state-segment-offer strategy board.

The no-refusal battery gains both valid questions plus a
fair-lending-template regression test.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
