### PR TITLE
docs(genie): document the three missing evidence signal types in the space

### DIFF
--- a/genie/mortgage_lead_intelligence_space.yml
+++ b/genie/mortgage_lead_intelligence_space.yml
@@ -367,7 +367,8 @@ trusted_assets:
       Refreshed trigger evidence table of events (rate_spread, equity,
       market_trend, competitor_lien, multi_property, absentee_mailing,
       corporate_owner, recent_refi, recent_payoff, recent_sale,
-      foreclosure_stage, listing, heloc_propensity, refi_propensity) per borrower with a UTC timestamp, confidence, and
+      foreclosure_stage, listing, heloc_propensity, refi_propensity,
+      product_type, origination_channel, loan_type_fit) per borrower with a UTC timestamp, confidence, and
       source-table citation. Filed building-permit trigger feeds are pending
       Cotality delivery and remain disabled today. Use this for
       supporting proof, timelines, and trigger freshness; offer rationale text


### PR DESCRIPTION
Deep modeling inspection (2026-08-06): mip.gold.evidence_events carries
17 live signal_type values; the space's asset description listed only
14, omitting product_type (3.05M rows), origination_channel (475k), and
loan_type_fit (335k) — an incomplete vocabulary that could steer Genie
away from valid enum filters. Inspection found NO modeling defects in
these rows; this is documentation drift only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
