### PR TITLE
fix(genie): don't render single-letter listing status codes in the brief

### DIFF
--- a/backend/services/repositories/databricks_genie_canonical.py
+++ b/backend/services/repositories/databricks_genie_canonical.py
@@ -716,7 +716,11 @@ def _brief_signal_sentences(row: dict[str, Any]) -> list[str]:
     segments = {code.strip() for code in str(row.get("segments") or "").split(",")}
     if row.get("listed_for_sale"):
         status = str(row.get("listing_status_category") or "").strip().lower()
-        status_txt = f" ({status})" if status and status not in {"none", "unknown"} else ""
+        # Only annotate with a readable status word — single-letter source
+        # codes ("a") add noise, not meaning, for a general reader.
+        status_txt = (
+            f" ({status})" if len(status) >= 4 and status not in {"none", "unknown"} else ""
+        )
         sentences.append(
             f"The home is actively listed for sale{status_txt} — the strongest "
             "intent signal in the funnel, because when it sells this borrower "


### PR DESCRIPTION
Live verification showed 'listed for sale (a)' — the raw MLS status
code leaking where only a readable word ('active', 'pending') adds
meaning for a general reader.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
