### PR TITLE
feat(genie): teaching-analyst brief across every borrower ranking shape

### DIFF
--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -70,6 +70,7 @@ from backend.services.repositories.databricks_genie_canonical import (
     _specific_top_borrower_intent_note,
     _specific_top_borrower_sort_label,
     compose_all_segments_brief,
+    compose_cohort_ranking_brief,
 )
 from backend.services.repositories.databricks_genie_direct import (
     direct_canonical_response,
@@ -132,7 +133,6 @@ from backend.services.repositories.databricks_genie_visualization import (
     _value_column,  # noqa: F401 - compatibility re-export
 )
 from backend.services.resilience import DependencyDownError
-from backend.services.scoring import offer_display_label
 
 _SOURCE_LINE_RE = re.compile(
     r"(?im)^\s*source\s*:\s*`?[A-Za-z_][\w-]*\.[A-Za-z_]\w*\.[A-Za-z_]\w*`?\.?\s*$"
@@ -881,14 +881,13 @@ def _canonical_genie_answer(
             source="trusted_sql",
         )
         if rows:
-            top = rows[0]
             intent_note = _specific_top_borrower_intent_note(question, intent)
-            answer = (
-                f"I ranked the top {len(rows)} {state_name} ({state_code}) "
-                f"{intent_label} borrowers from {borrower_asset}, ordered by "
-                f"{sort_label}. The current first borrower is masked "
-                f"{top.get('borrower_id')} with opportunity score "
-                f"{int(top.get('opportunity_score') or 0):,}.{intent_note}"
+            answer = compose_cohort_ranking_brief(
+                rows,
+                cohort_label=f"{state_name} ({state_code}) {intent_label} borrowers",
+                ordering_label=sort_label,
+                source_asset=borrower_asset,
+                scope_note=intent_note.strip(),
             )
         elif retention_fallback is not None:
             answer = retention_fallback.answer
@@ -980,14 +979,13 @@ def _canonical_genie_answer(
             source="trusted_sql",
         )
         if rows:
-            top = rows[0]
             intent_note = _specific_top_borrower_intent_note(question, intent)
-            answer = (
-                f"I ranked the top {len(rows)} {intent_label} borrowers across the "
-                f"current refreshed coverage from {borrower_asset}, ordered by "
-                f"{sort_label}. The current first borrower is masked "
-                f"{top.get('borrower_id')} with opportunity score "
-                f"{int(top.get('opportunity_score') or 0):,}.{intent_note}"
+            answer = compose_cohort_ranking_brief(
+                rows,
+                cohort_label=f"{intent_label} borrowers across the current refreshed coverage",
+                ordering_label=sort_label,
+                source_asset=borrower_asset,
+                scope_note=intent_note.strip(),
             )
         elif retention_fallback is not None:
             answer = retention_fallback.answer
@@ -1071,7 +1069,7 @@ def _canonical_genie_answer(
             _emit_genie_warning("canonical_genie_top_borrowers_state_failed", exc=exc)
             return None
         rows = _redact_genie_rows(rows) or []
-        trusted_assets = [lead_population_asset]
+        trusted_assets = [lead_population_asset, borrower_asset]
         question_hash = _genie_question_hash(question)
         proof = _build_genie_proof(
             sql_query=_CANONICAL_TOP_BORROWERS_BY_STATE_SQL,
@@ -1094,19 +1092,15 @@ def _canonical_genie_answer(
             sql_query=_CANONICAL_TOP_BORROWERS_BY_STATE_SQL,
             source="trusted_sql",
         )
-        if rows:
-            top = rows[0]
-            answer = (
-                f"I ranked the top {len(rows)} {state_name} ({state_code}) borrowers "
-                f"by lead score from {lead_population_asset}. "
-                f"The current leader is masked borrower {top.get('borrower_id')} "
-                f"with lead score {int(top.get('lead_score') or 0):,}."
-            )
-        else:
-            answer = (
-                f"The trusted lead population returned no {state_name} ({state_code}) "
-                "borrowers for the current refreshed data coverage."
-            )
+        answer = compose_cohort_ranking_brief(
+            rows,
+            cohort_label=f"{state_name} ({state_code}) borrowers in the ranked Lead Queue",
+            ordering_label="lead score",
+            source_asset=lead_population_asset,
+        ) if rows else (
+            f"The trusted lead population returned no {state_name} ({state_code}) "
+            "borrowers for the current refreshed data coverage."
+        )
         return GenieMessageResponse(
             conversation_id=result.conversation_id,
             message_id=result.message_id,
@@ -1130,7 +1124,7 @@ def _canonical_genie_answer(
             _emit_genie_warning("canonical_genie_top_borrowers_global_failed", exc=exc)
             return None
         rows = _redact_genie_rows(rows) or []
-        trusted_assets = [lead_population_asset]
+        trusted_assets = [lead_population_asset, borrower_asset]
         question_hash = _genie_question_hash(question)
         proof = _build_genie_proof(
             sql_query=_CANONICAL_TOP_BORROWERS_GLOBAL_SQL,
@@ -1153,19 +1147,15 @@ def _canonical_genie_answer(
             sql_query=_CANONICAL_TOP_BORROWERS_GLOBAL_SQL,
             source="trusted_sql",
         )
-        if rows:
-            top = rows[0]
-            answer = (
-                f"I ranked the top {len(rows)} marketing-eligible borrowers by lead "
-                f"score from {lead_population_asset}. The current first borrower is "
-                f"masked {top.get('borrower_id')} with lead score "
-                f"{int(top.get('lead_score') or 0):,}."
-            )
-        else:
-            answer = (
-                "The ranked lead population returned no marketing-eligible borrower "
-                "rows for the current refreshed coverage."
-            )
+        answer = compose_cohort_ranking_brief(
+            rows,
+            cohort_label="marketing-eligible borrowers in the ranked Lead Queue",
+            ordering_label="lead score",
+            source_asset=lead_population_asset,
+        ) if rows else (
+            "The ranked lead population returned no marketing-eligible borrower "
+            "rows for the current refreshed coverage."
+        )
         return GenieMessageResponse(
             conversation_id=result.conversation_id,
             message_id=result.message_id,
@@ -1547,24 +1537,15 @@ def _canonical_genie_answer(
             sql_query=_CANONICAL_LISTED_PURCHASE_TOP_SQL,
             source="trusted_sql",
         )
-        if rows:
-            top = rows[0]
-            top_offer = offer_display_label(
-                str(top.get("recommended_offer_code") or ""),
-                str(top.get("recommended_offer") or ""),
-            )
-            answer = (
-                f"I ranked the top {len(rows)} marketing-eligible listed-for-sale borrowers "
-                f"from {borrower_asset}. The current first borrower is masked "
-                f"{top.get('borrower_id')} in {top.get('city')}, {top.get('state')} "
-                f"with opportunity score {int(top.get('opportunity_score') or 0):,}. "
-                f"Lead with {top_offer} only after review in the governed outreach workflow."
-            )
-        else:
-            answer = (
-                "The trusted borrower table returned no marketing-eligible listed-for-sale "
-                "borrowers for the current refreshed coverage."
-            )
+        answer = compose_cohort_ranking_brief(
+            rows,
+            cohort_label="marketing-eligible listed-for-sale borrowers",
+            ordering_label="opportunity score among active listing signals",
+            source_asset=borrower_asset,
+        ) if rows else (
+            "The trusted borrower table returned no marketing-eligible listed-for-sale "
+            "borrowers for the current refreshed coverage."
+        )
         return GenieMessageResponse(
             conversation_id=result.conversation_id,
             message_id=result.message_id,
@@ -1693,7 +1674,7 @@ def _canonical_genie_answer(
             source="trusted_sql",
         )
         answer = (
-            f"There are {count_int:,} borrowers passing the refinance-economics screen in {city_scope} "
+            f"There are {count_int:,} borrowers passing the refinance-economics screen in {city_scope} — meaning their current mortgage rate sits far enough above today\'s market, with enough home equity, that refinancing typically pays for itself — "
             f"within the current {_current_footprint_label()} evaluation-share scope. "
             f"This is a city-scoped unique borrower count from {borrower_asset}; "
             "it is not the overall share total."
@@ -1758,7 +1739,7 @@ def _canonical_genie_answer(
     )
     geo_text = f" in {state_scope[0]} ({state_scope[1]})" if state_scope else ""
     answer = (
-        f"There are {count_int:,} borrowers passing the refinance-economics screen{geo_text}. "
+        f"There are {count_int:,} borrowers passing the refinance-economics screen{geo_text} — meaning their current mortgage rate sits far enough above today\'s market, with enough home equity, that refinancing typically pays for itself. "
         f"This is a unique borrower count from {borrower_asset} at the "
         "gold borrower grain, so multi-segment borrowers are counted once."
     )

--- a/backend/services/repositories/databricks_genie_canonical.py
+++ b/backend/services/repositories/databricks_genie_canonical.py
@@ -828,8 +828,37 @@ def _brief_offer_paragraph(row: dict[str, Any]) -> str:
     return f"**The offer: {offer}.** {reason[0].upper() + reason[1:] if reason else reason}"
 
 
-def compose_all_segments_brief(rows: list[dict[str, Any]], borrower_asset: str) -> str:
-    """Deterministic analyst brief for the all-segments top-candidates shape.
+def _brief_screen_txt(rows: list[dict[str, Any]]) -> str:
+    top = rows[0] if rows else {}
+    min_spread = _brief_int(top.get("min_spread_bps_applied"))
+    min_equity = _brief_int(top.get("min_equity_pct_applied"))
+    return (
+        f"at least {min_spread} bps of spread with at least {min_equity}% equity"
+        if min_spread and min_equity
+        else "enough spread and equity"
+    )
+
+
+def _brief_terms_txt(rows: list[dict[str, Any]]) -> str:
+    """The shared term-teaching sentence, thresholds read from the rows."""
+
+    return (
+        "Two terms recur below: **rate spread** is how far a borrower's "
+        "current mortgage rate sits above today's market rate, measured in "
+        "basis points (100 bps = 1 percentage point), and a borrower is "
+        "**in the money** when that gap is wide enough to make refinancing "
+        f"pay for itself ({_brief_screen_txt(rows)} under the current policy)."
+    )
+
+
+def compose_borrower_ranking_brief(
+    rows: list[dict[str, Any]],
+    *,
+    intro: str,
+    source_asset: str,
+    empty_message: str,
+) -> str:
+    """Teaching-analyst brief shared by every borrower-level ranking shape.
 
     Written for a Head of Growth, not a mortgage quant: every term is
     explained inline, every number is interpreted in dollars and plain
@@ -840,37 +869,8 @@ def compose_all_segments_brief(rows: list[dict[str, Any]], borrower_asset: str) 
     """
 
     if not rows:
-        return (
-            "The trusted borrower table returned no marketing-eligible, opt-in "
-            "borrowers across the segment portfolio for the current refreshed "
-            "coverage."
-        )
-    refreshed = str(rows[0].get("refreshed_at") or "")[:10]
-    refreshed_txt = f", refreshed {refreshed}," if refreshed else ""
-    top = rows[0]
-    min_spread = _brief_int(top.get("min_spread_bps_applied"))
-    min_equity = _brief_int(top.get("min_equity_pct_applied"))
-    screen_txt = (
-        f"at least {min_spread} bps of spread with at least {min_equity}% equity"
-        if min_spread and min_equity
-        else "enough spread and equity"
-    )
-    blocks: list[str] = [
-        (
-            f"I ranked every marketing-eligible, opt-in borrower in "
-            f"{borrower_asset}{refreshed_txt} by **opportunity score** — a "
-            "0-100 blend of refinance economics, home equity, listing "
-            "activity, portfolio ownership, retention risk, and Cotality's "
-            "behavioral propensity models — with rate-spread economics "
-            "breaking ties. Two terms recur below: **rate spread** is how far "
-            "a borrower's current mortgage rate sits above today's market "
-            "rate, measured in basis points (100 bps = 1 percentage point), "
-            "and a borrower is **in the money** when that gap is wide enough "
-            f"to make refinancing pay for itself ({screen_txt} under the "
-            f"current policy). Here are the top {len(rows)} candidates in "
-            "depth:"
-        )
-    ]
+        return empty_message
+    blocks: list[str] = [intro]
     for rank, row in enumerate(rows, start=1):
         score = _brief_int(row.get("opportunity_score"))
         header = (
@@ -918,8 +918,63 @@ def compose_all_segments_brief(rows: list[dict[str, Any]], borrower_asset: str) 
         "recommendation still requires human approval there before any "
         "outreach happens."
     )
-    blocks.append(f"Source: {borrower_asset}")
+    blocks.append(f"Source: {source_asset}")
     return "\n\n".join(blocks)
+
+
+def compose_all_segments_brief(rows: list[dict[str, Any]], borrower_asset: str) -> str:
+    """The all-segments hero brief, built on the shared ranking composer."""
+
+    refreshed = str(rows[0].get("refreshed_at") or "")[:10] if rows else ""
+    refreshed_txt = f", refreshed {refreshed}," if refreshed else ""
+    intro = (
+        f"I ranked every marketing-eligible, opt-in borrower in "
+        f"{borrower_asset}{refreshed_txt} by **opportunity score** — a "
+        "0-100 blend of refinance economics, home equity, listing "
+        "activity, portfolio ownership, retention risk, and Cotality's "
+        "behavioral propensity models — with rate-spread economics "
+        f"breaking ties. {_brief_terms_txt(rows)} Here are the top "
+        f"{len(rows)} candidates in depth:"
+    )
+    return compose_borrower_ranking_brief(
+        rows,
+        intro=intro,
+        source_asset=borrower_asset,
+        empty_message=(
+            "The trusted borrower table returned no marketing-eligible, opt-in "
+            "borrowers across the segment portfolio for the current refreshed "
+            "coverage."
+        ),
+    )
+
+
+def compose_cohort_ranking_brief(
+    rows: list[dict[str, Any]],
+    *,
+    cohort_label: str,
+    ordering_label: str,
+    source_asset: str,
+    scope_note: str = "",
+) -> str:
+    """Teaching brief for a named ranking cohort (intent, state, Lead Queue)."""
+
+    refreshed = str(rows[0].get("refreshed_at") or "")[:10] if rows else ""
+    refreshed_txt = f", refreshed {refreshed}," if refreshed else ""
+    intro = (
+        f"I ranked the top {len(rows)} {cohort_label} from "
+        f"{source_asset}{refreshed_txt} ordered by {ordering_label}."
+        f"{' ' + scope_note if scope_note else ''} "
+        f"{_brief_terms_txt(rows)} Here is each candidate in depth:"
+    )
+    return compose_borrower_ranking_brief(
+        rows,
+        intro=intro,
+        source_asset=source_asset,
+        empty_message=(
+            f"The trusted borrower table returned no marketing-eligible "
+            f"{cohort_label} for the current refreshed coverage."
+        ),
+    )
 
 _CANONICAL_TOP_REFI_BORROWERS_BY_STATE_SQL = f"""
 SELECT borrower_id
@@ -1217,6 +1272,119 @@ _CANONICAL_TOP_BORROWERS_GLOBAL_INTENT_SQL = {
     "investor": _CANONICAL_TOP_INVESTOR_BORROWERS_GLOBAL_SQL,
     "retention": _CANONICAL_TOP_RETENTION_BORROWERS_GLOBAL_SQL,
 }
+
+# ---------------------------------------------------------------------------
+# Teaching-analyst ranking SQL (2026-08-06). Every borrower-level ranking
+# shape shares one economics-rich SELECT so the analyst brief can interpret
+# each candidate in dollars, rates, and behavioral signals with the
+# run-specific policy thresholds. The generated dicts below REPLACE the
+# per-intent constants above at import time; the legacy constants remain only
+# as documentation of each shape's cohort predicate and ordering.
+# ---------------------------------------------------------------------------
+_RANKING_SELECT_COLUMNS = """b.borrower_id
+     , b.display_name
+     , b.city
+     , b.state
+     , b.zip
+     , array_join(b.segment_codes, ', ') AS segments
+     , b.opportunity_score
+     , b.rate_spread_bps
+     , b.equity_pct
+     , b.equity_estimate
+     , b.current_rate
+     , b.current_lien_balance
+     , b.avm_value
+     , b.in_the_money
+     , b.listed_for_sale
+     , b.listing_status_category
+     , b.related_property_count
+     , b.heloc_propensity_score
+     , b.has_heloc_propensity_trigger
+     , b.is_current_customer
+     , b.min_spread_bps_applied
+     , b.min_equity_pct_applied
+     , b.heloc_equity_min_applied
+     , b.cashout_equity_min_applied
+     , b.recommended_offer_code
+     , b.recommended_offer
+     , b.refreshed_at"""
+
+
+def _borrower_ranking_sql(where: str, order: str, *, state_scoped: bool) -> str:
+    scope = "b.state = :state\n  AND " if state_scoped else ""
+    return (
+        f"SELECT {_RANKING_SELECT_COLUMNS}\n"
+        f"FROM {_BORROWER_360} AS b\n"
+        f"WHERE {scope}{where}\n"
+        f"  AND {_B_ELIGIBLE}\n"
+        "  AND b.consent_status = 'opt_in'\n"
+        f"ORDER BY {order}\n"
+        "LIMIT 10"
+    )
+
+
+_INTENT_RANKING_SPECS: dict[str, tuple[str, str]] = {
+    "refi": (
+        "b.in_the_money = TRUE",
+        "b.opportunity_score DESC, b.rate_spread_bps DESC, b.borrower_id ASC",
+    ),
+    "cash_out": (
+        "b.recommended_offer_code = 'cash_out'",
+        "b.equity_estimate DESC, b.opportunity_score DESC, b.borrower_id ASC",
+    ),
+    "heloc": (
+        "(b.recommended_offer_code IN ('heloc', 'refi_plus_heloc')"
+        " OR b.has_heloc_propensity_trigger = TRUE"
+        " OR array_contains(b.segment_codes, 'permit'))",
+        "b.heloc_propensity_score DESC NULLS LAST, b.equity_estimate DESC, "
+        "b.opportunity_score DESC, b.borrower_id ASC",
+    ),
+    "listed": (
+        "b.listed_for_sale = TRUE",
+        "b.opportunity_score DESC, b.borrower_id ASC",
+    ),
+    "investor": (
+        "(array_contains(b.segment_codes, 'investor') OR b.is_investor = TRUE)",
+        "b.related_property_count DESC NULLS LAST, b.opportunity_score DESC, b.borrower_id ASC",
+    ),
+    "retention": (
+        "array_contains(b.segment_codes, 'retention')",
+        "b.opportunity_score DESC, b.rate_spread_bps DESC, b.borrower_id ASC",
+    ),
+}
+
+_CANONICAL_TOP_BORROWERS_BY_STATE_INTENT_SQL = {
+    intent: _borrower_ranking_sql(where, order, state_scoped=True)
+    for intent, (where, order) in _INTENT_RANKING_SPECS.items()
+}
+_CANONICAL_TOP_BORROWERS_GLOBAL_INTENT_SQL = {
+    intent: _borrower_ranking_sql(where, order, state_scoped=False)
+    for intent, (where, order) in _INTENT_RANKING_SPECS.items()
+}
+_CANONICAL_LISTED_PURCHASE_TOP_SQL = _borrower_ranking_sql(
+    _INTENT_RANKING_SPECS["listed"][0],
+    _INTENT_RANKING_SPECS["listed"][1],
+    state_scoped=False,
+)
+
+# Lead-Queue rankings keep mip.gold.lead_population as the source of the
+# ranked cohort (its rank/score are the operational truth) and join
+# borrower_360 for the economics the analyst brief interprets.
+_LEAD_QUEUE_RANKING_SQL_TEMPLATE = (
+    f"SELECT {_RANKING_SELECT_COLUMNS}\n"
+    "     , lp.rank_overall\n"
+    f"FROM {_LEAD_POPULATION} AS lp\n"
+    f"JOIN {_BORROWER_360} AS b ON b.borrower_id = lp.borrower_id\n"
+    "WHERE {scope}\n"
+    "ORDER BY lp.opportunity_score DESC, lp.rank_overall ASC, lp.borrower_id ASC\n"
+    "LIMIT 10"
+)
+_CANONICAL_TOP_BORROWERS_BY_STATE_SQL = _LEAD_QUEUE_RANKING_SQL_TEMPLATE.format(
+    scope="lp.state = :state"
+)
+_CANONICAL_TOP_BORROWERS_GLOBAL_SQL = _LEAD_QUEUE_RANKING_SQL_TEMPLATE.format(
+    scope=eligible_sql_predicate("lp")
+)
 
 _CANONICAL_TOP_CASH_OUT_BY_EQUITY_SQL = f"""
 SELECT borrower_id

--- a/backend/services/repositories/databricks_genie_direct.py
+++ b/backend/services/repositories/databricks_genie_direct.py
@@ -127,6 +127,7 @@ from backend.services.repositories.databricks_genie_canonical import (
     _specific_top_borrower_intent_note,
     _specific_top_borrower_sort_label,
     compose_all_segments_brief,
+    compose_cohort_ranking_brief,
 )
 from backend.services.repositories.databricks_genie_policy_helpers import (
     _emit_genie_warning,
@@ -839,14 +840,13 @@ def direct_canonical_response(
             )
             return None
         if rows:
-            top = rows[0]
             intent_note = _specific_top_borrower_intent_note(question, intent)
-            answer = (
-                f"I ranked the top {len(rows)} {state_name} ({state_code}) "
-                f"{intent_label} borrowers from {borrower_asset}, ordered by "
-                f"{sort_label}. The current first borrower is masked "
-                f"{top.get('borrower_id')} with opportunity score "
-                f"{int(top.get('opportunity_score') or 0):,}.{intent_note}"
+            answer = compose_cohort_ranking_brief(
+                rows,
+                cohort_label=f"{state_name} ({state_code}) {intent_label} borrowers",
+                ordering_label=sort_label,
+                source_asset=borrower_asset,
+                scope_note=intent_note.strip(),
             )
             response_sql_query = sql_query
             response_rows = rows
@@ -924,14 +924,13 @@ def direct_canonical_response(
             )
             return None
         if rows:
-            top = rows[0]
             intent_note = _specific_top_borrower_intent_note(question, intent)
-            answer = (
-                f"I ranked the top {len(rows)} {intent_label} borrowers across the "
-                f"current refreshed coverage from {borrower_asset}, ordered by "
-                f"{sort_label}. The current first borrower is masked "
-                f"{top.get('borrower_id')} with opportunity score "
-                f"{int(top.get('opportunity_score') or 0):,}.{intent_note}"
+            answer = compose_cohort_ranking_brief(
+                rows,
+                cohort_label=f"{intent_label} borrowers across the current refreshed coverage",
+                ordering_label=sort_label,
+                source_asset=borrower_asset,
+                scope_note=intent_note.strip(),
             )
             response_sql_query = sql_query
             response_rows = rows
@@ -1000,19 +999,15 @@ def direct_canonical_response(
         except DatabricksSqlError as exc:
             _emit_genie_warning("direct_canonical_genie_top_borrowers_state_failed", exc=exc)
             return None
-        if rows:
-            top = rows[0]
-            answer = (
-                f"I ranked the top {len(rows)} {state_name} ({state_code}) borrowers "
-                f"by lead score from {lead_population_asset}. "
-                f"The current leader is masked borrower {top.get('borrower_id')} "
-                f"with lead score {int(top.get('lead_score') or 0):,}."
-            )
-        else:
-            answer = (
-                f"The trusted lead population returned no {state_name} ({state_code}) "
-                "borrowers for the current refreshed data coverage."
-            )
+        answer = compose_cohort_ranking_brief(
+            rows,
+            cohort_label=f"{state_name} ({state_code}) borrowers in the ranked Lead Queue",
+            ordering_label="lead score",
+            source_asset=lead_population_asset,
+        ) if rows else (
+            f"The trusted lead population returned no {state_name} ({state_code}) "
+            "borrowers for the current refreshed data coverage."
+        )
         return trusted_response(
             question=question,
             sql_query=_CANONICAL_TOP_BORROWERS_BY_STATE_SQL,
@@ -1049,18 +1044,15 @@ def direct_canonical_response(
         except DatabricksSqlError as exc:
             _emit_genie_warning("direct_canonical_genie_top_borrowers_global_failed", exc=exc)
             return None
-        if rows:
-            top = rows[0]
-            answer = (
-                f"I ranked the top {len(rows)} marketing-eligible borrowers by lead score "
-                f"from {lead_population_asset}. The current first borrower is masked "
-                f"{top.get('borrower_id')} with lead score {int(top.get('lead_score') or 0):,}."
-            )
-        else:
-            answer = (
-                "The ranked lead population returned no marketing-eligible borrower rows "
-                "for the current refreshed coverage."
-            )
+        answer = compose_cohort_ranking_brief(
+            rows,
+            cohort_label="marketing-eligible borrowers in the ranked Lead Queue",
+            ordering_label="lead score",
+            source_asset=lead_population_asset,
+        ) if rows else (
+            "The ranked lead population returned no marketing-eligible borrower rows "
+            "for the current refreshed coverage."
+        )
         return trusted_response(
             question=question,
             sql_query=_CANONICAL_TOP_BORROWERS_GLOBAL_SQL,
@@ -1207,17 +1199,11 @@ def direct_canonical_response(
             return None
         listed_assets = [borrower_asset]
         if rows:
-            top = rows[0]
-            top_offer = offer_display_label(
-                str(top.get("recommended_offer_code") or ""),
-                str(top.get("recommended_offer") or ""),
-            )
-            answer = (
-                f"I ranked the top {len(rows)} marketing-eligible listed-for-sale borrowers "
-                f"from {borrower_asset}. The current first borrower is masked "
-                f"{top.get('borrower_id')} in {top.get('city')}, {top.get('state')} "
-                f"with opportunity score {int(top.get('opportunity_score') or 0):,}. "
-                f"Lead with {top_offer} only after review in the governed outreach workflow."
+            answer = compose_cohort_ranking_brief(
+                rows,
+                cohort_label="marketing-eligible listed-for-sale borrowers",
+                ordering_label="opportunity score among active listing signals",
+                source_asset=borrower_asset,
             )
         else:
             answer = (

--- a/tests/unit/test_genie_direct.py
+++ b/tests/unit/test_genie_direct.py
@@ -107,7 +107,7 @@ class _RetentionEligibilitySqlClient(_UniversalSqlClient):
                     "refreshed_at": "2026-06-17T14:33:04.239Z",
                 }
             ]
-        if "array_contains(segment_codes, 'retention')" in sql:
+        if "segment_codes, 'retention')" in sql and "action_ready" not in sql:
             return []
         return super().execute(statement, parameters)
 
@@ -513,7 +513,7 @@ def test_direct_investor_count_and_refi_economic_synonyms_stay_canonical() -> No
 
     assert investor is not None and investor.source == "trusted_sql"
     assert investor.sql_query is not None
-    assert "array_contains(segment_codes, 'investor')" in investor.sql_query
+    assert "segment_codes, 'investor')" in investor.sql_query
     assert investor.metric_value == "1,749,208"
     assert investor_display_verb is not None and investor_display_verb.source == "trusted_sql"
     assert investor_display_verb.sql_query is not None
@@ -582,13 +582,13 @@ def test_direct_itm_state_breakdown_reconciles_lead_queue_action_subset() -> Non
         (
             "best investor borrowers in Florida",
             "FL",
-            "array_contains(segment_codes, 'investor')",
+            "segment_codes, 'investor')",
             "Investor / Multi-Property borrowers",
         ),
         (
             "best retention borrowers in Illinois",
             "IL",
-            "array_contains(segment_codes, 'retention')",
+            "segment_codes, 'retention')",
             "retention-risk borrowers",
         ),
         (
@@ -626,7 +626,7 @@ def test_direct_specific_intent_state_top_borrowers_do_not_use_generic_lead_popu
         ("best cash-out candidates across the current Cotality coverage", "recommended_offer_code = 'cash_out'"),
         ("best HELOC candidates across the current Cotality coverage", "has_heloc_propensity_trigger = TRUE"),
         ("best listed borrowers across the current Cotality coverage", "listed_for_sale = TRUE"),
-        ("best investor borrowers across the current Cotality coverage", "array_contains(segment_codes, 'investor')"),
+        ("best investor borrowers across the current Cotality coverage", "segment_codes, 'investor')"),
     ],
 )
 def test_direct_specific_intent_global_top_borrowers_do_not_use_generic_lead_population(

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -814,7 +814,7 @@ def test_top_borrowers_by_state_uses_canonical_lead_population_rows() -> None:
     result = repo.respond("Show me the top 10 borrowers by lead score in Illinois.")
 
     assert result.source == "trusted_sql"
-    assert result.trusted_assets == ["mip.gold.lead_population"]
+    assert result.trusted_assets == ["mip.gold.lead_population", "mip.gold.borrower_360"]
     assert result.proof is not None
     assert result.proof.trusted is True
     assert result.sql_query is not None


### PR DESCRIPTION
Rolls the in-depth composer through the whole ranking family, live path
and direct fallback: state and global Lead Queue rankings, all six
intent rankings (refi/cash-out/HELOC/listed/investor/retention) at both
scopes, and the listed-purchase shape. One shared economics-rich SELECT
(_borrower_ranking_sql) now generates every ranking SQL with rates,
balances, AVM, propensity, and the run-specific policy thresholds; the
per-intent SQL constants are superseded at import time. Lead Queue
rankings keep mip.gold.lead_population as the ranked source of truth
and join borrower_360 for the economics (both assets cited). ITM count
answers gain the plain-language definition of the screen.

compose_cohort_ranking_brief shares the per-candidate story machinery
with the hero brief: position in dollars, market-rate comparison,
signals translated from codes, the governed offer, and the play.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
