### PR TITLE
fix(genie): rollout live-validation fixes — brief survives live voice, 'each one qualifies' is not a name

### DIFF
--- a/backend/schemas/_validators.py
+++ b/backend/schemas/_validators.py
@@ -550,7 +550,12 @@ _CONTEXTUAL_HUMAN_NAME_RE = re.compile(
     r"segments?|cohorts?|homeowners?|investors?|people|everyone|anyone|someone|"
     r"is|are|was|were|will|would|can|could|may|might|has|have|had)\b)"
     r"[A-Za-z]{2,30}\s+[A-Za-z]{2,30}\b|"
-    r"\b[A-Za-z]{2,30}\s+[A-Za-z]{2,30}\s+(?:qualifies?|is the top borrower)\b",
+    # "X Y qualifies" catches case-normalized names ("john smith qualifies").
+    # Quantifier/population pairs ("each one qualifies", "which borrower
+    # qualifies") are grammar, not identities.
+    r"\b(?!(?:each|every|any|no|which|that|this|the|one)\b)[A-Za-z]{2,30}\s+"
+    r"(?!(?:one|ones|borrower|borrowers|candidate|candidates|customer|customers|lead|leads)\b)"
+    r"[A-Za-z]{2,30}\s+(?:qualifies?|is the top borrower)\b",
     re.IGNORECASE,
 )
 

--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -739,10 +739,11 @@ def _restore_live_voice(
                     update={"known_data_gaps": [*proof.known_data_gaps, gap]}
                 )
     elif narrative:
-        if canonical.sql_query == _CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL:
-            # The all-segments brief is the product's deep per-borrower
-            # analysis; a surviving live narrative leads and the verified
-            # brief follows, instead of flattening to a one-line note.
+        if "**#1" in (canonical.answer or ""):
+            # Any teaching-analyst ranking brief (marked by its per-candidate
+            # headers) is the product's deep analysis; a surviving live
+            # narrative leads and the verified brief follows, instead of
+            # flattening to a one-line note.
             answer = f"{narrative}\n\n{canonical.answer}"
         else:
             note = _default_verification_note(

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -584,9 +584,11 @@ def test_text_only_specific_intent_state_fallback_uses_borrower_360_not_generic_
     assert "FROM mip.gold.lead_population" not in result.sql_query
     assert "recommended_offer_code = 'cash_out'" in result.sql_query
     assert sql.parameters[-1] == {"state": "TX"}
-    # Voice-first: Genie's own narrative leads, with an appended verification note.
+    # Voice-first: Genie's own narrative leads, and the teaching-analyst
+    # brief follows instead of a one-line verification note.
     assert result.answer.startswith("Texas cash-out candidates are available.")
-    assert "Verified against" in result.answer
+    assert "I ranked the top" in result.answer
+    assert "**#1" in result.answer
 
 
 def test_text_only_multi_intent_fallback_discloses_primary_ranking_lens() -> None:
@@ -624,10 +626,11 @@ def test_text_only_multi_intent_fallback_discloses_primary_ranking_lens() -> Non
     assert result.source == "trusted_sql"
     assert result.sql_query is not None
     assert "recommended_offer_code = 'cash_out'" in result.sql_query
-    # Voice-first: the answer is Genie's own narrative plus a verification note;
+    # Voice-first: Genie's narrative leads and the teaching brief follows;
     # the cash-out ranking lens is still enforced by the governed SQL above.
     assert result.answer.startswith("Texas borrowers are available.")
-    assert "Verified against" in result.answer
+    assert "I ranked the top" in result.answer
+    assert "**#1" in result.answer
 
 
 def test_text_only_global_retention_empty_fallback_explains_eligibility_gate() -> None:


### PR DESCRIPTION
Ten-shape live battery on the deployed rollout caught two behaviors:

1. When Genie's own narrative survived verification, non-hero ranking
   shapes flattened to narrative + one-line note, losing the teaching
   brief. The narrative-leads-brief-follows behavior now applies to
   every ranking brief (marked by its per-candidate headers), not just
   the all-segments hero.

2. 'Show the top cash-out candidates in Texas and explain why each one
   qualifies.' refused via the identity guard: the 'X Y qualifies'
   name-shape branch read 'each one qualifies' as a person. Quantifier
   and population words are now excluded; 'john smith qualifies' still
   fails closed (pinned).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
