### PR TITLE
fix(genie): accept a trailing SQL terminator; masked-ID city parens are geography

### DIFF
--- a/backend/services/genie_message_policy.py
+++ b/backend/services/genie_message_policy.py
@@ -189,6 +189,15 @@ GENIE_GEO_LOCATION_RE = re.compile(
     r"\(?\b[A-Z][A-Za-z.'-]*(?:\s+[A-Z][A-Za-z.'-]*){0,3},\s*[A-Z]{2}\b\)?"
 )
 
+# A parenthetical immediately after a masked borrower ID is always the
+# borrower's CITY in this product ("**B-0YINYSXBPWZBF** (Miramar): ...") —
+# borrower names never render and masked IDs are the only identity. City-only
+# forms lack the ", ST" the geography pattern above needs, so strip them here
+# before the name-shape scan.
+_MASKED_ID_CITY_PARENS_RE = re.compile(
+    r"(B-[0-9A-Z]{13}\*{0,2}[\s:,·—-]*)\(([A-Z][^)]{1,40})\)"
+)
+
 
 def genie_visible_text_unsafe(value: str, *, structured_value: bool = False) -> bool:
     """Fail-closed scan for one Genie-rendered string on the analytics surface.
@@ -208,6 +217,7 @@ def genie_visible_text_unsafe(value: str, *, structured_value: bool = False) -> 
     """
 
     scannable = GENIE_GEO_LOCATION_RE.sub(" ", value)
+    scannable = _MASKED_ID_CITY_PARENS_RE.sub(r"\1 ", scannable)
     return contains_unsafe_ai_text(
         scannable,
         include_titlecase=not structured_value,

--- a/backend/services/repositories/databricks_genie_policy.py
+++ b/backend/services/repositories/databricks_genie_policy.py
@@ -19,6 +19,14 @@ def _scrub_sql_for_policy(sql: str | None) -> str | None:
     """
     if not sql:
         return None
+    # One trailing statement terminator is benign and common in generated
+    # SQL (live capture 2026-08-06: Genie's valid single statements often end
+    # in ";" and were rejected wholesale). Interior semicolons — the actual
+    # multi-statement smuggling vector — still reject below.
+    trimmed = sql.strip()
+    if trimmed.endswith(";"):
+        trimmed = trimmed[:-1]
+    sql = trimmed
     out: list[str] = []
     i = 0
     while i < len(sql):


### PR DESCRIPTION
Live FL-investor probe blocked twice; capture showed two compounding
false negatives:

1. The policy scrubber rejected ANY semicolon — including the single
   trailing terminator Genie routinely emits on valid one-statement
   SQL, silently untrustng a large class of good turns. One trailing
   ';' is now stripped before the scan; interior semicolons (the real
   multi-statement smuggling vector) still reject (pinned).

2. Genie narratives write '**B-0YINYSXBPWZBF** (Miramar): ...' — a
   city-only parenthetical after a masked borrower ID, which the
   name-shape guard read as a person. In this product the parenthetical
   after a masked ID is always the city (names never render), so it is
   stripped before the scan.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
