### PR TITLE
feat(api): publish workspace_host on authenticated health body

### DIFF
--- a/.claude/agent-memory/governance-security-reviewer/MEMORY.md
+++ b/.claude/agent-memory/governance-security-reviewer/MEMORY.md
@@ -1,3 +1,4 @@
 - [CI OAuth mint failure must not fall through to localhost](feedback_ci_oauth_fallback.md) — deployed-path mint failure is hard-fail, not silent fallback
 - [Growth Agent Supervisor selection governance](project_growth_agent_supervisor_selection.md) — agent SELECTS workflow (allowlist-bounded); divergence now flagged review_required across step/policy/chip/audit (closed @13cd0b3)
 - [AI Gateway live-probe proof standard](project_ai_gateway_probe_proof.md) — claimable only after live endpoint query plus exact current inference row or async recent deployment-scoped row; proof kind must stay disclosed on public surfaces
+- [R6-09 health disclosure scope](project_r6_09_health_disclosure_scope.md) — R6-09 covers anonymous recon only; test new authenticated-health keys against lineage/data-estate (no auth dep) for marginal exposure

--- a/.claude/agent-memory/governance-security-reviewer/project_r6_09_health_disclosure_scope.md
+++ b/.claude/agent-memory/governance-security-reviewer/project_r6_09_health_disclosure_scope.md
@@ -1,0 +1,38 @@
+---
+name: r6-09-health-disclosure-scope
+description: R6-09's threat model is ANONYMOUS recon of the public Apps URL only; the marginal-exposure test for any new authenticated-health key is whether /api/lineage/manifest or /api/data-estate already leaks it
+metadata:
+  type: project
+---
+
+R6-09 (commit `a34ffe41`, swarm cycle 13) split `/api/health` to close **unauthenticated
+reconnaissance of the public Databricks Apps URL** — nothing broader. Anonymous callers get
+exactly `{status, mode}`; the diagnostic body (warehouse ids, app_env, breaker flap counts,
+identity-fallback counters) moved behind admin RBAC at `/api/admin/health`.
+
+**Why:** the Databricks Apps URL is publicly reachable because the platform LB does anonymous
+liveness probes there. An external scanner was getting free infra intel. R6-09 did NOT establish
+a general "authenticated callers should see less" principle — the authenticated body deliberately
+still carries dependency + breaker state for the degraded-state UI.
+
+**How to apply:** when someone proposes adding a key to the AUTHENTICATED health body, the test is
+*marginal* exposure, not absolute sensitivity. Two routes are the benchmark because they have
+**no FastAPI-layer auth dependency at all** and are therefore strictly more reachable than health's
+authenticated branch (which at least requires a trusted `X-Forwarded-Email`):
+- `backend/api/lineage.py` → `/api/lineage/manifest` — zero deps; emits `{host}/explore/data/...`
+  for every node via `catalog_explorer_url_for()`.
+- `backend/api/data_estate.py` → `/api/data-estate` — `AdminRulesServiceDep` is a plain service
+  factory (`get_admin_rules_service`), NOT an RBAC gate; emits the same URLs.
+`backend/main.py` adds no auth middleware (Backpressure, VisitTracking, CorrelationId,
+SecurityHeaders, GZip only). Auth on those routes comes from the Databricks Apps edge, which 401s
+before FastAPI sees the request. If a proposed key is already derivable from those payloads, it adds
+zero marginal exposure and R6-09 is not implicated. Verify the anonymous branch is untouched and
+that a test pins `set(body.keys()) == {"status","mode"}` with the new value configured.
+
+**Workspace host is config, not a secret in this repo:** the literal is committed in
+`databricks.yml` as the `&default_host` anchor plus three `workspace.host:` references, appears in
+~9 committed docs, and `docs/governance-real-data-review.md` classifies `DATABRICKS_HOST` as "not
+secrets by themselves." Databricks Apps auto-injects it into the runtime. Do not treat a proposal
+to surface it as a secrets-disclosure question.
+
+Related: [[address-lookup-governance-standard]], [[ai-gateway-probe-proof]]

--- a/backend/api/health.py
+++ b/backend/api/health.py
@@ -46,6 +46,7 @@ from fastapi import APIRouter, Request
 from backend.agents.gateway_contract import gateway_runtime_binding_hash
 from backend.config.settings import looks_like_databricks_app_deploy, settings
 from backend.schemas.health import AdminHealthResponse, HealthResponse
+from backend.services.asset_metadata_utils import workspace_origin
 from backend.services.audit_store import get_fallback_identity_count
 from backend.services.campaign_treatment_runtime import (
     CAMPAIGN_TREATMENT_RUNTIME_ENABLED,
@@ -75,7 +76,9 @@ def _agent_gateway_binding_sha256() -> str | None:
     supervisor_id = (settings.mip_agent_supervisor_id or "").strip()
     upstream = (settings.mip_agent_supervisor_endpoint or "").strip()
     runtime_application_id = (settings.mip_agent_runtime_client_id or "").strip()
-    workspace_host = (settings.databricks_host or "").strip()
+    # Raw host on purpose: the binding hash must match what the gateway
+    # signed, unlike the validated origin from _validated_workspace_host().
+    raw_workspace_host = (settings.databricks_host or "").strip()
     model_name = settings.mip_agent_gateway_model.strip()
     model_version = settings.mip_agent_gateway_model_version
     inference_table = (settings.mip_ai_gateway_inference_table or "").strip()
@@ -87,7 +90,7 @@ def _agent_gateway_binding_sha256() -> str | None:
         or not supervisor_id
         or not upstream
         or not runtime_application_id
-        or not workspace_host
+        or not raw_workspace_host
         or not model_name
         or model_version is None
         or not inference_table
@@ -101,7 +104,7 @@ def _agent_gateway_binding_sha256() -> str | None:
         supervisor_id=supervisor_id,
         upstream_endpoint=upstream,
         runtime_application_id=runtime_application_id,
-        workspace_host=workspace_host,
+        workspace_host=raw_workspace_host,
         model_name=model_name,
         model_version=model_version,
         inference_table=inference_table,
@@ -109,6 +112,17 @@ def _agent_gateway_binding_sha256() -> str | None:
         proxy_caller_credential_id=proxy_credential_id,
         proxy_caller_secret_reference=proxy_secret_reference,
     )
+
+
+def _validated_workspace_host() -> str | None:
+    """Validated https workspace origin shared by both non-anonymous bodies.
+
+    Single derivation point so the admin body stays a superset of the
+    authenticated body. Returns ``None`` (key omitted) unless
+    ``workspace_origin()`` accepts the configured host.
+    """
+
+    return workspace_origin(settings.databricks_host)
 
 
 def _actor_cache_key(actor_email: str) -> str:
@@ -269,6 +283,11 @@ def _diagnostic_body(
         "campaign_treatment_runtime": treatment_runtime,
         "boundary_warning": boundary_warning,
     }
+    # Same validated origin the authenticated body exposes (admin stays a
+    # superset of the authenticated shape).
+    workspace_host = _validated_workspace_host()
+    if workspace_host:
+        body["workspace_host"] = workspace_host
     if settings.mip_git_sha:
         body["git_sha"] = settings.mip_git_sha
     if settings.mip_app_deployment_lease_id:
@@ -340,6 +359,16 @@ def health(request: Request) -> dict[str, Any]:
         "circuit_breakers": breakers,
         "actor_cache_key": _actor_cache_key(actor_email or ""),
     }
+    # Workspace origin for the frontend's Catalog Explorer deep links
+    # ({host}/explore/data/...). Authenticated-only: lineage / data-estate
+    # payloads already emit full explorer URLs via catalog_explorer_url(),
+    # so this adds no exposure beyond R6-09's anonymous-reconnaissance
+    # boundary. The shared workspace_origin() guard rejects anything that
+    # is not a clean https Databricks workspace origin; omit the key
+    # entirely rather than ship an unvalidated or empty value.
+    workspace_host = _validated_workspace_host()
+    if workspace_host:
+        body["workspace_host"] = workspace_host
     if settings.mip_git_sha:
         body["git_sha"] = settings.mip_git_sha
     if settings.mip_app_deployment_lease_id:

--- a/backend/schemas/health.py
+++ b/backend/schemas/health.py
@@ -21,6 +21,11 @@ class HealthResponse(BaseModel):
     dependencies: dict[str, str] = Field(default_factory=dict)
     circuit_breakers: dict[str, str] = Field(default_factory=dict)
     actor_cache_key: str | None = None
+    # Validated https workspace origin for Catalog Explorer deep links,
+    # produced by the shared ``workspace_origin()`` guard. Authenticated
+    # bodies only; omitted (never empty/null) when DATABRICKS_HOST is unset
+    # or fails validation. Absent on the anonymous liveness body (R6-09).
+    workspace_host: str | None = None
     forced_degraded: ForcedDegradedInfo | None = None
     # Deploy-promotion marker state: "enabled" after a governed
     # scripts/deploy.sh snapshot promotion, "disabled_baseline_deploy" when

--- a/tests/fixtures/openapi_baseline.json
+++ b/tests/fixtures/openapi_baseline.json
@@ -613,6 +613,17 @@
               }
             ],
             "title": "Warehouse Id"
+          },
+          "workspace_host": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace Host"
           }
         },
         "required": [
@@ -7872,6 +7883,17 @@
           "status": {
             "title": "Status",
             "type": "string"
+          },
+          "workspace_host": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace Host"
           }
         },
         "required": [

--- a/tests/unit/test_health_endpoint.py
+++ b/tests/unit/test_health_endpoint.py
@@ -459,6 +459,11 @@ def test_health_authenticated_returns_runtime_status_only(
     monkeypatch.setattr(health_probes, "probe_warehouse", lambda: True)
     monkeypatch.setattr(health_probes, "probe_lakebase", lambda: True)
     monkeypatch.setattr(health_probes, "probe_genie", lambda: True)
+    # Pin the no-workspace-host shape deterministically: a developer shell
+    # with DATABRICKS_HOST exported must not add keys to this exact-set
+    # assertion. The configured-host shape is pinned in
+    # test_health_workspace_host.py.
+    monkeypatch.setattr(health_mod.settings, "databricks_host", None)
 
     res = client.get("/api/health", headers={"X-Forwarded-Email": "skyler@entrada.ai"})
     assert res.status_code == 200

--- a/tests/unit/test_health_workspace_host.py
+++ b/tests/unit/test_health_workspace_host.py
@@ -1,0 +1,120 @@
+"""Unit tests for ``workspace_host`` on the authenticated health body.
+
+The frontend Genie surface deep-links Unity Catalog asset names into the
+workspace Catalog Explorer. ``useWorkspaceHost()`` reads ``workspace_host``
+from ``GET /api/health`` and re-validates it with the same rules as the
+backend's ``workspace_origin()`` guard; when the key is absent it degrades
+to plain text. Contract pinned here:
+
+1. The anonymous liveness body stays exactly ``{status, mode}`` even when a
+   valid workspace host is configured (R6-09 reconnaissance contract).
+2. The authenticated body carries the validated https workspace origin.
+3. An unset or untrustworthy ``DATABRICKS_HOST`` omits the key entirely --
+   never an empty string or null -- so the frontend treats the host as
+   unknown.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api import health as health_mod
+from backend.main import app
+from backend.services import health_probes, resilience
+from backend.services.forced_degraded import _reset_forced_degraded_for_tests
+
+client = TestClient(app)
+
+VALID_HOST = "https://dbc-12345678-abcd.cloud.databricks.com"
+AUTH_HEADERS = {"X-Forwarded-Email": "ops@example.com"}
+ADMIN_HEADERS = {
+    "X-Forwarded-Email": "ops@example.com",
+    "X-Forwarded-Groups": "mip-admin",
+}
+
+
+@pytest.fixture(autouse=True)
+def _stub_probes(monkeypatch: pytest.MonkeyPatch) -> None:
+    resilience._reset_breakers_for_tests()
+    _reset_forced_degraded_for_tests()
+    client.cookies.clear()
+    health_probes._probe_cache.clear()
+    monkeypatch.setattr(health_probes, "probe_warehouse", lambda: True)
+    monkeypatch.setattr(health_probes, "probe_lakebase", lambda: True)
+    monkeypatch.setattr(health_probes, "probe_genie", lambda: True)
+
+
+def test_anonymous_body_keeps_r6_09_shape_with_host_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured workspace host must never leak onto the anonymous body."""
+    monkeypatch.setattr(health_mod.settings, "databricks_host", VALID_HOST)
+
+    res = client.get("/api/health")
+
+    assert res.status_code == 200
+    assert set(res.json().keys()) == {"status", "mode"}
+
+
+def test_authenticated_body_carries_validated_workspace_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(health_mod.settings, "databricks_host", VALID_HOST)
+
+    res = client.get("/api/health", headers=AUTH_HEADERS)
+
+    assert res.status_code == 200
+    assert res.json()["workspace_host"] == VALID_HOST
+
+
+def test_authenticated_body_normalizes_bare_hostname(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Health must reuse workspace_origin(), not echo the raw setting."""
+    monkeypatch.setattr(
+        health_mod.settings,
+        "databricks_host",
+        "dbc-12345678-abcd.cloud.databricks.com",
+    )
+
+    res = client.get("/api/health", headers=AUTH_HEADERS)
+
+    assert res.json()["workspace_host"] == VALID_HOST
+
+
+@pytest.mark.parametrize(
+    "raw_host",
+    [
+        None,
+        "",
+        "   ",
+        "https://workspace.example",  # .env.local placeholder template value
+        "http://dbc-12345678-abcd.cloud.databricks.com",  # https only
+        "https://user:pw@dbc-12345678-abcd.cloud.databricks.com",
+        "https://dbc-12345678-abcd.cloud.databricks.com/some/path",
+        "https://dbc-12345678-abcd.cloud.databricks.com?q=1",
+        "https://dbc-12345678-abcd.cloud.databricks.com#frag",
+        "https://evil.example.com",
+    ],
+)
+def test_invalid_or_unset_host_omits_key(
+    monkeypatch: pytest.MonkeyPatch, raw_host: str | None
+) -> None:
+    """The key is omitted -- never emitted as an empty string or null."""
+    monkeypatch.setattr(health_mod.settings, "databricks_host", raw_host)
+
+    res = client.get("/api/health", headers=AUTH_HEADERS)
+
+    assert res.status_code == 200
+    assert "workspace_host" not in res.json()
+
+
+def test_admin_body_carries_workspace_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Admin diagnostics stay a superset of the authenticated shape."""
+    monkeypatch.setattr(health_mod.settings, "databricks_host", VALID_HOST)
+
+    res = client.get("/api/admin/health", headers=ADMIN_HEADERS)
+
+    assert res.status_code == 200
+    assert res.json()["workspace_host"] == VALID_HOST


### PR DESCRIPTION
## Summary
- `GET /api/health` (authenticated body) and `/api/admin/health` now carry `workspace_host`, the validated https workspace origin, so the frontend's Catalog Explorer deep links (`useWorkspaceHost()`) can activate. The value comes from the existing `workspace_origin()` guard in `backend/services/asset_metadata_utils.py`; when the guard rejects the configured host the key is omitted entirely (never empty/null), and the frontend degrades to plain text.
- The anonymous liveness body is untouched: exactly `{status, mode}` per the R6-09 reconnaissance contract.
- Both bodies derive the value from one helper (`_validated_workspace_host()`) so admin stays a superset of authenticated. The raw gateway-binding local was renamed `raw_workspace_host` to keep raw-vs-validated visible.
- OpenAPI baseline regenerated (only the two health schemas gained the field).

## Governance
governance-security-reviewer verdict: **CONFIRMED** consistent with R6-09 — that decision targeted anonymous reconnaissance of the public Apps URL (commit a34ffe41), the anonymous branch is unchanged, the workspace host is committed in `databricks.yml`/docs and classified non-secret in `docs/governance-real-data-review.md`, and `/api/lineage/manifest` + `/api/data-estate` already emit full `{host}/explore/data/...` URLs to strictly less-gated callers. A separate follow-up was flagged for the lineage/data-estate in-code auth posture.

## Test plan
- New `tests/unit/test_health_workspace_host.py`: anonymous body keeps exactly `{status, mode}` even with a valid host configured; authenticated body carries the validated origin (incl. bare-hostname normalization); 10 invalid/unset host shapes omit the key; admin superset pinned.
- `test_health_authenticated_returns_runtime_status_only` now pins `databricks_host=None` explicitly so a developer shell with `DATABRICKS_HOST` exported can't flake the exact-key-set assertion.
- Full unit suite: 12779 passed; the only failure besides the (regenerated) OpenAPI baseline is `test_first_install_dry_run_executes_no_databricks_operations`, which fails identically on clean `origin/main` (missing `dotenv` for the harness interpreter — ambient, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)