### PR TITLE
feat(app): UC deep links, full linkage, robust Genie trace, chat history, one governed top-10

### DIFF
--- a/.claude/agent-memory/backend-databricks-engineer/MEMORY.md
+++ b/.claude/agent-memory/backend-databricks-engineer/MEMORY.md
@@ -9,3 +9,4 @@
 - [R5 governance fixes](project_r5_governance_fixes.md) — R5-01 request_id idempotency, R5-09 trust boundary flag, R5-18 broadened audit-write except, R5-23 no-body-in-logs test
 - [No Pydantic validation on PII fields](feedback_no_pydantic_validation_on_pii_fields.md) — 422 echoes raw input; validate PII fields in the route via HTTPException, not Pydantic validators
 - [Genie live-first routing](project_genie_live_first.md) — live Genie primary; canonical interceptors are a disclosed degraded fallback gated by mip_genie_live_first
+- [Genie visible-text Title-Case trap](project_genie_visible_text_titlecase_trap.md) — server-authored strings trip the name-shape guard; probe every new Genie string first

--- a/.claude/agent-memory/frontend-implementer/MEMORY.md
+++ b/.claude/agent-memory/frontend-implementer/MEMORY.md
@@ -4,6 +4,7 @@
 - [Footprint context is source of truth](project_footprint_context.md) — FootprintProvider hydrates /api/config/footprint; drives map drill + segment LOCATION + portfolio GEO.
 - [A11y/race patterns](project_a11y_patterns.md) — dialog focus-trap mirrors EvidenceDrawer; hotkeys check activeElement; async handlers need useRef latch.
 - [Warming-up retry pattern](project_warming_up_pattern.md) — cold-start 503s use useWarmingUpRetry + WarmingUpBlock; ApiError carries dependency/correlationId.
-- [CSS gzip budget red on main](project_css_budget_gzip_red.md) — initial-CSS gzip budget already fails on clean main; don't self-bump, reuse BEM primitives to fit raw headroom.
+- [CSS budget headroom is thin](project_css_budget_gzip_red.md) — budget passes since the re-baseline but only ~3.5 KiB raw / 0.5 KiB gzip is left; measure your delta, never self-bump.
+- [CSS cascade is source-order](project_css_cascade_order.md) — components.css is flat with no @layer; reusing a primitive declared later needs parent-scoped specificity.
 - [Lead-queue filter plumbing](project_lead_queue_filter_plumbing.md) — a new portfolio filter needs 4 parallel structures in lead-queue.filters.ts; API pass-through is generic.
 - [Component test context mock](project_component_test_context_mock.md) — mock ../AppContext useApp for setDrawer; run tests via npm --prefix frontend (not npx --root) or babel breaks.

--- a/backend/api/genie.py
+++ b/backend/api/genie.py
@@ -36,6 +36,8 @@ from backend.services.genie_answers import (
     GenieActionResponse,
     GenieMessageResponse,
     GenieProgressResponse,
+    GenieSessionDetailResponse,
+    GenieSessionListResponse,
     GenieStartResponse,
     GenieSubmitResponse,
     load_sample_questions,
@@ -51,6 +53,12 @@ from backend.services.genie_deterministic import (
     _deterministic_genie_response,
     _required_audit_write,
     _safe_genie_audit_entity_id,
+)
+from backend.services.genie_history import (
+    genie_session_turns,
+    history_payload_json,
+    history_question_text,
+    list_genie_sessions,
 )
 from backend.services.genie_message_policy import (
     GenieCompleteRequest,
@@ -135,11 +143,12 @@ ON CONFLICT (actor_email, conversation_id) DO UPDATE SET
 _GENIE_MESSAGE_INSERT_SQL = """
 INSERT INTO mip_app.genie_messages (
   conversation_id, message_id, actor_email, question_hash,
-  source, row_count, visualization_kind, trusted_assets, request_id
+  source, row_count, visualization_kind, trusted_assets, request_id,
+  question_text, response_json
 ) VALUES (
   %(conversation_id)s, %(message_id)s, %(actor_email)s, %(question_hash)s,
   %(source)s, %(row_count)s, %(visualization_kind)s, %(trusted_assets)s,
-  %(request_id)s
+  %(request_id)s, %(question_text)s, %(response_json)s::jsonb
 )
 ON CONFLICT (conversation_id, message_id) DO NOTHING
 """
@@ -222,6 +231,12 @@ def _record_genie_session(
         "row_count": int(response.row_count or 0),
         "visualization_kind": response.visualization.kind if response.visualization else None,
         "request_id": f"genie-{uuid4()}",
+        # History replay (2026-08-06). Both fields are already governed: the
+        # question cleared the prompt guard battery and the answer cleared the
+        # visible-text output policy plus row PII redaction. Signed action
+        # tokens are stripped by ``history_payload_json``.
+        "question_text": history_question_text(response.question),
+        "response_json": history_payload_json(response),
     }
     try:
         if getattr(lakebase, "_supports_atomic_transactions", False):
@@ -269,6 +284,43 @@ def genie_start(
         conversation_id=_latest_genie_conversation(lakebase, actor=actor),
         trusted_assets=trusted_assets(),
         sample_questions=load_sample_questions()[:4],
+    )
+
+
+@router.get("/sessions", response_model=GenieSessionListResponse)
+def genie_sessions(
+    request: Request,
+    lakebase: LakebaseDep,
+) -> GenieSessionListResponse:
+    """The requesting actor's recent Ask Genie conversations, newest first.
+
+    AUDIT EXEMPT: read-only listing of the caller's own conversation
+    metadata. It mutates nothing, and the underlying turns each carry their
+    own ``genie.run_query`` audit row from when they were answered.
+    """
+    return list_genie_sessions(lakebase, actor=resolve_actor(request))
+
+
+@router.get("/sessions/{conversation_id}", response_model=GenieSessionDetailResponse)
+def genie_session_detail(
+    conversation_id: str,
+    request: Request,
+    lakebase: LakebaseDep,
+) -> GenieSessionDetailResponse:
+    """Replay one owned conversation as governed question/answer turns.
+
+    Strictly actor-scoped: a conversation owned by anyone else is a 404, so
+    history cannot be probed for other actors' activity. Answers are re-served
+    exactly as they were governed at answer time (output policy + PII
+    redaction already applied before persistence), minus the signed action
+    tokens, which are never replayed.
+
+    AUDIT EXEMPT: read-only replay of the caller's own recorded turns.
+    """
+    return genie_session_turns(
+        lakebase,
+        actor=resolve_actor(request),
+        conversation_id=conversation_id,
     )
 
 

--- a/backend/api/health.py
+++ b/backend/api/health.py
@@ -224,6 +224,13 @@ def _diagnostic_body(
         # QueryClient data if Databricks Apps swaps the workspace identity
         # within the same browser session.
         "actor_cache_key": _actor_cache_key(actor_email),
+        # Validated workspace origin so admin surfaces can deep-link UC
+        # assets exactly like the authenticated browser body does.
+        **(
+            {"workspace_host": origin}
+            if (origin := workspace_origin(settings.databricks_host))
+            else {}
+        ),
         # Slice-13 observability counters. Values reflect the last
         # rolling hour. A non-zero ``breaker_state_changes_last_hour``
         # is the earliest signal that a dependency is flapping; a

--- a/backend/api/health.py
+++ b/backend/api/health.py
@@ -76,9 +76,7 @@ def _agent_gateway_binding_sha256() -> str | None:
     supervisor_id = (settings.mip_agent_supervisor_id or "").strip()
     upstream = (settings.mip_agent_supervisor_endpoint or "").strip()
     runtime_application_id = (settings.mip_agent_runtime_client_id or "").strip()
-    # Raw host on purpose: the binding hash must match what the gateway
-    # signed, unlike the validated origin from _validated_workspace_host().
-    raw_workspace_host = (settings.databricks_host or "").strip()
+    workspace_host = (settings.databricks_host or "").strip()
     model_name = settings.mip_agent_gateway_model.strip()
     model_version = settings.mip_agent_gateway_model_version
     inference_table = (settings.mip_ai_gateway_inference_table or "").strip()
@@ -90,7 +88,7 @@ def _agent_gateway_binding_sha256() -> str | None:
         or not supervisor_id
         or not upstream
         or not runtime_application_id
-        or not raw_workspace_host
+        or not workspace_host
         or not model_name
         or model_version is None
         or not inference_table
@@ -104,7 +102,7 @@ def _agent_gateway_binding_sha256() -> str | None:
         supervisor_id=supervisor_id,
         upstream_endpoint=upstream,
         runtime_application_id=runtime_application_id,
-        workspace_host=raw_workspace_host,
+        workspace_host=workspace_host,
         model_name=model_name,
         model_version=model_version,
         inference_table=inference_table,
@@ -112,17 +110,6 @@ def _agent_gateway_binding_sha256() -> str | None:
         proxy_caller_credential_id=proxy_credential_id,
         proxy_caller_secret_reference=proxy_secret_reference,
     )
-
-
-def _validated_workspace_host() -> str | None:
-    """Validated https workspace origin shared by both non-anonymous bodies.
-
-    Single derivation point so the admin body stays a superset of the
-    authenticated body. Returns ``None`` (key omitted) unless
-    ``workspace_origin()`` accepts the configured host.
-    """
-
-    return workspace_origin(settings.databricks_host)
 
 
 def _actor_cache_key(actor_email: str) -> str:
@@ -283,11 +270,6 @@ def _diagnostic_body(
         "campaign_treatment_runtime": treatment_runtime,
         "boundary_warning": boundary_warning,
     }
-    # Same validated origin the authenticated body exposes (admin stays a
-    # superset of the authenticated shape).
-    workspace_host = _validated_workspace_host()
-    if workspace_host:
-        body["workspace_host"] = workspace_host
     if settings.mip_git_sha:
         body["git_sha"] = settings.mip_git_sha
     if settings.mip_app_deployment_lease_id:
@@ -359,16 +341,12 @@ def health(request: Request) -> dict[str, Any]:
         "circuit_breakers": breakers,
         "actor_cache_key": _actor_cache_key(actor_email or ""),
     }
-    # Workspace origin for the frontend's Catalog Explorer deep links
-    # ({host}/explore/data/...). Authenticated-only: lineage / data-estate
-    # payloads already emit full explorer URLs via catalog_explorer_url(),
-    # so this adds no exposure beyond R6-09's anonymous-reconnaissance
-    # boundary. The shared workspace_origin() guard rejects anything that
-    # is not a clean https Databricks workspace origin; omit the key
-    # entirely rather than ship an unvalidated or empty value.
-    workspace_host = _validated_workspace_host()
-    if workspace_host:
-        body["workspace_host"] = workspace_host
+    # Workspace origin (scheme+host only, validated) so the UI can deep-link
+    # cited Unity Catalog assets to the Catalog Explorer. Authenticated body
+    # only — the anonymous liveness contract stays {status, mode}.
+    host_origin = workspace_origin(settings.databricks_host)
+    if host_origin:
+        body["workspace_host"] = host_origin
     if settings.mip_git_sha:
         body["git_sha"] = settings.mip_git_sha
     if settings.mip_app_deployment_lease_id:

--- a/backend/schemas/health.py
+++ b/backend/schemas/health.py
@@ -21,10 +21,8 @@ class HealthResponse(BaseModel):
     dependencies: dict[str, str] = Field(default_factory=dict)
     circuit_breakers: dict[str, str] = Field(default_factory=dict)
     actor_cache_key: str | None = None
-    # Validated https workspace origin for Catalog Explorer deep links,
-    # produced by the shared ``workspace_origin()`` guard. Authenticated
-    # bodies only; omitted (never empty/null) when DATABRICKS_HOST is unset
-    # or fails validation. Absent on the anonymous liveness body (R6-09).
+    # Validated workspace origin for Catalog Explorer deep links from cited
+    # UC assets. Authenticated health body only.
     workspace_host: str | None = None
     forced_degraded: ForcedDegradedInfo | None = None
     # Deploy-promotion marker state: "enabled" after a governed

--- a/backend/services/genie_answers.py
+++ b/backend/services/genie_answers.py
@@ -163,6 +163,38 @@ class GenieSubmitResponse(BaseModel):
     response: GenieMessageResponse | None = None
 
 
+class GenieSessionSummary(BaseModel):
+    """One row of the actor's Ask Genie history list."""
+
+    conversation_id: str
+    #: First question of the conversation, truncated for the list UI. Empty
+    #: for conversations recorded before turn payloads were persisted.
+    title: str = ""
+    last_activity_at: str | None = None
+    turn_count: int = 0
+
+
+class GenieSessionListResponse(BaseModel):
+    sessions: list[GenieSessionSummary] = Field(default_factory=list)
+
+
+class GenieSessionTurn(BaseModel):
+    """One replayable question/answer pair from a stored conversation.
+
+    ``response`` is the exact governed ``GenieMessageResponse`` the chat
+    already renders. It was scanned by the output policy and PII-redacted
+    before it was ever persisted.
+    """
+
+    question: str
+    response: GenieMessageResponse
+
+
+class GenieSessionDetailResponse(BaseModel):
+    conversation_id: str
+    turns: list[GenieSessionTurn] = Field(default_factory=list)
+
+
 class GenieProgressResponse(BaseModel):
     """Live progress for one in-flight Genie message.
 

--- a/backend/services/genie_history.py
+++ b/backend/services/genie_history.py
@@ -1,0 +1,266 @@
+"""Read-side of Ask Genie conversation history, backed by Lakebase.
+
+The chat UI can reopen a previous conversation, so the durable
+``mip_app.genie_messages`` ledger now carries, per turn, the guarded question
+and the exact governed ``GenieMessageResponse`` that was returned.
+
+Governance posture for the stored payload (deliberate change of the original
+"identifiers and proof metadata only" rule, 2026-08-06):
+
+* Only turns whose ``source`` is NOT in the refused/degraded/blocked set are
+  recorded at all, so a prompt that tripped the guard battery is never stored.
+* A stored question has already cleared the PII / identity / protected-class /
+  injection prompt guards.
+* A stored answer has already cleared ``genie_response_has_unsafe_visible_text``
+  and row-level PII-key redaction, which is why the read path re-serves it
+  without re-scanning.
+* Signed action tokens are stripped before persistence: replaying a transcript
+  must never hand back authorization to run a governed write action. A user who
+  wants to act re-asks and gets a fresh, freshly-authorized turn.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from backend.services.error_sanitizer import safe_dependency_detail
+from backend.services.genie_answers import (
+    GenieMessageResponse,
+    GenieSessionDetailResponse,
+    GenieSessionListResponse,
+    GenieSessionSummary,
+    GenieSessionTurn,
+)
+from backend.services.lakebase import LakebaseClient, LakebaseError
+from backend.services.observability import emit
+
+log = logging.getLogger("mip-genie")
+
+#: History list page size. The sidebar shows recent conversations, not an
+#: archive browser.
+GENIE_HISTORY_SESSION_LIMIT = 20
+#: Hard cap on turns replayed for one conversation.
+GENIE_HISTORY_TURN_LIMIT = 100
+#: List title length.
+GENIE_HISTORY_TITLE_MAX = 80
+#: Stored question length (the request model already caps the prompt at 4,000).
+GENIE_HISTORY_QUESTION_MAX = 4_000
+#: Serialized payload budget per turn. A governed answer with a full result
+#: table is a few tens of KiB; this bounds a pathological one.
+GENIE_HISTORY_PAYLOAD_MAX_BYTES = 256 * 1024
+#: Row count kept when a payload has to be trimmed to fit the budget.
+GENIE_HISTORY_TRIMMED_ROWS = 50
+
+_TRIMMED_ROWS_GAP = (
+    "Replayed from history: some result rows were trimmed to bound the stored "
+    "payload. Re-ask the question for the complete result set."
+)
+_DROPPED_ROWS_GAP = (
+    "Replayed from history: the result table was too large to store and is not "
+    "shown. Re-ask the question for the complete result set."
+)
+
+
+GENIE_SESSION_LIST_SQL = """
+SELECT s.conversation_id,
+       s.updated_at AS last_activity_at,
+       (SELECT count(*)
+          FROM mip_app.genie_messages gm
+         WHERE gm.actor_email = s.actor_email
+           AND gm.conversation_id = s.conversation_id) AS turn_count,
+       (SELECT gm.question_text
+          FROM mip_app.genie_messages gm
+         WHERE gm.actor_email = s.actor_email
+           AND gm.conversation_id = s.conversation_id
+           AND gm.question_text IS NOT NULL
+         ORDER BY gm.created_at, gm.message_id
+         LIMIT 1) AS first_question
+  FROM mip_app.genie_sessions s
+ WHERE s.actor_email = %(actor_email)s
+ ORDER BY s.updated_at DESC
+ LIMIT %(limit)s
+"""
+
+GENIE_SESSION_TURNS_SQL = """
+SELECT question_text, response_json
+  FROM mip_app.genie_messages
+ WHERE actor_email = %(actor_email)s
+   AND conversation_id = %(conversation_id)s
+ ORDER BY created_at, message_id
+ LIMIT %(limit)s
+"""
+
+
+def history_question_text(question: str | None) -> str | None:
+    """Bound the stored prompt; ``None`` when there is nothing to store."""
+    text = (question or "").strip()
+    if not text:
+        return None
+    return text[:GENIE_HISTORY_QUESTION_MAX]
+
+
+def history_payload_json(response: GenieMessageResponse) -> str | None:
+    """Serialize one governed answer for replay, bounded and de-authorized.
+
+    Returns ``None`` when even a row-free payload exceeds the budget; the turn
+    is still recorded for provenance, it just cannot be replayed.
+    """
+    payload = response.model_dump(mode="json")
+    # Never persist signed action authorization. See module docstring.
+    payload["actions"] = []
+    encoded = json.dumps(payload, separators=(",", ":"))
+    if len(encoded.encode("utf-8")) <= GENIE_HISTORY_PAYLOAD_MAX_BYTES:
+        return encoded
+
+    rows = payload.get("table_rows") or []
+    if isinstance(rows, list) and len(rows) > GENIE_HISTORY_TRIMMED_ROWS:
+        payload["table_rows"] = rows[:GENIE_HISTORY_TRIMMED_ROWS]
+        _append_history_gap(payload, _TRIMMED_ROWS_GAP)
+        encoded = json.dumps(payload, separators=(",", ":"))
+        if len(encoded.encode("utf-8")) <= GENIE_HISTORY_PAYLOAD_MAX_BYTES:
+            return encoded
+
+    payload["table_rows"] = []
+    _append_history_gap(payload, _DROPPED_ROWS_GAP)
+    encoded = json.dumps(payload, separators=(",", ":"))
+    if len(encoded.encode("utf-8")) <= GENIE_HISTORY_PAYLOAD_MAX_BYTES:
+        return encoded
+    emit(
+        log,
+        "genie_history_payload_too_large",
+        level=logging.WARNING,
+        dependency="lakebase",
+        outcome="skipped",
+        conversation_id=response.conversation_id,
+        message_id=response.message_id,
+    )
+    return None
+
+
+def _append_history_gap(payload: dict[str, Any], gap: str) -> None:
+    """Disclose a trim in the proof, so a replayed answer never overclaims."""
+    proof = payload.get("proof")
+    if not isinstance(proof, dict):
+        return
+    gaps = proof.get("known_data_gaps")
+    if not isinstance(gaps, list):
+        gaps = []
+    if gap not in gaps:
+        proof["known_data_gaps"] = [*gaps, gap]
+
+
+def _history_title(question: object) -> str:
+    text = str(question or "").strip()
+    return text[:GENIE_HISTORY_TITLE_MAX]
+
+
+def _iso(value: object) -> str | None:
+    if value is None:
+        return None
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    return str(value)
+
+
+def list_genie_sessions(
+    lakebase: LakebaseClient,
+    *,
+    actor: str,
+) -> GenieSessionListResponse:
+    """Most recent conversations owned by ``actor``, newest first."""
+    try:
+        rows = lakebase.fetchall(
+            GENIE_SESSION_LIST_SQL,
+            {"actor_email": actor, "limit": GENIE_HISTORY_SESSION_LIMIT},
+            limit=GENIE_HISTORY_SESSION_LIMIT,
+        )
+    except LakebaseError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=safe_dependency_detail("lakebase"),
+        ) from exc
+    sessions: list[GenieSessionSummary] = []
+    for row in rows or []:
+        conversation_id = str(row.get("conversation_id") or "")
+        if not conversation_id:
+            continue
+        try:
+            turn_count = max(int(row.get("turn_count") or 0), 0)
+        except (TypeError, ValueError):
+            turn_count = 0
+        sessions.append(
+            GenieSessionSummary(
+                conversation_id=conversation_id,
+                title=_history_title(row.get("first_question")),
+                last_activity_at=_iso(row.get("last_activity_at")),
+                turn_count=turn_count,
+            )
+        )
+    return GenieSessionListResponse(sessions=sessions)
+
+
+def genie_session_turns(
+    lakebase: LakebaseClient,
+    *,
+    actor: str,
+    conversation_id: str,
+) -> GenieSessionDetailResponse:
+    """Replayable turns of one conversation, in ask order.
+
+    Scoped to ``actor``: another actor's conversation is indistinguishable
+    from one that does not exist (404), so history cannot be probed.
+    """
+    try:
+        rows = lakebase.fetchall(
+            GENIE_SESSION_TURNS_SQL,
+            {
+                "actor_email": actor,
+                "conversation_id": conversation_id,
+                "limit": GENIE_HISTORY_TURN_LIMIT,
+            },
+            limit=GENIE_HISTORY_TURN_LIMIT,
+        )
+    except LakebaseError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=safe_dependency_detail("lakebase"),
+        ) from exc
+    if not rows:
+        raise HTTPException(status_code=404, detail="genie conversation not found")
+    turns: list[GenieSessionTurn] = []
+    for row in rows:
+        response = _decode_response(row.get("response_json"))
+        if response is None:
+            # Recorded before payload persistence, or unreadable after a
+            # schema change. Provenance is intact; the turn just cannot be
+            # replayed, and we do not invent one.
+            continue
+        turns.append(
+            GenieSessionTurn(
+                question=str(row.get("question_text") or response.question or ""),
+                response=response,
+            )
+        )
+    return GenieSessionDetailResponse(conversation_id=conversation_id, turns=turns)
+
+
+def _decode_response(payload: object) -> GenieMessageResponse | None:
+    if payload is None:
+        return None
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except ValueError:
+            return None
+    if not isinstance(payload, dict):
+        return None
+    try:
+        return GenieMessageResponse.model_validate(payload)
+    except ValidationError:
+        return None

--- a/backend/services/repositories/databricks_analytics.py
+++ b/backend/services/repositories/databricks_analytics.py
@@ -40,6 +40,7 @@ from backend.schemas.analytics import (
 from backend.schemas.funnel import FunnelPopulation
 from backend.services.databricks_sql import DatabricksSqlClient
 from backend.services.databricks_sql_helpers import qualify
+from backend.services.eligibility import eligible_sql_predicate
 from backend.services.repositories.databricks_economics_scatter import (
     economics_points as build_economics_points,
 )
@@ -305,6 +306,11 @@ class DatabricksAnalyticsRepository:
         "ORDER BY spread_bucket_bps"
     )
 
+    # Consistency contract (2026-08-06): this panel must rank EXACTLY like the
+    # governed canonical ranking Genie and the Lead Queue use — same
+    # marketing-eligibility + consent predicate, same ordering (opportunity
+    # score, then rate-spread economics, then borrower_id). One top-10, one
+    # truth, no surface-specific grain or tiebreakers.
     _TOP_BORROWERS_SQL = (
         "WITH ranked AS ( "
         "  SELECT "
@@ -316,7 +322,9 @@ class DatabricksAnalyticsRepository:
         "    b.rate_spread_bps AS rate_spread_bps, "
         "    b.equity_pct AS equity_pct, "
         "    b.recommended_offer AS recommended_offer, "
-        "    ROW_NUMBER() OVER (ORDER BY b.opportunity_score DESC, b.clip) AS rank_overall "
+        "    ROW_NUMBER() OVER ( "
+        "      ORDER BY b.opportunity_score DESC, b.rate_spread_bps DESC NULLS LAST, b.borrower_id ASC "
+        "    ) AS rank_overall "
         f"  FROM {qualify('gold', 'borrower_360')} AS b "
         "  {where} "
         ") "
@@ -661,7 +669,13 @@ class DatabricksAnalyticsRepository:
                     for row in self._execute_template(
                         self._TOP_BORROWERS_SQL,
                         analytics_filters,
-                        extra=["b.opportunity_score >= 50"],
+                        extra=[
+                            "b.opportunity_score >= 50",
+                            # Same actionability gate as the governed canonical
+                            # ranking: one top-10 across Genie, Lead Queue, and
+                            # this panel.
+                            eligible_sql_predicate("b"),
+                        ],
                     )
                 ],
             )

--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -101,6 +101,14 @@ from backend.services.repositories.databricks_genie_policy_helpers import (
 from backend.services.repositories.databricks_genie_strategy import (
     _canonical_strategy_board_answer,
 )
+from backend.services.repositories.databricks_genie_trace import (
+    WITHHELD_CONTRADICTED,
+    WITHHELD_NO_NARRATIVE,
+    WITHHELD_NO_NARRATIVE_DETERMINISTIC,
+    WITHHELD_UNSAFE_TEXT,
+    WITHHELD_UNVERIFIED_NUMBERS,
+    GenieProcessTrace,
+)
 from backend.services.repositories.databricks_genie_trust import (
     _TRUSTED_GENIE_ASSETS,  # noqa: F401 - compatibility re-export
     _bounded_genie_sql,  # noqa: F401 - compatibility re-export
@@ -246,14 +254,20 @@ class DatabricksGenieRepository:
                 question,
                 kind=DependencyDownError.KIND_BREAKER_OPEN,
             )
+        repaired = False
         try:
             result = self._genie.ask(question, conversation_id=conversation_id)
             if _needs_genie_sql_repair(question, result):
-                result = self._repair_text_only_genie_answer(
+                regenerated = self._repair_text_only_genie_answer(
                     question=question,
                     original=result,
                     conversation_id=conversation_id,
                 )
+                # The repair helper returns the ORIGINAL object when the retry
+                # did not recover governed SQL proof, so identity is the honest
+                # signal for "the repair actually changed this turn".
+                repaired = regenerated is not result
+                result = regenerated
         except DependencyDownError as exc:
             return self._degraded(question, kind=exc.kind)
         except GenieClientError:
@@ -261,7 +275,12 @@ class DatabricksGenieRepository:
             # 500, malformed JSON). Re-raise so the router translates
             # to 503 + degraded UI. No silent mock fallback.
             raise
-        return _adapt_genie_response(question, result, sql_client=self._sql_client)
+        return _adapt_genie_response(
+            question,
+            result,
+            sql_client=self._sql_client,
+            repaired=repaired,
+        )
 
     def respond_existing(
         self,
@@ -285,19 +304,27 @@ class DatabricksGenieRepository:
         breaker_state = self._genie.resilient.breaker.state
         if breaker_state == "open":
             return self._degraded(question, kind=DependencyDownError.KIND_BREAKER_OPEN)
+        repaired = False
         try:
             result = self._genie.resume_message(conversation_id, message_id)
             if _needs_genie_sql_repair(question, result):
-                result = self._repair_text_only_genie_answer(
+                regenerated = self._repair_text_only_genie_answer(
                     question=question,
                     original=result,
                     conversation_id=conversation_id,
                 )
+                repaired = regenerated is not result
+                result = regenerated
         except DependencyDownError as exc:
             return self._degraded(question, kind=exc.kind)
         except GenieClientError:
             raise
-        return _adapt_genie_response(question, result, sql_client=self._sql_client)
+        return _adapt_genie_response(
+            question,
+            result,
+            sql_client=self._sql_client,
+            repaired=repaired,
+        )
 
     def _repair_text_only_genie_answer(
         self,
@@ -384,6 +411,7 @@ def _adapt_genie_response(
     result: GenieResponse,
     *,
     sql_client: DatabricksSqlClient | None = None,
+    repaired: bool = False,
 ) -> GenieMessageResponse:
     """Wrap a live ``GenieResponse`` into the wire contract the UI
     already consumes. We derive ``trusted_assets`` from the SQL query
@@ -397,13 +425,24 @@ def _adapt_genie_response(
     (owner names, raw CLIP, owner_link_id, owner_name_hash, street addresses)
     regardless of what the model decided to select. Customers see zero PII
     columns in Ask Genie results even if the Space drifts.
+
+    ``repaired`` records that the narrative-only SQL repair retry actually
+    changed this turn, so the deterministic process trace can state that step
+    as fact instead of inferring it.
     """
+    trace = GenieProcessTrace()
+    trace.guardrails()
+    if repaired:
+        trace.repair()
     trusted_assets = _merge_trusted_assets(
         _extract_asset_refs(result.sql_query),
         result.trusted_assets,
     )
     rows = _redact_genie_rows(result.sql_result_rows)
     trusted_sql = _trusted_sql_policy(result.sql_query, trusted_assets)
+    trace.live_turn(sql_query=result.sql_query, assets=trusted_assets)
+    if trusted_sql:
+        trace.trust()
     question_hash = _genie_question_hash(question)
     text_contains_pii = _answer_text_contains_pii(result.answer_text)
     lacks_trusted_proof = not result.sql_query or not trusted_assets
@@ -452,6 +491,7 @@ def _adapt_genie_response(
                 canonical,
                 result,
                 narrative_withheld=text_contains_pii,
+                trace=trace,
             )
     if lacks_trusted_proof or unsafe_live_sql or depends_on_pending_feeds:
         if depends_on_pending_feeds:
@@ -496,6 +536,7 @@ def _adapt_genie_response(
         )
     if result.sql_query and trusted_sql and not rows and sql_client is not None:
         rows = _redact_genie_rows(_execute_trusted_genie_sql(sql_client, result.sql_query))
+    trace.execute(row_count=len(rows) if rows else 0, assets=trusted_assets)
     # Trusted SQL is a floor, not a coin flip: from here the governed query,
     # rows, proof, and actions ALWAYS ship. Only the model PROSE is
     # conditionally withheld — when the output safety guard flags its wording,
@@ -510,6 +551,7 @@ def _adapt_genie_response(
             "the governed query results are shown instead."
         )
         prose_withheld_reason = "the output safety guard flagged its wording."
+        trace.narrative_withheld(reason=WITHHELD_UNSAFE_TEXT)
     elif _unsupported_answer_numeric_claims(result.answer_text, rows, question):
         prose_withheld_gap = (
             "Genie's draft narrative included numeric or financial claims that "
@@ -519,10 +561,17 @@ def _adapt_genie_response(
         prose_withheld_reason = (
             "it contained numbers the app could not verify against the returned rows."
         )
-    # Genie enhancement fields (2026-07): scrub once, share between the proof
-    # trace and the top-level response fields so every emitted string clears
-    # the same output PII guard the answer text is held to.
-    reasoning_trace = genie_reasoning_trace_from_thoughts(result.thoughts)
+        trace.narrative_withheld(reason=WITHHELD_UNVERIFIED_NUMBERS)
+    elif (result.answer_text or "").strip():
+        trace.verified()
+    else:
+        trace.narrative_withheld(reason=WITHHELD_NO_NARRATIVE)
+    # Genie enhancement fields (2026-07): the deterministic pipeline trace above
+    # is the process summary; translated live thoughts are appended only when
+    # they add something the pipeline steps do not already state. Every emitted
+    # string clears the same output PII guard the answer text is held to, and
+    # raw thoughts still never cross this boundary.
+    reasoning_trace = trace.steps(genie_reasoning_trace_from_thoughts(result.thoughts))
     proof = _build_genie_proof(
         sql_query=result.sql_query,
         trusted_assets=trusted_assets,
@@ -671,6 +720,7 @@ def _restore_live_voice(
     result: GenieResponse,
     *,
     narrative_withheld: bool = False,
+    trace: GenieProcessTrace | None = None,
 ) -> GenieMessageResponse:
     """Keep a recognized-shape trusted answer's governance but restore voice.
 
@@ -687,9 +737,24 @@ def _restore_live_voice(
     * Carry through ``genie_status``, ``reasoning_trace``,
       ``native_visualization`` and ``follow_up_questions`` from the live result
       exactly like the generic adaptation path does.
+
+    ``trace`` is the in-progress deterministic process trace from
+    ``_adapt_genie_response``; this function appends the canonical /
+    execution / verification / composition steps it alone can observe. A
+    missing trace (direct callers, older tests) starts a fresh one so the
+    canonical half of the story still ships.
     """
-    reasoning_trace = genie_reasoning_trace_from_thoughts(result.thoughts)
+    trace = trace if trace is not None else GenieProcessTrace()
     proof = canonical.proof
+    canonical_rows = canonical.table_rows or []
+    if canonical.metric_value:
+        canonical_shape = "metric"
+    elif len(canonical_rows) > 1:
+        canonical_shape = "ranking"
+    else:
+        canonical_shape = ""
+    trace.canonical(shape=canonical_shape)
+    trace.execute(row_count=len(canonical_rows), assets=canonical.trusted_assets)
     # A guard-flagged narrative is withheld wholesale: the deterministic
     # canonical answer ships instead, and the withholding is disclosed below.
     narrative = "" if narrative_withheld else (result.answer_text or "").strip()
@@ -712,6 +777,18 @@ def _restore_live_voice(
         canonical.table_rows,
         canonical.question,
     )
+    if narrative_withheld:
+        trace.narrative_withheld(reason=WITHHELD_UNSAFE_TEXT)
+    elif narrative and contradicted:
+        trace.narrative_withheld(reason=WITHHELD_CONTRADICTED)
+    elif narrative and unsupported_claims:
+        trace.narrative_withheld(reason=WITHHELD_UNVERIFIED_NUMBERS)
+    elif narrative:
+        trace.verified()
+    else:
+        trace.narrative_withheld(reason=WITHHELD_NO_NARRATIVE_DETERMINISTIC)
+    if "**#1" in (canonical.answer or ""):
+        trace.composed_brief()
     if narrative and contradicted:
         updates["answer"] = canonical.answer
         if proof is not None:
@@ -761,6 +838,7 @@ def _restore_live_voice(
             proof = proof.model_copy(
                 update={"known_data_gaps": [*proof.known_data_gaps, gap]}
             )
+    reasoning_trace = trace.steps(genie_reasoning_trace_from_thoughts(result.thoughts))
     if proof is not None:
         updates["proof"] = proof.model_copy(
             update={

--- a/backend/services/repositories/databricks_genie_trace.py
+++ b/backend/services/repositories/databricks_genie_trace.py
@@ -1,0 +1,249 @@
+"""Deterministic, server-authored process trace for one governed Genie turn.
+
+Why this module exists
+----------------------
+``genie_reasoning_trace_from_thoughts`` translates the model's *private*
+thoughts into a tiny fixed vocabulary, which is correct for safety (raw
+thoughts must never ship) but useless as an explanation: a normal turn
+produced four identical "Analyzed the request within the governed Genie
+workflow." lines. Proof UI that repeats itself teaches nothing and reads as
+filler.
+
+This builder records what the *governed pipeline itself* did on the turn --
+guardrails, live drafting, trust policy, narrative repair, canonical
+re-execution, row execution, narrative verification, brief composition -- as
+ordered steps with distinct kinds. Every string is authored here, in server
+code, from structural facts (asset names already extracted by the trust
+policy, row counts, which branch executed). No model text is ever echoed.
+
+Safety contract
+---------------
+Each emitted ``content`` is scanned with ``genie_visible_text_unsafe`` before
+it enters the trace, exactly like every other model-adjacent visible string.
+Asset names are the only interpolated values that originate downstream of the
+model (via ``_extract_asset_refs``), so a step whose asset-bearing wording
+fails the scan falls back to asset-free wording and is dropped entirely if
+that fails too. Fail-closed, never redact-in-place.
+"""
+
+from __future__ import annotations
+
+from backend.services.genie_answers import GenieReasoningStep
+from backend.services.genie_message_policy import genie_visible_text_unsafe
+
+# Same cap as the thought translation path: a bounded proof body.
+GENIE_MAX_TRACE_STEPS = 12
+
+# Number of asset names named inline before the wording switches to a summary
+# phrase. Two keeps the sentence readable for the common
+# lead_population + borrower_360 pair.
+_MAX_NAMED_ASSETS = 2
+
+_GENERIC_ASSET_PHRASE = "the trusted gold assets"
+
+# Translated live-thought contents that the pipeline steps already state more
+# precisely. When a translated thought reduces to one of these, it adds nothing
+# beyond the deterministic trace and is dropped rather than appended.
+SUPERSEDED_TRANSLATED_CONTENTS: frozenset[str] = frozenset(
+    {
+        # The generic catch-all: it describes nothing.
+        "Analyzed the request within the governed Genie workflow.",
+        # Superseded by the richer `live` + `trust` + `execute` steps.
+        "Prepared a governed query plan over approved data assets.",
+    }
+)
+
+
+def _asset_phrase(assets: list[str] | None) -> str:
+    named = [str(asset).strip() for asset in (assets or []) if str(asset).strip()]
+    if not named:
+        return _GENERIC_ASSET_PHRASE
+    return ", ".join(named[:_MAX_NAMED_ASSETS])
+
+
+class GenieProcessTrace:
+    """Ordered, deduped, server-authored steps describing one governed turn.
+
+    The repository populates this as the turn progresses; ``steps()`` renders
+    the wire models for both ``proof.reasoning_trace`` and the response-level
+    ``reasoning_trace``.
+    """
+
+    __slots__ = ("_steps",)
+
+    def __init__(self) -> None:
+        self._steps: list[tuple[str, str]] = []
+
+    # -- internals ---------------------------------------------------
+
+    def _add(self, kind: str, content: str, *, fallback: str | None = None) -> None:
+        for candidate in (content, fallback):
+            if not candidate:
+                continue
+            if genie_visible_text_unsafe(candidate):
+                continue
+            if any(existing == candidate for _, existing in self._steps):
+                return
+            if len(self._steps) >= GENIE_MAX_TRACE_STEPS:
+                return
+            self._steps.append((kind, candidate))
+            return
+
+    # -- pipeline steps ----------------------------------------------
+
+    def guardrails(self) -> None:
+        """Every turn reaching the repository cleared the router guard battery."""
+        self._add(
+            "guardrails",
+            "Prompt cleared the governed guardrails: fair-lending, PII, scope, "
+            "and injection screens.",
+        )
+
+    def repair(self) -> None:
+        """A data question came back narrative-only and was regenerated."""
+        self._add(
+            "repair",
+            "Narrative-only turn repaired: asked Genie to regenerate the answer "
+            "as governed SQL.",
+        )
+
+    def live_turn(self, *, sql_query: str | None, assets: list[str] | None) -> None:
+        if not sql_query:
+            self._add(
+                "live",
+                "The live Genie turn returned a narrative draft with no SQL attachment.",
+            )
+            return
+        self._add(
+            "live",
+            f"The live Genie turn drafted a SQL plan over {_asset_phrase(assets)}.",
+            fallback=(
+                f"The live Genie turn drafted a SQL plan over {_GENERIC_ASSET_PHRASE}."
+            ),
+        )
+
+    def trust(self) -> None:
+        self._add(
+            "trust",
+            "Generated SQL passed the trust policy: a single read-only SELECT "
+            "over trusted assets.",
+        )
+
+    def canonical(self, *, shape: str) -> None:
+        """A recognized grain-sensitive shape was re-executed canonically.
+
+        ``shape`` is a server-chosen label ("ranking" or "metric"), never model
+        text; unknown labels degrade to the neutral wording.
+        """
+        if shape == "metric":
+            self._add(
+                "canonical",
+                "Recognized metric shape: re-executed the governed canonical "
+                "count at the unique-borrower grain.",
+            )
+            return
+        if shape == "ranking":
+            self._add(
+                "canonical",
+                "Recognized ranking shape: re-executed the governed canonical "
+                "query at the unique-borrower grain.",
+            )
+            return
+        self._add(
+            "canonical",
+            "Recognized a governed shape: re-executed the canonical query at "
+            "the unique-borrower grain.",
+        )
+
+    def execute(self, *, row_count: int, assets: list[str] | None) -> None:
+        count = max(int(row_count), 0)
+        row_word = "row" if count == 1 else "rows"
+        self._add(
+            "execute",
+            f"Returned {count:,} {row_word} from {_asset_phrase(assets)}; "
+            "PII columns stripped at the boundary.",
+            fallback=(
+                f"Returned {count:,} {row_word} from {_GENERIC_ASSET_PHRASE}; "
+                "PII columns stripped at the boundary."
+            ),
+        )
+
+    def verified(self) -> None:
+        self._add("verify", "Narrative numbers verified against the returned rows.")
+
+    def narrative_withheld(self, *, reason: str) -> None:
+        """Record the ACTUAL reason the model prose did not render.
+
+        ``reason`` is one of this module's server-owned enum values; anything
+        else degrades to the neutral withholding wording rather than echoing a
+        caller-supplied string.
+        """
+        self._add("verify", NARRATIVE_WITHHELD_CONTENT.get(reason, _WITHHELD_DEFAULT))
+
+    def composed_brief(self) -> None:
+        self._add(
+            "compose",
+            "Composed the per-candidate analyst brief from governed row values.",
+        )
+
+    # -- rendering ----------------------------------------------------
+
+    def steps(
+        self,
+        live_steps: list[GenieReasoningStep] | None = None,
+    ) -> list[GenieReasoningStep]:
+        """Render the trace, optionally appending non-generic live thoughts.
+
+        Translated live thoughts are appended only when they say something the
+        deterministic pipeline steps do not already say (see
+        ``SUPERSEDED_TRANSLATED_CONTENTS``) and are not duplicates.
+        """
+        rendered = [GenieReasoningStep(kind=kind, content=content) for kind, content in self._steps]
+        seen = {content for _, content in self._steps}
+        for step in live_steps or []:
+            if len(rendered) >= GENIE_MAX_TRACE_STEPS:
+                break
+            content = (step.content or "").strip()
+            if not content or content in seen or content in SUPERSEDED_TRANSLATED_CONTENTS:
+                continue
+            if genie_visible_text_unsafe(content):
+                continue
+            seen.add(content)
+            rendered.append(GenieReasoningStep(kind=step.kind, content=content))
+        return rendered
+
+
+# Reasons the model narrative did not render. Keys are internal; values are the
+# only strings that ship.
+WITHHELD_UNSAFE_TEXT = "unsafe_text"
+WITHHELD_UNVERIFIED_NUMBERS = "unverified_numbers"
+WITHHELD_CONTRADICTED = "contradicted"
+#: The live turn produced no prose and there is no deterministic summary to
+#: stand in for it -- the rows and generated SQL are the whole answer.
+WITHHELD_NO_NARRATIVE = "no_narrative"
+#: The live turn produced no prose, but a governed canonical answer did.
+WITHHELD_NO_NARRATIVE_DETERMINISTIC = "no_narrative_deterministic"
+
+_WITHHELD_DEFAULT = (
+    "Draft narrative withheld; the governed query results are shown instead."
+)
+
+NARRATIVE_WITHHELD_CONTENT: dict[str, str] = {
+    WITHHELD_UNSAFE_TEXT: (
+        "Draft narrative withheld: the output safety guard flagged its wording. "
+        "Governed rows are shown instead."
+    ),
+    WITHHELD_UNVERIFIED_NUMBERS: (
+        "Draft narrative withheld: it carried numbers the returned rows could "
+        "not verify."
+    ),
+    WITHHELD_CONTRADICTED: (
+        "Draft narrative superseded: it contradicted the governed recomputation."
+    ),
+    WITHHELD_NO_NARRATIVE: (
+        "Genie returned no narrative; the governed query result is shown without prose."
+    ),
+    WITHHELD_NO_NARRATIVE_DETERMINISTIC: (
+        "Genie returned no narrative, so the verified deterministic summary is shown."
+    ),
+}

--- a/frontend/src/components/HealthProvider.tsx
+++ b/frontend/src/components/HealthProvider.tsx
@@ -8,6 +8,7 @@ import {
   type PropsWithChildren,
 } from 'react';
 import { api, isAbortError, type HealthPayload } from '../lib/api';
+import { normalizeWorkspaceHost } from '../lib/ucAssetLinks';
 
 /**
  * HealthProvider — one `/api/health` poll, shared via context.
@@ -306,4 +307,20 @@ export function useHealth(): HealthContextValue {
  */
 export function useOptionalHealth(): HealthContextValue | null {
   return useContext(HealthContext);
+}
+
+/**
+ * Workspace origin published on the authenticated health body, normalized
+ * and validated (see `normalizeWorkspaceHost`). Returns `null` when the poll
+ * hasn't resolved, when the backend omits `workspace_host` (anonymous body /
+ * older build), when the value fails validation, or when the caller renders
+ * outside a HealthProvider. Callers MUST treat `null` as "render plain text",
+ * never as a reason to fabricate a workspace URL.
+ *
+ * Reuses the shared health poll on purpose — there is exactly one
+ * `/api/health` request per document and this adds no second fetch.
+ */
+export function useWorkspaceHost(): string | null {
+  const ctx = useContext(HealthContext);
+  return normalizeWorkspaceHost(ctx?.health?.workspace_host);
 }

--- a/frontend/src/components/mortgage/GenieAnswer.links.test.tsx
+++ b/frontend/src/components/mortgage/GenieAnswer.links.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Linkage surfaces on the Genie answer:
+ *   - the trailing "Source: <catalog.schema.table>" disclosure becomes a
+ *     Catalog Explorer link when the workspace host is known, and stays
+ *     plain text when it is not
+ *   - table cells for borrower_id / state drill into the same routes the
+ *     drill-down cards and the geography map use; city stays plain
+ */
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GenieAnswer as GenieAnswerShape } from '../../types';
+
+vi.mock('../AppContext', () => ({ useApp: () => ({ setDrawer: vi.fn() }) }));
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>('../../lib/api');
+  return { ...actual, api: { genieFeedback: vi.fn().mockResolvedValue({ accepted: true }) } };
+});
+
+const workspaceHost = vi.hoisted(() => ({ value: null as string | null }));
+vi.mock('../HealthProvider', () => ({ useWorkspaceHost: () => workspaceHost.value }));
+
+import { GenieAnswer } from './GenieAnswer';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const HOST = 'https://dbc-test.cloud.databricks.com';
+const BORROWER = 'B-7K2M9QX4TB3PZ';
+
+function payload(overrides: Partial<GenieAnswerShape> = {}): GenieAnswerShape {
+  return {
+    answer: 'The average loan age is 5.25 years. Source: mip.gold.borrower_360.',
+    source: 'genie',
+    trusted_assets: ['mip.gold.borrower_360'],
+    conversation_id: 'conv-1',
+    message_id: 'msg-1',
+    genie_status: 'COMPLETED',
+    ...overrides,
+  } as unknown as GenieAnswerShape;
+}
+
+describe('GenieAnswer UC + route linkage', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    workspaceHost.value = HOST;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const mount = (p: GenieAnswerShape) => {
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <GenieAnswer payload={p} />
+        </MemoryRouter>,
+      );
+    });
+  };
+
+  it('links the trailing Source disclosure to Catalog Explorer in a new tab', () => {
+    mount(payload());
+    const link = container.querySelector('a.uc-asset-link') as HTMLAnchorElement | null;
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('href')).toBe(`${HOST}/explore/data/mip/gold/borrower_360`);
+    expect(link?.getAttribute('target')).toBe('_blank');
+    expect(link?.getAttribute('rel')).toContain('noopener');
+    expect(link?.textContent).toBe('mip.gold.borrower_360');
+  });
+
+  it('keeps the "Source:" label as text and does not swallow the sentence period', () => {
+    mount(payload());
+    expect(container.textContent).toContain('Source: mip.gold.borrower_360');
+    const link = container.querySelector('a.uc-asset-link');
+    expect(link?.textContent?.endsWith('.')).toBe(false);
+  });
+
+  it('degrades to plain text when the workspace host is unknown', () => {
+    workspaceHost.value = null;
+    mount(payload());
+    expect(container.querySelector('a.uc-asset-link')).toBeNull();
+    expect(container.textContent).toContain('Source: mip.gold.borrower_360');
+  });
+
+  it('links borrower_id and state table cells, leaving city plain', () => {
+    mount(
+      payload({
+        answer: 'Top borrowers.',
+        table_rows: [{ borrower_id: BORROWER, state: 'IL', city: 'Chicago' }],
+      } as Partial<GenieAnswerShape>),
+    );
+    const hrefs = Array.from(container.querySelectorAll('.genie-answer__table a')).map((a) =>
+      a.getAttribute('href'),
+    );
+    expect(hrefs).toContain(`/borrower-360/${BORROWER}`);
+    expect(hrefs).toContain('/lead-queue?state=IL');
+    expect(hrefs.some((h) => h?.includes('Chicago'))).toBe(false);
+  });
+
+  it('leaves a borrower_id that is not a masked id as plain text', () => {
+    mount(
+      payload({
+        answer: 'Rows.',
+        table_rows: [{ borrower_id: 'not-a-masked-id', state: 'IL' }],
+      } as Partial<GenieAnswerShape>),
+    );
+    const hrefs = Array.from(container.querySelectorAll('.genie-answer__table a')).map((a) =>
+      a.getAttribute('href'),
+    );
+    expect(hrefs).toEqual(['/lead-queue?state=IL']);
+  });
+});

--- a/frontend/src/components/mortgage/GenieAnswer.markdown.tsx
+++ b/frontend/src/components/mortgage/GenieAnswer.markdown.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { SOURCE_LINE_RE, catalogExplorerUrl } from '../../lib/ucAssetLinks';
 
 /** Phrases Genie commonly uses to restate the question before answering. */
 const RESTATEMENT_LEADERS = [
@@ -34,8 +35,50 @@ export function stripQuestionRestatement(answer: string): string {
   return trimmed;
 }
 
+/**
+ * Auto-link the trailing "Source: mip.gold.borrower_360" disclosure Genie
+ * appends to its answers, so the reader can jump straight into the workspace
+ * Catalog Explorer entry for the asset that produced the number.
+ *
+ * Degrades to the original plain text whenever the workspace host is unknown
+ * (health poll not resolved, anonymous health body, older backend) or the
+ * captured token is not a 3-part UC name — a "Source:" line must never
+ * render as a dead or fabricated link.
+ */
+export function renderSourceLinks(text: string, workspaceHost: string | null | undefined): ReactNode[] {
+  if (!workspaceHost || !text.includes('.')) return [text];
+  const out: ReactNode[] = [];
+  const re = new RegExp(SOURCE_LINE_RE.source, SOURCE_LINE_RE.flags);
+  let last = 0;
+  let key = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const [whole, label, asset] = match;
+    const href = catalogExplorerUrl(workspaceHost, asset);
+    if (!href) continue;
+    if (match.index > last) out.push(text.slice(last, match.index));
+    out.push(label);
+    out.push(
+      <a
+        key={`uc-${key++}`}
+        className="uc-asset-link"
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={`Open ${asset} in Databricks Catalog Explorer`}
+      >
+        {asset}
+      </a>,
+    );
+    last = match.index + whole.length;
+  }
+  if (out.length === 0) return [text];
+  if (last < text.length) out.push(text.slice(last));
+  return out;
+}
+
 /** Tiny markdown renderer for Genie answers: bold, inline code, bullets. */
-function renderInlineMd(text: string): ReactNode[] {
+function renderInlineMd(text: string, workspaceHost?: string | null): ReactNode[] {
   const out: ReactNode[] = [];
   const re = /(\*\*([^*]+?)\*\*|`([^`]+?)`)/g;
   let last = 0;
@@ -43,7 +86,7 @@ function renderInlineMd(text: string): ReactNode[] {
   let key = 0;
   while ((match = re.exec(text)) !== null) {
     if (match.index > last) {
-      out.push(<span key={key++}>{text.slice(last, match.index)}</span>);
+      out.push(<span key={key++}>{renderSourceLinks(text.slice(last, match.index), workspaceHost)}</span>);
     }
     if (match[2] != null) {
       out.push(<strong key={key++}>{match[2]}</strong>);
@@ -60,12 +103,21 @@ function renderInlineMd(text: string): ReactNode[] {
     last = match.index + match[0].length;
   }
   if (last < text.length) {
-    out.push(<span key={key++}>{text.slice(last)}</span>);
+    out.push(<span key={key++}>{renderSourceLinks(text.slice(last), workspaceHost)}</span>);
   }
   return out;
 }
 
-export function MarkdownAnswer({ text }: { text: string }) {
+export function MarkdownAnswer({
+  text,
+  workspaceHost,
+}: {
+  text: string;
+  /** Workspace origin for Catalog Explorer deep links. Threaded in from
+   *  `useWorkspaceHost()` by the caller so this renderer stays pure and
+   *  testable. Omitted/null ⇒ "Source: …" stays plain text. */
+  workspaceHost?: string | null;
+}) {
   const lines = text.split(/\r?\n/);
   type Block = { type: 'p'; text: string } | { type: 'ul'; items: string[] };
   const blocks: Block[] = [];
@@ -104,7 +156,7 @@ export function MarkdownAnswer({ text }: { text: string }) {
               key={i}
               className={`genie-md-p ${i === 0 ? 'genie-md-p--first' : ''}`}
             >
-              {renderInlineMd(b.text)}
+              {renderInlineMd(b.text, workspaceHost)}
             </p>
           ) : (
             <ul
@@ -112,7 +164,7 @@ export function MarkdownAnswer({ text }: { text: string }) {
               className="genie-md-list"
             >
               {b.items.map((it, j) => (
-                <li key={j}>{renderInlineMd(it)}</li>
+                <li key={j}>{renderInlineMd(it, workspaceHost)}</li>
               ))}
             </ul>
           ),

--- a/frontend/src/components/mortgage/GenieAnswer.tsx
+++ b/frontend/src/components/mortgage/GenieAnswer.tsx
@@ -1,11 +1,13 @@
 import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { Link } from 'react-router';
 import type {
   GenieActionSuggestion,
   GenieAnswer as GenieAnswerShape,
 } from '../../types';
 import { Icon } from '../Icon';
 import { useApp } from '../AppContext';
+import { useWorkspaceHost } from '../HealthProvider';
 import { GenieActions } from './GenieAnswerActions';
 import {
   GenieBarChart,
@@ -34,6 +36,7 @@ import {
   pickPlan,
 } from './GenieAnswer.logic';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { genieCellHref } from '../../lib/genieCellLinks';
 
 export { stripQuestionRestatement } from './GenieAnswer.markdown';
 export { inferChartFromRows } from './GenieAnswer.logic';
@@ -84,6 +87,10 @@ export function GenieAnswer({
 }: GenieAnswerProps) {
   const { answer, metric_value, table_rows, follow_up_questions, actions } = payload;
   const { setDrawer } = useApp();
+  // Workspace origin for Catalog Explorer deep links on UC asset names.
+  // Reads the shared health poll; null (poll pending / older backend /
+  // rendered outside HealthProvider in a test) degrades to plain text.
+  const workspaceHost = useWorkspaceHost();
   const { pins, pin, unpin } = usePinnedInsights();
   const [showProof, setShowProof] = useState(false);
   const proofDrawerRef = useRef<HTMLElement | null>(null);
@@ -232,7 +239,7 @@ export function GenieAnswer({
       )}
       {proofToggle}
       {nativeVizBadge}
-      {cleanedAnswer && <MarkdownAnswer text={cleanedAnswer} />}
+      {cleanedAnswer && <MarkdownAnswer text={cleanedAnswer} workspaceHost={workspaceHost} />}
       {/* The backend exposes bounded, public process summaries for live Genie
           turns through the existing reasoning_trace wire field. Render them
           as escaped text in a native disclosure. */}
@@ -334,9 +341,22 @@ export function GenieAnswer({
                       {columns.map((c) => {
                         const v = row[c];
                         const isNum = typeof v === 'number' && !isIdentifierColumn(c);
+                        // Linkage: a masked borrower id drills into the same
+                        // Borrower 360 route the drill-down cards use; a state
+                        // code opens the same filtered Lead Queue the
+                        // geography map navigates to on a state click.
+                        // Everything else (including city — no route filters
+                        // by city) renders as plain text.
+                        const href = genieCellHref(c, v);
                         return (
                           <td key={c} className={isNum ? 'num' : undefined}>
-                            {formatCell(c, v)}
+                            {href ? (
+                              <Link className="mono" to={href}>
+                                {formatCell(c, v)}
+                              </Link>
+                            ) : (
+                              formatCell(c, v)
+                            )}
                           </td>
                         );
                       })}
@@ -386,6 +406,7 @@ export function GenieAnswer({
             <div className="drawer__body">
               <GenieProofPanel
                 payload={payload}
+                workspaceHost={workspaceHost}
                 onOpenSource={(source) => {
                   setShowProof(false);
                   setDrawer(source);

--- a/frontend/src/components/mortgage/GenieAnswerCharts.tsx
+++ b/frontend/src/components/mortgage/GenieAnswerCharts.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router';
 import {
   coerceNumber,
   formatCell,
@@ -11,6 +12,7 @@ import { loadUsaStateMap } from './USStateMapData';
 import type { UsaSvgMap } from './USChoroplethMap.utils';
 import { offerDisplayLabel } from '../../lib/offerLanguage';
 import { safeSegmentName } from '../../lib/segmentMetadata';
+import { borrower360Path } from '../../lib/genieCellLinks';
 
 export function strategySegmentLabel(value: unknown): string | null {
   if (value === null || value === undefined || value === '') return null;
@@ -238,13 +240,16 @@ export function GenieBorrowerList({ rows }: { rows: Array<Record<string, unknown
           const id = String(row.borrower_id);
           const score = coerceNumber(row.opportunity_score ?? row.score);
           return (
-            <a key={id} className="genie-board__card" href={`/borrower-360/${encodeURIComponent(id)}`}>
+            // Router <Link>, not a raw <a>: the card used to hard-navigate,
+            // dropping the SPA state (and the open Genie panel) on every
+            // borrower drill-down.
+            <Link key={id} className="genie-board__card" to={borrower360Path(id)}>
               <div className="genie-board__title">{id}</div>
               <div className="genie-board__meta">
                 {[row.city, row.state, row.zip].filter(Boolean).join(', ') || 'Open borrower evidence'}
               </div>
               {score !== null && <div className="genie-board__value">{score.toLocaleString()}</div>}
-            </a>
+            </Link>
           );
         })}
       </div>

--- a/frontend/src/components/mortgage/GenieAnswerProof.tsx
+++ b/frontend/src/components/mortgage/GenieAnswerProof.tsx
@@ -3,13 +3,19 @@ import { drawerForAsset } from '../../lib/drawerSources';
 import { formatTimestamp } from '../../lib/time';
 import type { DrawerSource } from '../AppContext';
 import { Chip, EvidenceChip } from '../Primitives';
+import { Icon } from '../Icon';
+import { catalogExplorerUrl } from '../../lib/ucAssetLinks';
 
 export function GenieProofPanel({
   payload,
   onOpenSource,
+  workspaceHost,
 }: {
   payload: GenieAnswerShape;
   onOpenSource: (source: DrawerSource) => void;
+  /** Workspace origin for Catalog Explorer deep links. null/undefined ⇒ the
+   *  asset chips render exactly as before (no external link affordance). */
+  workspaceHost?: string | null;
 }) {
   const proof = payload.proof;
   if (!proof) return null;
@@ -40,14 +46,39 @@ export function GenieProofPanel({
           <div className="chip-row">
             {assets.map((asset) => {
               const drawer = drawerForAsset(asset);
-              return drawer ? (
-                <EvidenceChip key={asset} source={drawer} onClick={() => onOpenSource(drawer)}>
-                  {asset}
-                </EvidenceChip>
-              ) : (
-                <Chip key={asset} variant="neutral" title={`Source: ${asset}`}>
-                  {asset}
-                </Chip>
+              const explorerUrl = catalogExplorerUrl(workspaceHost, asset);
+              const explorerLink = explorerUrl ? (
+                <a
+                  className="chip chip--neutral uc-asset-link"
+                  href={explorerUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Open ${asset} in Catalog Explorer`}
+                  title={`Open ${asset} in Databricks Catalog Explorer`}
+                >
+                  {/* Drawer-mapped assets keep the in-app evidence chip as the
+                      primary action; this is the escape hatch to the workspace.
+                      Unmapped assets get the asset name on the link itself so
+                      the previously inert chip becomes reachable. */}
+                  {!drawer && <span className="chip__label">{asset}</span>}
+                  <Icon name="export" size={10} />
+                </a>
+              ) : null;
+              return (
+                <span key={asset} className="genie-proof__asset">
+                  {drawer ? (
+                    <EvidenceChip source={drawer} onClick={() => onOpenSource(drawer)}>
+                      {asset}
+                    </EvidenceChip>
+                  ) : (
+                    !explorerLink && (
+                      <Chip variant="neutral" title={`Source: ${asset}`}>
+                        {asset}
+                      </Chip>
+                    )
+                  )}
+                  {explorerLink}
+                </span>
               );
             })}
           </div>

--- a/frontend/src/components/mortgage/GenieChat.tsx
+++ b/frontend/src/components/mortgage/GenieChat.tsx
@@ -16,7 +16,17 @@ import {
   writeGenieConversationId,
 } from '../../lib/genieConversation';
 import { NON_PERSISTABLE_SOURCES } from '../../lib/pinnedInsights';
+import {
+  clearGenieTurns,
+  getGenieTurns,
+  persistGenieMessages,
+  setGenieTurns,
+  turnsToMessages,
+  type GenieChatMessage,
+  type GenieTurn,
+} from '../../lib/genieConversationStore';
 import { GENIE_POINTER_RESIZE_HANDLES, useGenieWindow } from './useGenieWindow';
+import { GenieHistoryMenu } from './GenieHistoryMenu';
 
 /**
  * Floating Genie chat panel — `.genie` BEM from the prototype. Fixed
@@ -30,9 +40,7 @@ import { GENIE_POINTER_RESIZE_HANDLES, useGenieWindow } from './useGenieWindow';
  * via the shared <GenieAnswer> subcomponent.
  */
 
-type ChatMsg =
-  | { who: 'user'; text: string }
-  | { who: 'ai'; payload: GenieAnswerShape; sources?: string[] };
+type ChatMsg = GenieChatMessage;
 
 export function sourceAssetsFor(payload: GenieAnswerShape): string[] {
   const seen = new Set<string>();
@@ -66,9 +74,16 @@ export function shouldRenderGenieSourceAssets(payload: GenieAnswerShape): boolea
 export function GenieChat() {
   const { genieOpen, setGenieOpen, lender, refreshWorkspace } = useApp();
   const navigate = useNavigate();
-  const [msgs, setMsgs] = useState<ChatMsg[]>([]);
+  // Transcript restored from the tab-scoped store. The panel is unmounted
+  // whenever it is closed (`{genieOpen ? <GenieChat/> : null}` in AppShell),
+  // so without this the whole conversation died on every close/reopen and on
+  // any navigation that remounted the shell.
+  const [msgs, setMsgs] = useState<ChatMsg[]>(() =>
+    turnsToMessages(getGenieTurns(), sourceAssetsFor),
+  );
   const [input, setInput] = useState('');
   const [typing, setTyping] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
   // Live lifecycle telemetry for the in-flight turn (stage, public process
   // steps, generated SQL) driven by the submit → progress → complete flow.
   const [liveProgress, setLiveProgress] = useState<GenieLiveProgress | null>(null);
@@ -118,9 +133,14 @@ export function GenieChat() {
       askGenerationRef.current += 1;
       askAbortRef.current?.abort();
       setConversationId(null);
+      // An actor-boundary reset / 403 invalidates the transcript too: the
+      // conversation is not resumable and the prior actor's questions must
+      // not linger in this tab.
+      clearGenieTurns();
       setMsgs([]);
       setInput('');
       setTyping(false);
+      setHistoryOpen(false);
       setLiveProgress(null);
       setAskStartedAt(null);
     };
@@ -154,6 +174,13 @@ export function GenieChat() {
   useEffect(() => {
     if (bodyRef.current) bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
   }, [msgs, typing, genieOpen]);
+
+  // Persist the settled transcript. Gated on `typing` so an in-flight turn is
+  // never written — a reload mid-answer restores the last completed exchange
+  // instead of a dangling question with no answer.
+  useEffect(() => {
+    persistGenieMessages(msgs, { inFlight: typing });
+  }, [msgs, typing]);
 
   // R5-12: ESC closes + initial focus + focus restore. Deliberately do
   // NOT trap Tab: the floating Genie panel is a non-modal dialog, and the
@@ -252,9 +279,31 @@ export function GenieChat() {
     if (typing) return;
     suppressBootstrapConversationRef.current = true;
     setConversationId(null);
+    clearGenieTurns();
     setMsgs([]);
     setInput('');
+    setHistoryOpen(false);
     clearGenieConversationState({ notify: true });
+  };
+
+  /**
+   * Restore a past conversation from the History menu. The loaded turns are
+   * the same `{question, response}` shape the local store persists, so they
+   * render through the identical <GenieAnswer> path. The conversation id is
+   * adopted too, so a follow-up continues that Databricks thread rather than
+   * opening an orphan one.
+   */
+  const loadSession = (conversationIdToLoad: string, turns: GenieTurn[]) => {
+    if (typing) return;
+    askGenerationRef.current += 1;
+    askAbortRef.current?.abort();
+    suppressBootstrapConversationRef.current = true;
+    const restored = setGenieTurns(turns);
+    setMsgs(turnsToMessages(restored, sourceAssetsFor));
+    setConversationId(conversationIdToLoad);
+    writeGenieConversationId(conversationIdToLoad);
+    setHistoryOpen(false);
+    setInput('');
   };
 
   const runAction = async (action: GenieActionSuggestion, payload: GenieAnswerShape) => {
@@ -432,9 +481,19 @@ export function GenieChat() {
               <Icon name="db" size={14} />
             </button>
           )}
+          <GenieHistoryMenu
+            open={historyOpen}
+            onToggle={setHistoryOpen}
+            onLoad={loadSession}
+            disabled={typing}
+          />
+          {/* "New thread" is now a labeled control, not an icon-only button:
+              it clears the persisted transcript, so the destructive intent
+              has to be readable. `.btn--ghost .btn--sm` per the design
+              system's existing button vocabulary. */}
           <button
             type="button"
-            className="drawer__close"
+            className="btn btn--ghost btn--sm genie__new-thread"
             onClick={(e) => {
               e.stopPropagation();
               newConversation();
@@ -443,7 +502,8 @@ export function GenieChat() {
             aria-label="Start a new Genie thread"
             title="New thread"
           >
-            <Icon name="chat" size={14} />
+            <Icon name="chat" size={12} />
+            <span className="genie__new-thread-label">New thread</span>
           </button>
           <button
             className="drawer__close"

--- a/frontend/src/components/mortgage/GenieHistoryMenu.tsx
+++ b/frontend/src/components/mortgage/GenieHistoryMenu.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from 'react';
+import { api, isAbortError } from '../../lib/api';
+import { formatTimestamp } from '../../lib/time';
+import type { GenieSessionSummary } from '../../types';
+import type { GenieTurn } from '../../lib/genieConversationStore';
+import { Icon } from '../Icon';
+
+/**
+ * Past-conversation picker for the floating Genie panel header.
+ *
+ * Reads `GET /api/genie/sessions` on open (not on mount) so the panel's first
+ * paint never waits on an optional affordance, and re-reads on each open so a
+ * session finished in another tab shows up.
+ *
+ * Failure posture: history is a convenience, never a dependency. A 404 (older
+ * backend without the endpoint), a 5xx, or a network failure all collapse to
+ * one inline "History unavailable" row — the chat underneath keeps working
+ * and no error is surfaced as a governed answer.
+ */
+export function GenieHistoryMenu({
+  open,
+  onToggle,
+  onLoad,
+  disabled = false,
+}: {
+  open: boolean;
+  onToggle: (next: boolean) => void;
+  onLoad: (conversationId: string, turns: GenieTurn[]) => void;
+  /** True while a turn is in flight — loading another session mid-answer
+   *  would race the in-flight response into the restored transcript. */
+  disabled?: boolean;
+}) {
+  const [sessions, setSessions] = useState<GenieSessionSummary[] | null>(null);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+  // Synchronous latch: two fast clicks on the same row both read
+  // `loadingId === null` in the same frame without it.
+  const loadLatchRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const controller = new AbortController();
+    setStatus('loading');
+    api
+      .genieSessions(controller.signal)
+      .then((rows) => {
+        if (controller.signal.aborted) return;
+        setSessions(Array.isArray(rows) ? rows : []);
+        setStatus('ready');
+      })
+      .catch((err) => {
+        if (isAbortError(err) || controller.signal.aborted) return;
+        setSessions(null);
+        setStatus('error');
+      });
+    return () => controller.abort();
+  }, [open]);
+
+  const load = async (conversationId: string) => {
+    if (loadLatchRef.current || disabled) return;
+    loadLatchRef.current = true;
+    setLoadingId(conversationId);
+    try {
+      const detail = await api.genieSession(conversationId);
+      const turns = Array.isArray(detail?.turns) ? detail.turns : [];
+      onLoad(detail?.conversation_id ?? conversationId, turns as GenieTurn[]);
+    } catch {
+      setStatus('error');
+    } finally {
+      loadLatchRef.current = false;
+      setLoadingId(null);
+    }
+  };
+
+  return (
+    <div className="genie-history">
+      <button
+        type="button"
+        className="drawer__close"
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle(!open);
+        }}
+        disabled={disabled}
+        aria-expanded={open}
+        aria-label="Genie conversation history"
+        title="History"
+      >
+        <Icon name="audit" size={14} />
+      </button>
+      {open && (
+        <div
+          className="filter-menu genie-history__menu"
+          role="menu"
+          aria-label="Past Genie conversations"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          {status === 'loading' && <div className="genie-history__state">Loading history…</div>}
+          {status === 'error' && (
+            <div className="genie-history__state genie-history__state--error">
+              History unavailable
+            </div>
+          )}
+          {status === 'ready' && (sessions?.length ?? 0) === 0 && (
+            <div className="genie-history__state">No past conversations yet</div>
+          )}
+          {status === 'ready' &&
+            (sessions ?? []).map((session) => (
+              <button
+                key={session.conversation_id}
+                type="button"
+                role="menuitem"
+                className="filter-menu__item genie-history__item"
+                disabled={loadingId !== null || disabled}
+                onClick={() => void load(session.conversation_id)}
+              >
+                <span className="genie-history__title">{session.title || 'Untitled conversation'}</span>
+                <span className="genie-history__meta">
+                  {session.turn_count} turn{session.turn_count === 1 ? '' : 's'}
+                  {session.last_activity_at ? ` · ${formatTimestamp(session.last_activity_at)}` : ''}
+                </span>
+              </button>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/design-system/components.css
+++ b/frontend/src/design-system/components.css
@@ -9,8 +9,15 @@
    ============================================================ */
 .app-shell {
   display: grid;
+  /* --shell-topbar-h drives BOTH the topbar grid row and the rail's brand
+     slot height. Keeping them on one variable is what makes the Entrada
+     mark's vertical center land exactly on the "Mortgage Intelligence
+     Platform" crumb's center — before this, the rail carried its own top
+     padding and the mark sat ~12px below the title at 1440x900. Any future
+     topbar height change stays aligned by construction. */
+  --shell-topbar-h: 56px;
   grid-template-columns: 72px 1fr;
-  grid-template-rows: 56px 1fr;
+  grid-template-rows: var(--shell-topbar-h) 1fr;
   grid-template-areas:
     "rail topbar"
     "rail main";
@@ -303,14 +310,23 @@
   display: flex; flex-direction: column; align-items: stretch;
   background: var(--bg-1);
   border-right: 1px solid var(--line-1);
-  padding: var(--sp-3) var(--sp-2);
+  /* No block-start padding: the brand slot below IS the rail's header band
+     and must be flush with the top of the shell so it mirrors the topbar
+     row exactly. Inline padding is unchanged, so `margin: 0 auto` on
+     .rail__item still centers the M0-M4 boxes on the same vertical axis as
+     the centered mark. */
+  padding: 0 var(--sp-2) var(--sp-3);
   gap: var(--sp-1);
 }
 .rail__brand {
-  width: 56px; height: 56px; margin: 0 auto var(--sp-4);
+  /* Full rail content width x exact topbar height => the mark's center is
+     the topbar's center line. The former 56x56 box with 10px padding left a
+     36px content box that the 47x32 mark overflowed, so it read as
+     off-center inside its own slot. */
+  width: 100%; height: var(--shell-topbar-h); margin: 0 0 var(--sp-3);
   display: grid; place-items: center;
   border-radius: var(--r-lg);
-  padding: 10px;
+  padding: 0;
   text-decoration: none;
   transition: background var(--dur-fast) var(--ease), transform var(--dur-fast) var(--ease);
 }
@@ -323,6 +339,11 @@
 }
 .rail__item {
   width: 56px; height: 56px; margin: 0 auto;
+  /* The rail's 1px right border makes its content box 55px, so a fixed 56px
+     item overflowed by 0.5px on each side — enough to push the M0-M4 boxes
+     off the mark's center line and to bleed the active pill into the border.
+     Clamping keeps every rail box on one vertical axis at every breakpoint. */
+  max-inline-size: 100%;
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 3px;
   border-radius: var(--r-md);
@@ -2548,6 +2569,38 @@ a.lineage-node__chip:focus-visible {
 }
 .genie__title { font-size: var(--fs-13); font-weight: 600; color: var(--text-1); }
 .genie__sub { font-size: var(--fs-11); color: var(--text-3); }
+/* Header controls (History, New thread, Close) are fixed-width; the title
+   block is what absorbs the remaining space and truncates. Without
+   min-inline-size:0 the flex title refuses to shrink and pushes the
+   controls out of a narrow panel. */
+.genie-chat__drag-title { min-inline-size: 0; }
+.genie__title,
+.genie__sub { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.genie__new-thread { flex-shrink: 0; white-space: nowrap; }
+.genie__new-thread-label { white-space: nowrap; }
+/* History menu. Reuses the existing `.filter-menu` / `.filter-menu__item`
+   dropdown primitives; only the right-edge anchor, the fixed width, and the
+   two-line item stack are specific to the Genie panel header.
+   NOTE the `.genie-history` parent on the overrides: `.filter-menu` is
+   declared LATER in this file, so a bare `.genie-history__menu` rule would
+   lose the cascade on `left` / `align-items` and the menu would anchor to
+   the wrong edge with its rows on one line. */
+.genie-history { position: relative; flex-shrink: 0; }
+.genie-history .genie-history__menu {
+  left: auto; inset-inline-end: 0; inline-size: 240px; cursor: default;
+}
+.genie-history .genie-history__item {
+  flex-direction: column; align-items: flex-start; gap: 2px;
+}
+.genie-history .genie-history__item:disabled { opacity: 0.55; cursor: default; }
+.genie-history__state { padding: var(--sp-2); color: var(--text-3); font-size: var(--fs-12); }
+.genie-history__state--error { color: var(--signal-warning); }
+.genie-history__title {
+  max-inline-size: 100%;
+  overflow: hidden; text-overflow: ellipsis;
+  color: var(--text-1); font-weight: 600;
+}
+.genie-history__meta { color: var(--text-3); font-family: var(--font-mono); font-size: var(--fs-11); }
 .genie__body { flex: 1; overflow-y: auto; padding: var(--sp-4); display: flex; flex-direction: column; gap: var(--sp-3); }
 .genie__msg { max-width: 92%; }
 .genie__msg--user {
@@ -3394,7 +3447,17 @@ a.lineage-node__chip:focus-visible {
 }
 .filter:hover { border-color: var(--line-2); color: var(--text-1); }
 .filter.is-active { border-color: var(--accent); color: var(--accent-ink); background: var(--accent-soft); }
-.filter__label { color: var(--text-3); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; margin-right: 2px; }
+/* `white-space: nowrap` + `flex-shrink: 0`: the "ASK" prefix on a Genie
+   follow-up chip (`.filter--question`) is a flex item inside a
+   width-constrained chip, so the flex algorithm was shrinking it below its
+   min-content width and wrapping it to "AS / K". The label is a fixed
+   2-4 character eyebrow — it must never wrap or shrink; the long value
+   next to it is what absorbs the remaining width. */
+.filter__label {
+  color: var(--text-3); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; margin-right: 2px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
 .filter__value { font-weight: 500; color: var(--text-1); font-family: var(--font-mono); font-size: var(--fs-12); }
 .filter.is-active .filter__value { color: var(--accent-ink); }
 .filter--question {
@@ -4454,6 +4517,64 @@ a.lineage-node__chip:focus-visible {
 .analytics-chart__grid {
   stroke: var(--line-1);
 }
+/* Pointer hover readout for the distribution line charts (Rate Spread,
+   Opportunity Score). The layer itself is transparent and aria-hidden; the
+   crosshair, dot, and tip are positioned in the same 0-100 percent space the
+   `preserveAspectRatio="none"` SVG uses, so they track the line at any
+   container width. */
+.analytics-chart__hover {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline: 0;
+  block-size: var(--analytics-chart-h);
+}
+.analytics-chart__crosshair,
+.analytics-chart__hover-dot,
+.analytics-chart__tip {
+  position: absolute;
+  inset-inline-start: var(--hover-x);
+  pointer-events: none;
+}
+.analytics-chart__crosshair {
+  inset-block: 0;
+  inline-size: 1px;
+  background: var(--line-2);
+}
+.analytics-chart__hover-dot,
+.analytics-chart__tip { inset-block-start: var(--hover-y); }
+.analytics-chart__hover-dot {
+  inline-size: var(--sp-2);
+  block-size: var(--sp-2);
+  border-radius: var(--r-pill);
+  background: var(--accent);
+  border: 1px solid var(--bg-1);
+  transform: translate(-50%, -50%);
+}
+.analytics-chart__tip {
+  transform: translate(var(--sp-3), calc(-100% - var(--sp-2)));
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  padding: var(--sp-2);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-md);
+  background: var(--bg-1);
+  box-shadow: var(--shadow-md);
+  white-space: nowrap;
+  z-index: 1;
+}
+/* Past ~60% of the plot width the tip would overflow the surface; flip it to
+   the left of the crosshair instead. */
+.analytics-chart__tip--flip {
+  transform: translate(calc(-100% - var(--sp-3)), calc(-100% - var(--sp-2)));
+}
+.analytics-chart__tip-x {
+  color: var(--text-1);
+  font-family: var(--font-mono);
+  font-size: var(--fs-12);
+  font-weight: 600;
+}
+.analytics-chart__tip-y { color: var(--text-2); font-size: var(--fs-11); }
 .analytics-line-chart polyline {
   fill: none;
   stroke: var(--accent);
@@ -5104,9 +5225,11 @@ a.lineage-node__chip:focus-visible {
     width: 100%;
   }
   .rail {
-    padding: var(--sp-2) var(--sp-1);
+    padding: 0 var(--sp-1) var(--sp-2);
   }
-  .rail__brand,
+  /* .rail__brand keeps width:100% + height:var(--shell-topbar-h) at every
+     breakpoint so the mark stays on the topbar center line; only the module
+     boxes need an explicit size here. */
   .rail__item {
     width: 48px;
     height: 48px;
@@ -5139,7 +5262,6 @@ a.lineage-node__chip:focus-visible {
   .app-shell {
     grid-template-columns: 80px 1fr;
   }
-  .rail__brand,
   .rail__item {
     width: 60px;
     height: 60px;
@@ -5152,9 +5274,10 @@ a.lineage-node__chip:focus-visible {
 @media (min-width: 2560px) {
   .app-shell {
     grid-template-columns: 96px 1fr;
-    grid-template-rows: 64px 1fr;
+    /* Row height flows from the variable so .rail__brand tracks it and the
+       mark stays centered on the topbar line at this breakpoint too. */
+    --shell-topbar-h: 64px;
   }
-  .rail__brand,
   .rail__item {
     width: 72px;
     height: 72px;
@@ -6289,6 +6412,26 @@ a.lineage-node__chip:focus-visible {
   color: var(--signal-warning);
   font-size: var(--fs-12);
   margin-top: var(--sp-1);
+}
+/* UC asset → Catalog Explorer deep link. Two callers: the inline
+   "Source: mip.gold.borrower_360" disclosure inside a Genie answer
+   paragraph, and the proof drawer's source-asset chip row (where it also
+   carries `.chip .chip--neutral`, so only the link affordance is added
+   here). Mirrors `.lineage-node__chip`'s external-link treatment. */
+.uc-asset-link {
+  color: var(--accent-ink);
+  font-family: var(--font-mono);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+  overflow-wrap: anywhere;
+}
+.uc-asset-link:hover { text-decoration-style: solid; }
+.chip.uc-asset-link { text-decoration: none; }
+.genie-proof__asset {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
 }
 .genie-proof__trace {
   display: flex;

--- a/frontend/src/lib/actorScopedBrowserState.ts
+++ b/frontend/src/lib/actorScopedBrowserState.ts
@@ -1,8 +1,15 @@
 import { clearGenieConversationState } from './genieConversation';
+import { GENIE_CONVERSATION_TURNS_KEY, clearGenieTurns } from './genieConversationStore';
 import { clearPinnedInsights } from './pinnedInsights';
 
 export const ACTOR_SCOPED_LOCAL_STORAGE_KEYS = ['mip.lastBorrowerId'] as const;
-export const ACTOR_SCOPED_SESSION_STORAGE_KEYS = ['mip.bulkApprove.lastCancelled'] as const;
+export const ACTOR_SCOPED_SESSION_STORAGE_KEYS = [
+  'mip.bulkApprove.lastCancelled',
+  // Genie transcript. Actor-scoped: one operator's questions and answers must
+  // never survive into another operator's session on a shared booth machine.
+  // Imported rather than duplicated so the key cannot drift from the store.
+  GENIE_CONVERSATION_TURNS_KEY,
+] as const;
 
 export function clearActorScopedBrowserState(): void {
   if (typeof window === 'undefined') return;
@@ -21,6 +28,9 @@ export function clearActorScopedBrowserState(): void {
     // Storage can be unavailable in privacy-restricted contexts.
   }
   clearGenieConversationState({ notify: true });
+  // Also drop the in-memory transcript cache: removing the sessionStorage key
+  // above does not reset the module-level copy a mounted panel is rendering.
+  clearGenieTurns();
   // Personal pinned insights (Buyer-Wow #9) are actor-scoped — clear them on
   // an actor change so one operator's pins never bleed into another session.
   clearPinnedInsights();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -53,6 +53,8 @@ import type {
   SavedLeadInput,
   GenieActionResult,
   GenieActionSuggestion,
+  GenieSessionDetail,
+  GenieSessionSummary,
   GenieStartResult,
   GrowthAgentDueMonitorRunRequest,
   GrowthAgentDueMonitorRunResponse,
@@ -107,6 +109,14 @@ export interface HealthPayload {
   dependencies?: Record<string, string>;
   circuit_breakers?: Record<string, string>;
   actor_cache_key?: string | null;
+  /**
+   * Databricks workspace origin (e.g. "https://dbc-x.cloud.databricks.com").
+   * Present on the authenticated health body only; absent on the anonymous
+   * liveness body and on older backends. Consumed by `useWorkspaceHost()` to
+   * build Catalog Explorer deep links for Genie source assets — every caller
+   * degrades to plain text when it is missing.
+   */
+  workspace_host?: string | null;
   /**
    * Deploy-promotion marker state: "enabled" after a governed
    * scripts/deploy.sh promotion, "disabled_baseline_deploy" when the
@@ -1777,6 +1787,23 @@ export const api = {
     postJson<GenieStartResult, { context: Record<string, never> }>(
       '/api/genie/start',
       { context: {} },
+      signal,
+    ),
+
+  /** Past Genie conversations for the current actor, newest first. The
+   *  History menu treats any failure (404 on an older backend, 5xx, network)
+   *  as "History unavailable" — it is an optional affordance, never a
+   *  blocking dependency of the chat. */
+  genieSessions: (signal?: AbortSignal) =>
+    getJson<{ sessions: GenieSessionSummary[] }>('/api/genie/sessions', signal).then(
+      (body) => body.sessions ?? [],
+    ),
+
+  /** Full transcript of one past conversation, in the same
+   *  `{question, response}` turn shape the local transcript store uses. */
+  genieSession: (conversationId: string, signal?: AbortSignal) =>
+    getJson<GenieSessionDetail>(
+      `/api/genie/sessions/${encodeURIComponent(conversationId)}`,
       signal,
     ),
 

--- a/frontend/src/lib/genieCellLinks.test.ts
+++ b/frontend/src/lib/genieCellLinks.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { borrower360Path, genieCellHref, isMaskedBorrowerId, stateLeadQueuePath } from './genieCellLinks';
+
+const BORROWER = 'B-7K2M9QX4TB3PZ';
+
+describe('isMaskedBorrowerId', () => {
+  it('accepts the canonical masked id shape', () => {
+    expect(isMaskedBorrowerId(BORROWER)).toBe(true);
+  });
+
+  it.each([
+    ['lowercase', 'b-7k2m9qx4tb3pz'],
+    ['too short', 'B-7K2M9QX4TB3'],
+    ['too long', 'B-7K2M9QX4TB3PZQ'],
+    ['no prefix', '7K2M9QX4TB3PZ'],
+    ['number', 12345],
+    ['null', null],
+  ])('rejects %s', (_label, value) => {
+    expect(isMaskedBorrowerId(value)).toBe(false);
+  });
+});
+
+describe('genieCellHref', () => {
+  it('links a borrower_id cell to the borrower 360 route', () => {
+    expect(genieCellHref('borrower_id', BORROWER)).toBe(`/borrower-360/${BORROWER}`);
+  });
+
+  it('links a state cell to the same state-filtered lead queue the map uses', () => {
+    expect(genieCellHref('state', 'IL')).toBe('/lead-queue?state=IL');
+    expect(genieCellHref('state', 'il')).toBe('/lead-queue?state=IL');
+    expect(genieCellHref('state_code', 'TX')).toBe('/lead-queue?state=TX');
+  });
+
+  it('leaves a city cell plain — no route supports a city filter', () => {
+    expect(genieCellHref('city', 'Chicago')).toBeNull();
+  });
+
+  it('leaves a borrower_id that does not match the masked shape plain', () => {
+    expect(genieCellHref('borrower_id', 'unknown')).toBeNull();
+    expect(genieCellHref('borrower_id', null)).toBeNull();
+  });
+
+  it('leaves a state-looking value in an unrelated column plain', () => {
+    expect(genieCellHref('segment_code', 'IL')).toBeNull();
+  });
+
+  it('leaves non-2-letter state values plain', () => {
+    expect(genieCellHref('state', 'Illinois')).toBeNull();
+  });
+
+  it('is case-insensitive on the column name', () => {
+    expect(genieCellHref('State', 'IL')).toBe('/lead-queue?state=IL');
+    expect(genieCellHref('BORROWER_ID', BORROWER)).toBe(`/borrower-360/${BORROWER}`);
+  });
+});
+
+describe('path builders', () => {
+  it('encodes the borrower id', () => {
+    expect(borrower360Path('B-ABC/DEF')).toBe('/borrower-360/B-ABC%2FDEF');
+  });
+
+  it('upper-cases the state before building the queue path', () => {
+    expect(stateLeadQueuePath(' ca ')).toBe('/lead-queue?state=CA');
+  });
+});

--- a/frontend/src/lib/genieCellLinks.ts
+++ b/frontend/src/lib/genieCellLinks.ts
@@ -1,0 +1,68 @@
+/**
+ * Genie table-cell linkage.
+ *
+ * A Genie answer table is currently a dead end: the reader sees a masked
+ * borrower id or a state code and has to retype it into the Lead Queue. These
+ * helpers decide when a cell value is a safe navigation target and build the
+ * SAME route the rest of the app already uses, so a Genie answer drills into
+ * exactly the surface the drill-down cards and geography map drill into.
+ *
+ * Deliberately conservative: only values that match the canonical masked
+ * borrower id shape (`B-[0-9A-Z]{13}`, per CLAUDE.md "Naming rules") and
+ * 2-letter state codes become links. Anything else stays plain text — a
+ * fabricated link into /borrower-360/<garbage> is worse than no link.
+ */
+
+import { buildLeadQueuePath } from '../components/mortgage/USChoroplethMap.utils';
+
+/** Canonical masked borrower id (CLAUDE.md naming rules). */
+export const MASKED_BORROWER_ID_RE = /^B-[0-9A-Z]{13}$/;
+
+/** 2-letter USPS state code, as emitted by the gold tables. */
+const STATE_CODE_RE = /^[A-Z]{2}$/;
+
+/** Columns whose values address a borrower record. */
+const BORROWER_ID_COLUMNS = new Set(['borrower_id']);
+
+/** Columns whose values address a state. */
+const STATE_COLUMNS = new Set(['state', 'state_code']);
+
+export function isMaskedBorrowerId(value: unknown): value is string {
+  return typeof value === 'string' && MASKED_BORROWER_ID_RE.test(value.trim());
+}
+
+export function isStateCode(value: unknown): value is string {
+  return typeof value === 'string' && STATE_CODE_RE.test(value.trim().toUpperCase());
+}
+
+/** Borrower 360 deep link — mirrors every other borrower link in the app. */
+export function borrower360Path(borrowerId: string): string {
+  return `/borrower-360/${encodeURIComponent(borrowerId.trim())}`;
+}
+
+/**
+ * State-filtered Lead Queue link. Reuses `buildLeadQueuePath`, the exact
+ * helper the geography drill-down map calls on a state click
+ * (`USChoroplethMap.tsx` → `navigate(leadQueuePath({ state }))`), so a Genie
+ * answer and the map land on an identically-filtered queue.
+ */
+export function stateLeadQueuePath(state: string): string {
+  return buildLeadQueuePath({ geo: { state: state.trim().toUpperCase() } });
+}
+
+/**
+ * Resolve a table cell to an in-app route, or null when it should render as
+ * plain text. `city` intentionally returns null: no route in `app.tsx`
+ * supports a city filter (`lead-queue.filters.ts` has no city param), and a
+ * link that silently drops the filter misleads the reader.
+ */
+export function genieCellHref(column: string, value: unknown): string | null {
+  const key = column.trim().toLowerCase();
+  if (BORROWER_ID_COLUMNS.has(key) && isMaskedBorrowerId(value)) {
+    return borrower360Path(value as string);
+  }
+  if (STATE_COLUMNS.has(key) && isStateCode(value)) {
+    return stateLeadQueuePath(value as string);
+  }
+  return null;
+}

--- a/frontend/src/lib/genieConversationStore.test.ts
+++ b/frontend/src/lib/genieConversationStore.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GenieAnswer } from '../types';
+import {
+  GENIE_CONVERSATION_TURNS_KEY,
+  MAX_STORED_TURNS,
+  clearGenieTurns,
+  getGenieTurns,
+  messagesToTurns,
+  persistGenieMessages,
+  setGenieTurns,
+  subscribeGenieTurns,
+  turnsToMessages,
+  type GenieChatMessage,
+  type GenieTurn,
+} from './genieConversationStore';
+
+function answer(text: string): GenieAnswer {
+  return { answer: text, source: 'genie', trusted_assets: ['mip.gold.borrower_360'] } as GenieAnswer;
+}
+
+function turn(question: string, text = `${question} answer`): GenieTurn {
+  return { question, response: answer(text) };
+}
+
+let values: Map<string, string>;
+
+beforeEach(() => {
+  values = new Map<string, string>();
+  const storage = {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    clear: () => values.clear(),
+  };
+  vi.stubGlobal('window', { sessionStorage: storage });
+  vi.stubGlobal('sessionStorage', storage);
+  // Reset the module-level cache between cases.
+  clearGenieTurns();
+  values.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('genie transcript store — persist / restore', () => {
+  it('persists a settled transcript to sessionStorage under the versioned key', () => {
+    const messages: GenieChatMessage[] = [
+      { who: 'user', text: 'How many borrowers are in the money?' },
+      { who: 'ai', payload: answer('12,480 borrowers.') },
+    ];
+    persistGenieMessages(messages, { inFlight: false });
+
+    const raw = values.get(GENIE_CONVERSATION_TURNS_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string)).toEqual([
+      { question: 'How many borrowers are in the money?', response: answer('12,480 borrowers.') },
+    ]);
+  });
+
+  it('restores the full conversation — including the latest answer — after a remount', async () => {
+    persistGenieMessages(
+      [
+        { who: 'user', text: 'first' },
+        { who: 'ai', payload: answer('first answer') },
+        { who: 'user', text: 'second' },
+        { who: 'ai', payload: answer('second answer') },
+      ],
+      { inFlight: false },
+    );
+
+    // A remount (panel closed then reopened) re-reads sessionStorage.
+    const restored = turnsToMessages(await hydrateFresh());
+    expect(restored.map((m) => (m.who === 'user' ? m.text : m.payload.answer))).toEqual([
+      'first',
+      'first answer',
+      'second',
+      'second answer',
+    ]);
+  });
+
+  it('never writes while a turn is in flight', () => {
+    persistGenieMessages([{ who: 'user', text: 'q1' }, { who: 'ai', payload: answer('a1') }], {
+      inFlight: false,
+    });
+    const settled = values.get(GENIE_CONVERSATION_TURNS_KEY);
+
+    // A pending question with no answer yet must not overwrite the settled state.
+    persistGenieMessages(
+      [
+        { who: 'user', text: 'q1' },
+        { who: 'ai', payload: answer('a1') },
+        { who: 'user', text: 'q2 (pending)' },
+      ],
+      { inFlight: true },
+    );
+
+    expect(values.get(GENIE_CONVERSATION_TURNS_KEY)).toBe(settled);
+  });
+
+  it('caps stored turns at MAX_STORED_TURNS, dropping the oldest', () => {
+    const many = Array.from({ length: MAX_STORED_TURNS + 5 }, (_, i) => turn(`q${i}`));
+    setGenieTurns(many);
+
+    const stored = JSON.parse(values.get(GENIE_CONVERSATION_TURNS_KEY) as string) as GenieTurn[];
+    expect(stored).toHaveLength(MAX_STORED_TURNS);
+    expect(stored[0].question).toBe('q5');
+    expect(stored[stored.length - 1].question).toBe(`q${MAX_STORED_TURNS + 4}`);
+  });
+
+  it('tolerates corrupt stored JSON by starting clean', async () => {
+    values.set(GENIE_CONVERSATION_TURNS_KEY, '{not json');
+    await expect(hydrateFresh()).resolves.toEqual([]);
+  });
+
+  it('drops entries that are not turn-shaped', async () => {
+    values.set(GENIE_CONVERSATION_TURNS_KEY, JSON.stringify([{ nope: true }, turn('good')]));
+    const hydrated = await hydrateFresh();
+    expect(hydrated).toHaveLength(1);
+    expect(hydrated[0].question).toBe('good');
+  });
+});
+
+describe('genie transcript store — new thread', () => {
+  it('clears both the in-memory cache and sessionStorage', () => {
+    setGenieTurns([turn('q1'), turn('q2')]);
+    expect(getGenieTurns()).toHaveLength(2);
+
+    clearGenieTurns();
+
+    expect(getGenieTurns()).toEqual([]);
+    expect(values.get(GENIE_CONVERSATION_TURNS_KEY)).toBeUndefined();
+  });
+
+  it('notifies subscribers on write and on clear', () => {
+    const seen: number[] = [];
+    const unsubscribe = subscribeGenieTurns(() => seen.push(getGenieTurns().length));
+
+    setGenieTurns([turn('q1')]);
+    clearGenieTurns();
+    unsubscribe();
+    setGenieTurns([turn('ignored')]);
+
+    expect(seen).toEqual([1, 0]);
+  });
+});
+
+describe('message <-> turn adapters', () => {
+  it('round-trips a normal alternating conversation', () => {
+    const messages: GenieChatMessage[] = [
+      { who: 'user', text: 'q1' },
+      { who: 'ai', payload: answer('a1') },
+      { who: 'user', text: 'q2' },
+      { who: 'ai', payload: answer('a2') },
+    ];
+    expect(turnsToMessages(messagesToTurns(messages))).toEqual(messages);
+  });
+
+  it('keeps an answer that has no originating question (governed action result)', () => {
+    const messages: GenieChatMessage[] = [{ who: 'ai', payload: answer('Saved 12 borrowers.') }];
+    const turns = messagesToTurns(messages);
+    expect(turns).toEqual([{ question: '', response: answer('Saved 12 borrowers.') }]);
+    expect(turnsToMessages(turns)).toEqual(messages);
+  });
+
+  it('attaches derived source assets when a resolver is supplied', () => {
+    const messages = turnsToMessages([turn('q1')], (payload) => payload.trusted_assets ?? []);
+    const ai = messages.find((m) => m.who === 'ai');
+    expect(ai && ai.who === 'ai' ? ai.sources : null).toEqual(['mip.gold.borrower_360']);
+  });
+});
+
+/**
+ * Hydrate from whatever is currently in sessionStorage using a FRESH module
+ * instance. The store's in-memory cache is module-level and only reads
+ * storage once (`cache === null`), so a genuine "reopen the panel / reload
+ * the tab" restore can only be exercised by re-importing the module.
+ */
+async function hydrateFresh(): Promise<GenieTurn[]> {
+  vi.resetModules();
+  const fresh = await import('./genieConversationStore');
+  return fresh.getGenieTurns();
+}

--- a/frontend/src/lib/genieConversationStore.ts
+++ b/frontend/src/lib/genieConversationStore.ts
@@ -1,0 +1,171 @@
+import type { GenieAnswer as GenieAnswerShape } from '../types';
+
+/**
+ * Genie conversation transcript store.
+ *
+ * The floating Genie panel is mounted conditionally (`{genieOpen ? <GenieChat/> : null}`
+ * in AppShell), so closing the panel — or any remount — used to destroy the
+ * entire visible conversation. This module keeps the turn list in a
+ * module-level cache mirrored into `sessionStorage`, so the transcript
+ * survives panel close/reopen and route navigation for the life of the tab.
+ *
+ * Scope decisions:
+ *   - `sessionStorage`, not `localStorage`: a transcript is tab-scoped
+ *     working state, not a durable artifact. Closing the tab ends it.
+ *     The Genie *conversation id* keeps living in localStorage
+ *     (`lib/genieConversation.ts`) — that is a Databricks-side handle, this
+ *     is the rendered transcript.
+ *   - Capped at MAX_STORED_TURNS so a long booth session cannot grow the
+ *     quota unbounded; the OLDEST turns are dropped first.
+ *   - Writes happen on turn completion only. An in-flight turn is never
+ *     persisted, so a reload mid-answer restores the last settled state
+ *     rather than a half-rendered bubble.
+ *   - The persisted shape is deliberately `{question, response}[]` — the
+ *     same shape `GET /api/genie/sessions/{id}` returns — so loading a past
+ *     session and restoring local state go through one code path.
+ */
+
+export const GENIE_CONVERSATION_TURNS_KEY = 'mip-genie-conversation-v1';
+
+/** Hard cap on persisted turns. Oldest-first eviction. */
+export const MAX_STORED_TURNS = 20;
+
+export interface GenieTurn {
+  /** The user question that produced `response`. Empty string for entries
+   *  with no originating question (governed action results, transport
+   *  errors) so the transcript still round-trips faithfully. */
+  question: string;
+  response: GenieAnswerShape;
+}
+
+/** Rendered message shape consumed by GenieChat. */
+export type GenieChatMessage =
+  | { who: 'user'; text: string }
+  | { who: 'ai'; payload: GenieAnswerShape; sources?: string[] };
+
+let cache: GenieTurn[] | null = null;
+const listeners = new Set<() => void>();
+
+const EMPTY: GenieTurn[] = [];
+
+function isTurn(value: unknown): value is GenieTurn {
+  if (!value || typeof value !== 'object') return false;
+  const turn = value as Partial<GenieTurn>;
+  return typeof turn.question === 'string' && Boolean(turn.response) && typeof turn.response === 'object';
+}
+
+function hydrate(): GenieTurn[] {
+  if (typeof window === 'undefined') return EMPTY;
+  try {
+    const raw = window.sessionStorage.getItem(GENIE_CONVERSATION_TURNS_KEY);
+    if (!raw) return EMPTY;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return EMPTY;
+    const turns = parsed.filter(isTurn);
+    return turns.length > 0 ? turns.slice(-MAX_STORED_TURNS) : EMPTY;
+  } catch {
+    // Unparseable or storage-denied: start clean rather than throwing into
+    // the render path.
+    return EMPTY;
+  }
+}
+
+function persist(turns: GenieTurn[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (turns.length === 0) {
+      window.sessionStorage.removeItem(GENIE_CONVERSATION_TURNS_KEY);
+      return;
+    }
+    window.sessionStorage.setItem(GENIE_CONVERSATION_TURNS_KEY, JSON.stringify(turns));
+  } catch {
+    // Quota exceeded / privacy mode. In-memory state still works for this
+    // mount; persistence is best-effort.
+  }
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+/** Current turns. Stable reference between writes (safe for
+ *  `useSyncExternalStore`). */
+export function getGenieTurns(): GenieTurn[] {
+  if (cache === null) cache = hydrate();
+  return cache;
+}
+
+/** Server-render snapshot — no sessionStorage available. */
+export function getGenieTurnsServerSnapshot(): GenieTurn[] {
+  return EMPTY;
+}
+
+export function subscribeGenieTurns(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Replace the whole transcript (restore-from-history, or a trimmed set). */
+export function setGenieTurns(turns: GenieTurn[]): GenieTurn[] {
+  const next = turns.slice(-MAX_STORED_TURNS);
+  cache = next.length > 0 ? next : EMPTY;
+  persist(cache);
+  emit();
+  return cache;
+}
+
+/** Drop the transcript (New thread, actor boundary reset, 403). */
+export function clearGenieTurns(): void {
+  cache = EMPTY;
+  persist(EMPTY);
+  emit();
+}
+
+/** Convert rendered messages into the persisted turn shape. An `ai` message
+ *  is paired with the `user` message immediately before it. */
+export function messagesToTurns(messages: readonly GenieChatMessage[]): GenieTurn[] {
+  const turns: GenieTurn[] = [];
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
+    if (message.who !== 'ai') continue;
+    const previous = messages[i - 1];
+    turns.push({
+      question: previous && previous.who === 'user' ? previous.text : '',
+      response: message.payload,
+    });
+  }
+  return turns;
+}
+
+/** Inverse of `messagesToTurns`. Also the adapter for a loaded history
+ *  session, whose `turns` arrive in exactly this shape. */
+export function turnsToMessages(
+  turns: readonly GenieTurn[],
+  sourcesFor?: (payload: GenieAnswerShape) => string[],
+): GenieChatMessage[] {
+  const messages: GenieChatMessage[] = [];
+  for (const turn of turns) {
+    if (!turn || !turn.response) continue;
+    if (turn.question) messages.push({ who: 'user', text: turn.question });
+    messages.push({
+      who: 'ai',
+      payload: turn.response,
+      sources: sourcesFor ? sourcesFor(turn.response) : undefined,
+    });
+  }
+  return messages;
+}
+
+/**
+ * Persist the settled transcript. No-ops while a turn is in flight so a
+ * half-complete exchange is never written.
+ */
+export function persistGenieMessages(
+  messages: readonly GenieChatMessage[],
+  { inFlight }: { inFlight: boolean },
+): void {
+  if (inFlight) return;
+  setGenieTurns(messagesToTurns(messages));
+}

--- a/frontend/src/lib/ucAssetLinks.test.ts
+++ b/frontend/src/lib/ucAssetLinks.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { SOURCE_LINE_RE, catalogExplorerUrl, normalizeWorkspaceHost, parseUcAsset } from './ucAssetLinks';
+
+const HOST = 'https://dbc-test.cloud.databricks.com';
+
+describe('parseUcAsset', () => {
+  it('splits a 3-part dotted UC name', () => {
+    expect(parseUcAsset('mip.gold.borrower_360')).toEqual({
+      catalog: 'mip',
+      schema: 'gold',
+      table: 'borrower_360',
+    });
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseUcAsset('  mip.gold.lead_population ')?.table).toBe('lead_population');
+  });
+
+  it.each([
+    ['two-part name', 'gold.borrower_360'],
+    ['four-part name', 'a.b.c.d'],
+    ['wildcard', 'mip.gold.*'],
+    ['prose', 'the gold table'],
+    ['empty', ''],
+    ['nullish', null],
+  ])('returns null for %s', (_label, value) => {
+    expect(parseUcAsset(value as string | null)).toBeNull();
+  });
+});
+
+describe('normalizeWorkspaceHost', () => {
+  it('accepts a bare workspace hostname and adds https', () => {
+    expect(normalizeWorkspaceHost('dbc-test.cloud.databricks.com')).toBe(HOST);
+  });
+
+  it('accepts a full https origin and strips a trailing slash', () => {
+    expect(normalizeWorkspaceHost(`${HOST}/`)).toBe(HOST);
+  });
+
+  it('accepts azure and gcp workspace suffixes', () => {
+    expect(normalizeWorkspaceHost('adb-123.4.azuredatabricks.net')).toBe(
+      'https://adb-123.4.azuredatabricks.net',
+    );
+    expect(normalizeWorkspaceHost('x.gcp.databricks.com')).toBe('https://x.gcp.databricks.com');
+  });
+
+  it.each([
+    ['http scheme', 'http://dbc-test.cloud.databricks.com'],
+    ['non-databricks host', 'https://evil.example.com'],
+    ['embedded credentials', 'https://user:pw@dbc-test.cloud.databricks.com'],
+    ['path segment', 'https://dbc-test.cloud.databricks.com/redirect'],
+    ['query string', 'https://dbc-test.cloud.databricks.com?next=x'],
+    ['whitespace', 'dbc test.cloud.databricks.com'],
+    ['empty', ''],
+    ['nullish', null],
+  ])('rejects %s', (_label, value) => {
+    expect(normalizeWorkspaceHost(value as string | null)).toBeNull();
+  });
+});
+
+describe('catalogExplorerUrl', () => {
+  it('builds the Catalog Explorer path from a dotted asset', () => {
+    expect(catalogExplorerUrl(HOST, 'mip.gold.borrower_360')).toBe(
+      `${HOST}/explore/data/mip/gold/borrower_360`,
+    );
+  });
+
+  it('returns null when the workspace host is unknown — callers degrade to plain text', () => {
+    expect(catalogExplorerUrl(null, 'mip.gold.borrower_360')).toBeNull();
+    expect(catalogExplorerUrl(undefined, 'mip.gold.borrower_360')).toBeNull();
+  });
+
+  it('returns null for a non-UC asset string', () => {
+    expect(catalogExplorerUrl(HOST, 'lakebase.approvals')).toBeNull();
+  });
+});
+
+describe('SOURCE_LINE_RE', () => {
+  it('captures the label and the asset from a trailing source disclosure', () => {
+    const re = new RegExp(SOURCE_LINE_RE.source, SOURCE_LINE_RE.flags);
+    const match = re.exec('12,480 borrowers. Source: mip.gold.borrower_360.');
+    expect(match?.[1]).toBe('Source: ');
+    expect(match?.[2]).toBe('mip.gold.borrower_360');
+  });
+
+  it('does not swallow the sentence-ending period into the asset', () => {
+    const re = new RegExp(SOURCE_LINE_RE.source, SOURCE_LINE_RE.flags);
+    const match = re.exec('Source: mip.gold.lead_population.');
+    expect(match?.[2]).toBe('mip.gold.lead_population');
+  });
+
+  it('ignores a Source line whose value is not a 3-part UC name', () => {
+    const re = new RegExp(SOURCE_LINE_RE.source, SOURCE_LINE_RE.flags);
+    expect(re.exec('Source: internal notes')).toBeNull();
+  });
+});

--- a/frontend/src/lib/ucAssetLinks.ts
+++ b/frontend/src/lib/ucAssetLinks.ts
@@ -1,0 +1,88 @@
+/**
+ * Unity Catalog asset → workspace Catalog Explorer deep links.
+ *
+ * The backend already emits `catalog_explorer_url` for lineage/data-estate
+ * nodes (see `backend/services/asset_metadata_utils.py::catalog_explorer_url`).
+ * Genie answers do NOT carry that field — they carry bare dotted names
+ * ("mip.gold.borrower_360") in the trailing "Source: …" line of the answer
+ * markdown and in `proof.source_assets`. This module turns those bare names
+ * into the same `{host}/explore/data/{catalog}/{schema}/{table}` URL the
+ * backend builds, using the workspace host published on the health payload.
+ *
+ * Host validation deliberately mirrors the backend's `workspace_origin()`
+ * guard (https only, no credentials/path/query/fragment, hostname must end in
+ * a known Databricks workspace suffix). A Genie answer is model-influenced
+ * text; an unvalidated host would let a bad value render an off-platform link
+ * that looks like a governed Catalog Explorer destination.
+ */
+
+/** Hostname suffixes accepted as a Databricks workspace origin. Mirrors
+ *  `_DATABRICKS_WORKSPACE_SUFFIXES` in backend/services/asset_metadata_utils.py. */
+const WORKSPACE_HOST_SUFFIXES = ['.cloud.databricks.com', '.gcp.databricks.com', '.azuredatabricks.net'];
+
+/** `catalog.schema.table` — UC identifiers are letters/digits/underscore. */
+const UC_ASSET_RE = /^[A-Za-z0-9_]+\.[A-Za-z0-9_]+\.[A-Za-z0-9_]+$/;
+
+/**
+ * Matches the trailing source disclosure Genie appends to an answer, e.g.
+ * "Source: mip.gold.borrower_360". Case-insensitive on the "Source" label;
+ * the asset itself must be a 3-part dotted UC name. A trailing period is
+ * left OUT of the captured asset so sentence punctuation never leaks into
+ * the URL.
+ */
+export const SOURCE_LINE_RE = /(Sources?:\s*)([A-Za-z0-9_]+\.[A-Za-z0-9_]+\.[A-Za-z0-9_]+)/gi;
+
+export interface UcAssetParts {
+  catalog: string;
+  schema: string;
+  table: string;
+}
+
+/** Split a dotted UC name. Returns null for anything that is not exactly
+ *  `catalog.schema.table` (wildcards, 2-part names, Lakebase refs, prose). */
+export function parseUcAsset(asset: string | null | undefined): UcAssetParts | null {
+  const raw = (asset ?? '').trim();
+  if (!UC_ASSET_RE.test(raw)) return null;
+  const [catalog, schema, table] = raw.split('.');
+  return { catalog, schema, table };
+}
+
+/**
+ * Normalize a workspace host into an https origin, or null when the value is
+ * missing/untrustworthy. Accepts a bare hostname ("dbc-x.cloud.databricks.com")
+ * or a full https origin; rejects http, credentials, paths, and any hostname
+ * outside the Databricks workspace suffix allowlist.
+ */
+export function normalizeWorkspaceHost(host: string | null | undefined): string | null {
+  const raw = (host ?? '').trim();
+  if (!raw || /\s/.test(raw)) return null;
+  const candidate = raw.includes('://') ? raw : `https://${raw}`;
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'https:') return null;
+  if (url.username || url.password) return null;
+  if (url.search || url.hash) return null;
+  if (url.pathname !== '' && url.pathname !== '/') return null;
+  const hostname = url.hostname.toLowerCase();
+  if (!WORKSPACE_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix))) return null;
+  return `https://${url.host}`;
+}
+
+/**
+ * Build the Catalog Explorer URL for a dotted UC asset name. Returns null
+ * when the host is unknown/invalid or the asset is not a 3-part name — every
+ * caller degrades to plain text on null.
+ */
+export function catalogExplorerUrl(
+  workspaceHost: string | null | undefined,
+  asset: string | null | undefined,
+): string | null {
+  const origin = normalizeWorkspaceHost(workspaceHost);
+  const parts = parseUcAsset(asset);
+  if (!origin || !parts) return null;
+  return `${origin}/explore/data/${encodeURIComponent(parts.catalog)}/${encodeURIComponent(parts.schema)}/${encodeURIComponent(parts.table)}`;
+}

--- a/frontend/src/routes/analytics.charts.tsx
+++ b/frontend/src/routes/analytics.charts.tsx
@@ -5,8 +5,11 @@
 import {
   useId,
   useMemo,
+  useRef,
+  useState,
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from 'react';
 import { Link, useNavigate } from 'react-router';
@@ -285,14 +288,23 @@ export function LineChart({
   y,
   xLabel,
   yLabel,
+  xUnit,
 }: {
   rows: Array<ScoreBucket | RateSpreadBucket>;
   x: (row: ScoreBucket | RateSpreadBucket) => number;
   y: (row: ScoreBucket | RateSpreadBucket) => number;
   xLabel: string;
   yLabel: string;
+  /** Unit appended to the x value in the hover readout, e.g. "bps" →
+   *  "125 bps". Omitted for unitless axes (opportunity score). */
+  xUnit?: string;
 }) {
   const clipId = useId();
+  // Nearest-point hover readout. Index into `plotted` (never the raw row
+  // array) so the crosshair always lands on a coordinate the chart actually
+  // drew. null = pointer is not over the plot.
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+  const hoverLayerRef = useRef<HTMLDivElement | null>(null);
   const chart = useMemo(() => {
     if (rows.length === 0) return null;
     const xs = rows.map(x);
@@ -301,23 +313,47 @@ export function LineChart({
     const maxX = Math.max(...xs);
     const maxY = Math.max(1, ...ys);
     const plotY = (value: number) => 92 - (Math.max(0, Math.min(1, value / maxY)) * 84);
-    const points = rows.map((row) => {
-      const px = maxX === minX ? 50 : ((x(row) - minX) / (maxX - minX)) * 100;
-      const py = plotY(y(row));
-      return `${px.toFixed(2)},${py.toFixed(2)}`;
-    }).join(' ');
+    const plotted = rows.map((row) => {
+      const xValue = x(row);
+      const yValue = y(row);
+      return {
+        xValue,
+        yValue,
+        px: maxX === minX ? 50 : ((xValue - minX) / (maxX - minX)) * 100,
+        py: plotY(yValue),
+      };
+    });
     return {
       minX,
       maxX,
       maxY,
-      points,
+      plotted,
+      points: plotted.map((p) => `${p.px.toFixed(2)},${p.py.toFixed(2)}`).join(' '),
       xTicks: makeTicks(minX, maxX),
       yTicks: makeTicks(0, maxY),
       plotY,
     };
   }, [rows, x, y]);
 
+  // Pointer -> nearest plotted point. Measured off the live bounding rect so
+  // the mapping stays correct at any container width (the SVG is
+  // `preserveAspectRatio="none"`, so the 0-100 viewBox maps linearly onto
+  // whatever width the responsive layout hands us).
+  const onHoverMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const plotted = chart?.plotted;
+    if (!plotted || plotted.length === 0) return;
+    const rect = (hoverLayerRef.current ?? event.currentTarget).getBoundingClientRect();
+    if (rect.width === 0) return;
+    const ratio = ((event.clientX - rect.left) / rect.width) * 100;
+    let nearest = 0;
+    for (let i = 1; i < plotted.length; i += 1) {
+      if (Math.abs(plotted[i].px - ratio) < Math.abs(plotted[nearest].px - ratio)) nearest = i;
+    }
+    setHoverIndex(nearest);
+  };
+
   if (!chart) return <div className="analytics-empty">No distribution returned.</div>;
+  const hovered = hoverIndex === null ? null : chart.plotted[hoverIndex] ?? null;
   return (
     <div className="analytics-chart" role="img" aria-label={`${yLabel} by ${xLabel}`}>
       <div className="analytics-chart__plot">
@@ -352,6 +388,41 @@ export function LineChart({
             ))}
             <polyline points={chart.points} clipPath={`url(#${clipId})`} vectorEffect="non-scaling-stroke" />
           </svg>
+          {/* Hover readout. Entirely `aria-hidden` + non-focusable: the
+              chart already exposes its meaning through the parent
+              `role="img"` + aria-label and the tick text, so this layer adds
+              a pointer affordance without adding a keyboard/AT trap. */}
+          <div
+            ref={hoverLayerRef}
+            className="analytics-chart__hover"
+            aria-hidden="true"
+            onPointerMove={onHoverMove}
+            onPointerLeave={() => setHoverIndex(null)}
+          >
+            {hovered && (
+              <>
+                <span
+                  className="analytics-chart__crosshair"
+                  style={{ '--hover-x': `${hovered.px}%` } as CSSProperties}
+                />
+                <span
+                  className="analytics-chart__hover-dot"
+                  style={{ '--hover-x': `${hovered.px}%`, '--hover-y': `${hovered.py}%` } as CSSProperties}
+                />
+                <span
+                  className={`analytics-chart__tip${hovered.px > 60 ? ' analytics-chart__tip--flip' : ''}`}
+                  style={{ '--hover-x': `${hovered.px}%`, '--hover-y': `${hovered.py}%` } as CSSProperties}
+                >
+                  <span className="analytics-chart__tip-x">
+                    {formatAxisTick(hovered.xValue)}{xUnit ? ` ${xUnit}` : ''}
+                  </span>
+                  <span className="analytics-chart__tip-y">
+                    {hovered.yValue.toLocaleString()} {yLabel.toLowerCase()}
+                  </span>
+                </span>
+              </>
+            )}
+          </div>
           <div className="analytics-chart__x-ticks" aria-hidden="true">
             {chart.xTicks.map((tick) => (
               <span

--- a/frontend/src/routes/analytics.line-hover.test.tsx
+++ b/frontend/src/routes/analytics.line-hover.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Pointer hover readout on the distribution LineChart (Rate Spread /
+ * Opportunity Score). Covers nearest-point selection, the formatted x/y
+ * readout, teardown on pointer leave, and the a11y contract (the hover layer
+ * must stay invisible to assistive tech).
+ */
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { RateSpreadBucket } from '../types';
+import { LineChart } from './analytics.charts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ROWS = [
+  { spread_bucket_bps: 0, borrower_count: 1200 },
+  { spread_bucket_bps: 50, borrower_count: 4300 },
+  { spread_bucket_bps: 100, borrower_count: 12480 },
+  { spread_bucket_bps: 150, borrower_count: 900 },
+] as unknown as RateSpreadBucket[];
+
+describe('LineChart hover readout', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        <LineChart
+          rows={ROWS}
+          x={(row) => (row as RateSpreadBucket).spread_bucket_bps}
+          y={(row) => row.borrower_count}
+          xLabel="Spread bps"
+          yLabel="Borrowers"
+          xUnit="bps"
+        />,
+      );
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const layer = () => container.querySelector('.analytics-chart__hover') as HTMLElement;
+
+  /** Drive a pointer move at `ratio` (0..1) across a stubbed 400px-wide layer. */
+  const hoverAt = (ratio: number) => {
+    const el = layer();
+    el.getBoundingClientRect = () =>
+      ({ left: 0, width: 400, top: 0, height: 200, right: 400, bottom: 200, x: 0, y: 0 }) as DOMRect;
+    act(() => {
+      const event = new Event('pointermove', { bubbles: true });
+      Object.defineProperty(event, 'clientX', { value: ratio * 400 });
+      el.dispatchEvent(event);
+    });
+  };
+
+  it('keeps the hover layer out of the accessibility tree', () => {
+    expect(layer().getAttribute('aria-hidden')).toBe('true');
+    expect(layer().querySelector('button, a, [tabindex]')).toBeNull();
+    // The chart's own meaning still comes from the parent role="img".
+    expect(container.querySelector('.analytics-chart')?.getAttribute('role')).toBe('img');
+  });
+
+  it('renders no crosshair until the pointer enters the plot', () => {
+    expect(container.querySelector('.analytics-chart__tip')).toBeNull();
+    expect(container.querySelector('.analytics-chart__hover-dot')).toBeNull();
+  });
+
+  it('snaps to the nearest point and formats both axes', () => {
+    hoverAt(0.68); // closest to the 100 bps bucket
+    const tip = container.querySelector('.analytics-chart__tip');
+    expect(tip?.querySelector('.analytics-chart__tip-x')?.textContent).toBe('100 bps');
+    expect(tip?.querySelector('.analytics-chart__tip-y')?.textContent).toBe('12,480 borrowers');
+    expect(container.querySelector('.analytics-chart__hover-dot')).not.toBeNull();
+    expect(container.querySelector('.analytics-chart__crosshair')).not.toBeNull();
+  });
+
+  it('formats the borrower count with thousands separators', () => {
+    hoverAt(0.34); // 50 bps bucket
+    expect(container.querySelector('.analytics-chart__tip-y')?.textContent).toBe('4,300 borrowers');
+  });
+
+  it('snaps to the first and last points at the plot edges', () => {
+    hoverAt(0);
+    expect(container.querySelector('.analytics-chart__tip-x')?.textContent).toBe('0 bps');
+    hoverAt(1);
+    expect(container.querySelector('.analytics-chart__tip-x')?.textContent).toBe('150 bps');
+  });
+
+  it('flips the tip away from the right edge so it cannot overflow the surface', () => {
+    hoverAt(0.05);
+    expect(container.querySelector('.analytics-chart__tip')?.className).not.toContain('--flip');
+    hoverAt(1);
+    expect(container.querySelector('.analytics-chart__tip')?.className).toContain('--flip');
+  });
+
+  it('clears the readout when the pointer leaves', () => {
+    hoverAt(0.5);
+    expect(container.querySelector('.analytics-chart__tip')).not.toBeNull();
+    act(() => {
+      // React synthesizes onPointerLeave from a bubbling `pointerout` whose
+      // relatedTarget is outside the element — `pointerleave` itself does not
+      // bubble, so dispatching it directly would never reach React.
+      const event = new Event('pointerout', { bubbles: true });
+      Object.defineProperty(event, 'relatedTarget', { value: null });
+      layer().dispatchEvent(event);
+    });
+    expect(container.querySelector('.analytics-chart__tip')).toBeNull();
+  });
+});

--- a/frontend/src/routes/analytics.sections.tsx
+++ b/frontend/src/routes/analytics.sections.tsx
@@ -180,21 +180,26 @@ export function EconomicsView({
               y={(row) => row.borrower_count}
               xLabel="Spread bps"
               yLabel="Borrowers"
+              xUnit="bps"
             />
           </div>
         </section>
         <section className="surface">
           <div className="surface__hdr">
             <h2 className="h-3">Top Borrowers</h2>
-            {/* Re-audit #3 P3 (2026-06-12): rows are borrower records (one
-                per property lien) but the display label is the masked Owner
-                Link identity — without this note, the owner-styled labels
-                read as a mismatch with the B- ids used everywhere else, and
-                a multi-property owner appearing twice looks like a dupe. */}
+            {/* Consistency contract (2026-08-06): this panel now ranks with
+                the exact governed predicate and ordering the Lead Queue and
+                Ask Genie use — one top-10 everywhere. Labels remain the
+                masked owner identity plus the borrower id's last 4; an owner
+                holding multiple eligible properties can still appear more
+                than once because each property loan is its own borrower
+                record. */}
             <p className="analytics-panel-note">
-              One row per borrower record (property lien), labeled by its masked
-              Owner Link identity plus the borrower id&apos;s last 4. An owner
-              holding multiple properties can appear more than once.
+              The same governed ranking Ask Genie and the Lead Queue use:
+              marketing-eligible, opt-in borrowers ordered by opportunity
+              score, then rate-spread economics. Labels show the masked owner
+              identity plus the borrower id&apos;s last 4; an owner with
+              multiple eligible properties can appear more than once.
             </p>
           </div>
           <div className="surface__body">

--- a/frontend/src/types/genie.ts
+++ b/frontend/src/types/genie.ts
@@ -98,6 +98,23 @@ export interface GenieStartResult {
   sample_questions?: string[];
 }
 
+/** One row of `GET /api/genie/sessions` — a past conversation the actor can
+ *  reopen from the Genie panel's History menu. */
+export interface GenieSessionSummary {
+  conversation_id: string;
+  title: string;
+  last_activity_at: string;
+  turn_count: number;
+}
+
+/** `GET /api/genie/sessions/{conversation_id}`. `response` is the same
+ *  GenieMessageResponse payload the live chat already renders, so a restored
+ *  session goes through the identical <GenieAnswer> path. */
+export interface GenieSessionDetail {
+  conversation_id?: string | null;
+  turns: Array<{ question: string; response: GenieAnswer }>;
+}
+
 export interface GenieActionSuggestion {
   id: string;
   label: string;

--- a/lakebase/schema.sql
+++ b/lakebase/schema.sql
@@ -2258,12 +2258,28 @@ VALUES (
 ON CONFLICT (version) DO NOTHING;
 
 -- Genie sessions ------------------------------------------------------
--- Durable state for Databricks Genie conversations. These tables store
--- conversation/message identifiers and proof metadata only; they do NOT
--- store raw user prompts or answer text, because those fields can contain
--- free-form PII-like content. The app can recover the latest conversation
--- after reload while the append-only action_audit ledger remains the
--- governed proof of each read/action.
+-- Durable state for Databricks Genie conversations, so the app can recover
+-- the latest conversation after reload and replay conversation history,
+-- while the append-only action_audit ledger remains the governed proof of
+-- each read/action.
+--
+-- Text posture (revised 2026-08-06, migration
+-- 2026_08_06_genie_history_replay): these tables originally stored
+-- identifiers and proof metadata only, on the grounds that prompts and
+-- answers can carry free-form PII-like content. Conversation history replay
+-- requires the turn text, so `genie_messages.question_text` and
+-- `genie_messages.response_json` now persist it under these invariants,
+-- enforced by the write path in backend/api/genie.py and
+-- backend/services/genie_history.py:
+--   * refused / policy_blocked / degraded / data_gap / out_of_footprint
+--     turns are never recorded, so a guard-tripping prompt is never stored;
+--   * a stored question already cleared the PII, identity, protected-class,
+--     scope and injection prompt guards;
+--   * a stored answer already cleared genie_response_has_unsafe_visible_text
+--     and the row-level PII key denylist, which is why replay does not
+--     re-scan it;
+--   * signed action confirmation tokens are stripped before persistence, so
+--     replaying a transcript never re-authorizes a governed write action.
 CREATE TABLE IF NOT EXISTS mip_app.genie_sessions (
     actor_email        TEXT NOT NULL,
     conversation_id    TEXT NOT NULL,
@@ -3484,5 +3500,44 @@ INSERT INTO mip_app.schema_migrations (version, description)
 VALUES (
     '2026_07_14_hmac_outcome_source_reference',
     'Enforce HMAC-derived auto-<32 lowercase hex> lead outcome source references on new and updated rows while preserving legacy history'
+)
+ON CONFLICT (version) DO NOTHING;
+
+-- Ask Genie conversation history replay --------------------------------
+-- `question_text` and `response_json` let the chat reopen a previous
+-- conversation and re-render the exact governed answer. See the text-posture
+-- note above mip_app.genie_sessions for the governance invariants that make
+-- storing this text safe; the write path enforces them.
+ALTER TABLE mip_app.genie_messages
+    ADD COLUMN IF NOT EXISTS question_text TEXT,
+    ADD COLUMN IF NOT EXISTS response_json JSONB;
+
+ALTER TABLE mip_app.genie_messages
+    DROP CONSTRAINT IF EXISTS genie_messages_question_text_len_chk;
+ALTER TABLE mip_app.genie_messages
+    ADD CONSTRAINT genie_messages_question_text_len_chk
+    CHECK (question_text IS NULL OR length(question_text) <= 4000);
+
+ALTER TABLE mip_app.genie_messages
+    DROP CONSTRAINT IF EXISTS genie_messages_response_json_size_chk;
+ALTER TABLE mip_app.genie_messages
+    ADD CONSTRAINT genie_messages_response_json_size_chk
+    CHECK (
+        response_json IS NULL
+        OR pg_column_size(response_json) <= 1048576
+    );
+
+CREATE INDEX IF NOT EXISTS idx_genie_messages_conversation_created
+    ON mip_app.genie_messages (actor_email, conversation_id, created_at);
+
+COMMENT ON COLUMN mip_app.genie_messages.question_text IS
+    'Guard-battery-cleared user question for history replay; refused prompts are never recorded.';
+COMMENT ON COLUMN mip_app.genie_messages.response_json IS
+    'Governed GenieMessageResponse for history replay: output-policy scanned, PII-redacted, action tokens stripped.';
+
+INSERT INTO mip_app.schema_migrations (version, description)
+VALUES (
+    '2026_08_06_genie_history_replay',
+    'Persist guarded question text and the governed Genie response payload per turn so the chat can replay owned conversation history'
 )
 ON CONFLICT (version) DO NOTHING;

--- a/tests/fixtures/openapi_baseline.json
+++ b/tests/fixtures/openapi_baseline.json
@@ -6218,6 +6218,92 @@
         "title": "GenieReasoningStep",
         "type": "object"
       },
+      "GenieSessionDetailResponse": {
+        "properties": {
+          "conversation_id": {
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "turns": {
+            "items": {
+              "$ref": "#/components/schemas/GenieSessionTurn"
+            },
+            "title": "Turns",
+            "type": "array"
+          }
+        },
+        "required": [
+          "conversation_id"
+        ],
+        "title": "GenieSessionDetailResponse",
+        "type": "object"
+      },
+      "GenieSessionListResponse": {
+        "properties": {
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/GenieSessionSummary"
+            },
+            "title": "Sessions",
+            "type": "array"
+          }
+        },
+        "title": "GenieSessionListResponse",
+        "type": "object"
+      },
+      "GenieSessionSummary": {
+        "description": "One row of the actor's Ask Genie history list.",
+        "properties": {
+          "conversation_id": {
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "last_activity_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Activity At"
+          },
+          "title": {
+            "default": "",
+            "title": "Title",
+            "type": "string"
+          },
+          "turn_count": {
+            "default": 0,
+            "title": "Turn Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "conversation_id"
+        ],
+        "title": "GenieSessionSummary",
+        "type": "object"
+      },
+      "GenieSessionTurn": {
+        "description": "One replayable question/answer pair from a stored conversation.\n\n``response`` is the exact governed ``GenieMessageResponse`` the chat\nalready renders. It was scanned by the output policy and PII-redacted\nbefore it was ever persisted.",
+        "properties": {
+          "question": {
+            "title": "Question",
+            "type": "string"
+          },
+          "response": {
+            "$ref": "#/components/schemas/GenieMessageResponse"
+          }
+        },
+        "required": [
+          "question",
+          "response"
+        ],
+        "title": "GenieSessionTurn",
+        "type": "object"
+      },
       "GenieStartResponse": {
         "properties": {
           "conversation_id": {
@@ -16661,6 +16747,73 @@
         ]
       }
     },
+    "/api/genie/sessions": {
+      "get": {
+        "deprecated": true,
+        "description": "The requesting actor's recent Ask Genie conversations, newest first.\n\nAUDIT EXEMPT: read-only listing of the caller's own conversation\nmetadata. It mutates nothing, and the underlying turns each carry their\nown ``genie.run_query`` audit row from when they were answered.",
+        "operationId": "get_api_genie_sessions_genie_sessions",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenieSessionListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Genie Sessions",
+        "tags": [
+          "genie"
+        ]
+      }
+    },
+    "/api/genie/sessions/{conversation_id}": {
+      "get": {
+        "deprecated": true,
+        "description": "Replay one owned conversation as governed question/answer turns.\n\nStrictly actor-scoped: a conversation owned by anyone else is a 404, so\nhistory cannot be probed for other actors' activity. Answers are re-served\nexactly as they were governed at answer time (output policy + PII\nredaction already applied before persistence), minus the signed action\ntokens, which are never replayed.\n\nAUDIT EXEMPT: read-only replay of the caller's own recorded turns.",
+        "operationId": "get_api_genie_sessions_conversation_id_genie_session_detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenieSessionDetailResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Genie Session Detail",
+        "tags": [
+          "genie"
+        ]
+      }
+    },
     "/api/genie/start": {
       "post": {
         "deprecated": true,
@@ -23999,6 +24152,71 @@
           }
         },
         "summary": "Genie Message Submit",
+        "tags": [
+          "genie"
+        ]
+      }
+    },
+    "/api/v1/genie/sessions": {
+      "get": {
+        "description": "The requesting actor's recent Ask Genie conversations, newest first.\n\nAUDIT EXEMPT: read-only listing of the caller's own conversation\nmetadata. It mutates nothing, and the underlying turns each carry their\nown ``genie.run_query`` audit row from when they were answered.",
+        "operationId": "get_api_v1_genie_sessions_genie_sessions",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenieSessionListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Genie Sessions",
+        "tags": [
+          "genie"
+        ]
+      }
+    },
+    "/api/v1/genie/sessions/{conversation_id}": {
+      "get": {
+        "description": "Replay one owned conversation as governed question/answer turns.\n\nStrictly actor-scoped: a conversation owned by anyone else is a 404, so\nhistory cannot be probed for other actors' activity. Answers are re-served\nexactly as they were governed at answer time (output policy + PII\nredaction already applied before persistence), minus the signed action\ntokens, which are never replayed.\n\nAUDIT EXEMPT: read-only replay of the caller's own recorded turns.",
+        "operationId": "get_api_v1_genie_sessions_conversation_id_genie_session_detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenieSessionDetailResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Genie Session Detail",
         "tags": [
           "genie"
         ]

--- a/tests/unit/test_analytics_api.py
+++ b/tests/unit/test_analytics_api.py
@@ -182,7 +182,7 @@ class _AnalyticsSqlClient:
                 "score_band": "high",
                 "in_the_money": True,
             }]
-        if "ROW_NUMBER() OVER (ORDER BY b.opportunity_score DESC, b.clip)" in statement:
+        if "b.rate_spread_bps DESC NULLS LAST, b.borrower_id ASC" in statement and "rank_overall" in statement:
             return [{"borrower_id": "B-48291", "display_name": "Owner anon", "state": "IL", "city": "Chicago", "opportunity_score": 91, "rate_spread_bps": 88, "equity_pct": 42, "recommended_offer": "Refi", "rank_overall": 1}]
         if "segment_dim AS" in statement:
             return [{"segment_code": "itm", "name": "Prime Refi Candidates", "borrower_count": 10, "mean_opportunity_score": 81, "delta_vs_prior_label": "+1%", "description": "test", "approval_rate": 1.2, "outreach_rate": 0.5, "mean_rate_spread_bps": 90, "mean_equity_pct": 40, "in_the_money_borrowers": 8}]
@@ -252,7 +252,7 @@ def test_analytics_repository_uses_governed_gold_and_semantic_sql() -> None:
     assert "AVG(CASE WHEN in_the_money THEN rate_spread_bps END)" in top_zip_sql
     state_sql = next(sql for sql in client.statements if "COUNT(DISTINCT clip)" in sql)
     assert "ORDER BY in_the_money_borrowers DESC, mean_opportunity_score DESC" in state_sql
-    top_borrower_sql = next(sql for sql in client.statements if "ROW_NUMBER() OVER (ORDER BY b.opportunity_score DESC, b.clip)" in sql)
+    top_borrower_sql = next(sql for sql in client.statements if "b.rate_spread_bps DESC NULLS LAST, b.borrower_id ASC" in sql and "rank_overall" in sql)
     assert "FROM mip.gold.borrower_360" in top_borrower_sql
     assert "lead_population" not in top_borrower_sql
 

--- a/tests/unit/test_architecture_boundaries.py
+++ b/tests/unit/test_architecture_boundaries.py
@@ -62,6 +62,11 @@ ROUTE_TEST_MANIFEST: dict[tuple[str, str], str] = {
     ("POST", "/api/genie/message/progress"): "tests/unit/test_genie_async_flow.py",
     ("POST", "/api/genie/message/complete"): "tests/unit/test_genie_async_flow.py",
     ("POST", "/api/genie/start"): "tests/unit/test_api_routes.py",
+    ("GET", "/api/genie/sessions"): "tests/unit/test_genie_history_api.py",
+    (
+        "GET",
+        "/api/genie/sessions/{conversation_id}",
+    ): "tests/unit/test_genie_history_api.py",
     ("GET", "/api/geo/assignment-overlay"): "tests/unit/test_geo_assignment_overlay.py",
     ("GET", "/api/geo/county-rollups"): "tests/unit/test_geo_state_rollups.py",
     ("GET", "/api/geo/state-rollups"): "tests/unit/test_geo_state_rollups.py",

--- a/tests/unit/test_genie_fallback.py
+++ b/tests/unit/test_genie_fallback.py
@@ -107,7 +107,14 @@ def test_floating_genie_has_no_ai_shaped_seed_answer() -> None:
     text = (REPO / "frontend" / "src" / "components" / "mortgage" / "GenieChat.tsx").read_text(
         encoding="utf-8"
     )
-    assert "useState<ChatMsg[]>([])" in text
+    # The chat may lazily RESTORE the actor's own persisted turns (history
+    # feature, 2026-08-06) — that is replay of governed answers, not a
+    # fabricated seed. The guard's intent stands: no literal AI-shaped
+    # answer payload may be authored into the component itself.
+    assert (
+        "useState<ChatMsg[]>([])" in text
+        or "useState<ChatMsg[]>(() =>\n    turnsToMessages(getGenieTurns()" in text
+    )
     pre_ask = text.split("const ask = async", maxsplit=1)[0]
     assert "payload: {\n        answer:" not in pre_ask
     assert "Answers run against Unity Catalog metric views" not in text

--- a/tests/unit/test_genie_history_api.py
+++ b/tests/unit/test_genie_history_api.py
@@ -1,0 +1,336 @@
+"""Ask Genie conversation history: persistence, listing, and replay.
+
+Covers ``GET /api/genie/sessions`` and
+``GET /api/genie/sessions/{conversation_id}`` plus the write-path extension
+in ``_record_genie_session`` that makes replay possible. Router tests follow
+the stubbed-Lakebase / snapshot-and-restore override pattern in
+``tests/unit/test_genie_actions_api.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from backend.api.genie import _record_genie_session
+from backend.main import app
+from backend.services.genie_answers import (
+    GenieActionSuggestion,
+    GenieMessageResponse,
+    GenieProof,
+    GenieReasoningStep,
+)
+from backend.services.genie_history import (
+    GENIE_HISTORY_PAYLOAD_MAX_BYTES,
+    GENIE_HISTORY_SESSION_LIMIT,
+    GENIE_HISTORY_TITLE_MAX,
+    GENIE_HISTORY_TRIMMED_ROWS,
+    history_payload_json,
+)
+from backend.services.lakebase import LakebaseError, get_lakebase_client
+
+client = TestClient(app)
+ACTOR_HEADERS = {"X-Forwarded-Email": "lo@example.com"}
+
+
+class _Lakebase:
+    """Minimal Lakebase stand-in that records writes and serves fixed reads."""
+
+    def __init__(
+        self,
+        *,
+        session_rows: list[dict[str, Any]] | None = None,
+        turn_rows: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.executes: list[tuple[str, dict[str, Any]]] = []
+        self.fetchall_calls: list[tuple[str, dict[str, Any]]] = []
+        self._session_rows = session_rows or []
+        self._turn_rows = turn_rows or []
+
+    def execute(self, sql: str, params: dict[str, Any]) -> None:
+        self.executes.append((sql, params))
+
+    def fetchall(
+        self,
+        sql: str,
+        params: dict[str, Any] | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        self.fetchall_calls.append((sql, dict(params or {})))
+        rows = self._turn_rows if "response_json" in sql else self._session_rows
+        return rows[:limit]
+
+
+class _BrokenLakebase(_Lakebase):
+    def fetchall(
+        self,
+        sql: str,
+        params: dict[str, Any] | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        raise LakebaseError("lakebase unavailable")
+
+
+def _with_lakebase(lakebase: object, call):  # type: ignore[no-untyped-def]
+    prior = app.dependency_overrides.get(get_lakebase_client)
+    app.dependency_overrides[get_lakebase_client] = lambda: lakebase
+    try:
+        return call()
+    finally:
+        if prior is None:
+            app.dependency_overrides.pop(get_lakebase_client, None)
+        else:
+            app.dependency_overrides[get_lakebase_client] = prior
+
+
+def _response(
+    *,
+    conversation_id: str = "conv-1",
+    message_id: str = "msg-1",
+    question: str = "How many borrowers are in the money?",
+    table_rows: list[dict[str, Any]] | None = None,
+    actions: list[GenieActionSuggestion] | None = None,
+) -> GenieMessageResponse:
+    return GenieMessageResponse(
+        conversation_id=conversation_id,
+        message_id=message_id,
+        question=question,
+        question_hash="hash-1",
+        answer="117,404 borrowers.\n\nSource: mip.gold.borrower_360",
+        source="genie",
+        genie_status="COMPLETED",
+        trusted_assets=["mip.gold.borrower_360"],
+        row_count=len(table_rows or []),
+        table_rows=table_rows if table_rows is not None else [{"borrowers": 117404}],
+        actions=actions or [],
+        reasoning_trace=[
+            GenieReasoningStep(kind="guardrails", content="Prompt cleared the guardrails."),
+        ],
+        proof=GenieProof(source_assets=["mip.gold.borrower_360"], row_count=1, trusted=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write path
+# ---------------------------------------------------------------------------
+
+
+def test_recorded_turn_persists_question_and_response_payload() -> None:
+    lakebase = _Lakebase()
+    response = _response()
+
+    _record_genie_session(lakebase, actor="analyst@example.com", response=response)  # type: ignore[arg-type]
+
+    assert len(lakebase.executes) == 2
+    _, params = lakebase.executes[1]
+    assert params["question_text"] == "How many borrowers are in the money?"
+    stored = json.loads(params["response_json"])
+    assert stored["conversation_id"] == "conv-1"
+    assert stored["answer"] == response.answer
+    assert stored["table_rows"] == [{"borrowers": 117404}]
+
+
+def test_persisted_payload_never_carries_signed_action_tokens() -> None:
+    response = _response(
+        actions=[
+            GenieActionSuggestion(
+                id="open-cohort",
+                label="Open cohort",
+                action_type="open_cohort",
+                description="Open the matching borrowers in Lead Queue.",
+                confirmation_token="signed.token.value",
+                request_id="req-1",
+            )
+        ]
+    )
+
+    stored = json.loads(history_payload_json(response) or "{}")
+
+    assert stored["actions"] == []
+    assert "signed.token.value" not in json.dumps(stored)
+
+
+def test_oversized_payload_is_trimmed_and_discloses_the_trim() -> None:
+    wide_row = {f"col_{index}": "x" * 200 for index in range(20)}
+    response = _response(table_rows=[dict(wide_row) for _ in range(400)])
+
+    encoded = history_payload_json(response)
+
+    assert encoded is not None
+    assert len(encoded.encode("utf-8")) <= GENIE_HISTORY_PAYLOAD_MAX_BYTES
+    stored = json.loads(encoded)
+    assert len(stored["table_rows"]) <= GENIE_HISTORY_TRIMMED_ROWS
+    assert any("trimmed" in gap or "not\nshown" in gap for gap in stored["proof"]["known_data_gaps"])
+
+
+def test_refused_turn_is_never_persisted() -> None:
+    lakebase = _Lakebase()
+    refused = _response().model_copy(update={"source": "refused"})
+
+    _record_genie_session(lakebase, actor="analyst@example.com", response=refused)  # type: ignore[arg-type]
+
+    assert lakebase.executes == []
+
+
+# ---------------------------------------------------------------------------
+# GET /api/genie/sessions
+# ---------------------------------------------------------------------------
+
+
+def test_sessions_list_returns_actor_scoped_titles_newest_first() -> None:
+    long_question = "Which borrowers " + ("should we contact " * 10)
+    lakebase = _Lakebase(
+        session_rows=[
+            {
+                "conversation_id": "conv-2",
+                "last_activity_at": "2026-08-06T12:00:00+00:00",
+                "turn_count": 3,
+                "first_question": long_question,
+            },
+            {
+                "conversation_id": "conv-1",
+                "last_activity_at": "2026-08-05T09:30:00+00:00",
+                "turn_count": 1,
+                "first_question": "How many borrowers are in the money?",
+            },
+        ]
+    )
+
+    res = _with_lakebase(
+        lakebase,
+        lambda: client.get("/api/genie/sessions", headers=ACTOR_HEADERS),
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert [session["conversation_id"] for session in body["sessions"]] == ["conv-2", "conv-1"]
+    first = body["sessions"][0]
+    assert first["turn_count"] == 3
+    assert first["last_activity_at"] == "2026-08-06T12:00:00+00:00"
+    assert first["title"] == long_question[:GENIE_HISTORY_TITLE_MAX]
+    assert len(first["title"]) == GENIE_HISTORY_TITLE_MAX
+    _, params = lakebase.fetchall_calls[0]
+    assert params["actor_email"] == "lo@example.com"
+    assert params["limit"] == GENIE_HISTORY_SESSION_LIMIT
+
+
+def test_sessions_list_is_empty_when_the_actor_has_no_history() -> None:
+    res = _with_lakebase(
+        _Lakebase(),
+        lambda: client.get("/api/genie/sessions", headers=ACTOR_HEADERS),
+    )
+
+    assert res.status_code == 200
+    assert res.json() == {"sessions": []}
+
+
+def test_sessions_list_returns_503_when_lakebase_is_down() -> None:
+    res = _with_lakebase(
+        _BrokenLakebase(),
+        lambda: client.get("/api/genie/sessions", headers=ACTOR_HEADERS),
+    )
+
+    assert res.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# GET /api/genie/sessions/{conversation_id}
+# ---------------------------------------------------------------------------
+
+
+def _turn_row(question: str, response: GenieMessageResponse) -> dict[str, Any]:
+    return {
+        "question_text": question,
+        "response_json": json.loads(history_payload_json(response) or "{}"),
+    }
+
+
+def test_session_detail_replays_turns_in_ask_order() -> None:
+    first = _response(message_id="msg-1", question="How many borrowers are in the money?")
+    second = _response(message_id="msg-2", question="Break that down by state.")
+    lakebase = _Lakebase(
+        turn_rows=[
+            _turn_row("How many borrowers are in the money?", first),
+            _turn_row("Break that down by state.", second),
+        ]
+    )
+
+    res = _with_lakebase(
+        lakebase,
+        lambda: client.get("/api/genie/sessions/conv-1", headers=ACTOR_HEADERS),
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["conversation_id"] == "conv-1"
+    assert [turn["question"] for turn in body["turns"]] == [
+        "How many borrowers are in the money?",
+        "Break that down by state.",
+    ]
+    replayed = body["turns"][0]["response"]
+    assert replayed["answer"] == first.answer
+    assert replayed["source"] == "genie"
+    assert replayed["table_rows"] == [{"borrowers": 117404}]
+    assert replayed["reasoning_trace"][0]["kind"] == "guardrails"
+    _, params = lakebase.fetchall_calls[0]
+    assert params["actor_email"] == "lo@example.com"
+    assert params["conversation_id"] == "conv-1"
+
+
+def test_session_detail_accepts_a_json_encoded_payload_column() -> None:
+    response = _response()
+    lakebase = _Lakebase(
+        turn_rows=[
+            {
+                "question_text": response.question,
+                "response_json": history_payload_json(response),
+            }
+        ]
+    )
+
+    res = _with_lakebase(
+        lakebase,
+        lambda: client.get("/api/genie/sessions/conv-1", headers=ACTOR_HEADERS),
+    )
+
+    assert res.status_code == 200
+    assert res.json()["turns"][0]["response"]["answer"] == response.answer
+
+
+def test_session_detail_404s_for_a_conversation_owned_by_another_actor() -> None:
+    # The read is actor-scoped, so another actor's conversation yields no rows
+    # and is indistinguishable from one that never existed.
+    res = _with_lakebase(
+        _Lakebase(turn_rows=[]),
+        lambda: client.get("/api/genie/sessions/conv-someone-else", headers=ACTOR_HEADERS),
+    )
+
+    assert res.status_code == 404
+
+
+def test_session_detail_skips_turns_recorded_before_payload_persistence() -> None:
+    lakebase = _Lakebase(
+        turn_rows=[
+            {"question_text": None, "response_json": None},
+            _turn_row("How many borrowers are in the money?", _response()),
+        ]
+    )
+
+    res = _with_lakebase(
+        lakebase,
+        lambda: client.get("/api/genie/sessions/conv-1", headers=ACTOR_HEADERS),
+    )
+
+    assert res.status_code == 200
+    assert len(res.json()["turns"]) == 1
+
+
+def test_session_detail_returns_503_when_lakebase_is_down() -> None:
+    res = _with_lakebase(
+        _BrokenLakebase(),
+        lambda: client.get("/api/genie/sessions/conv-1", headers=ACTOR_HEADERS),
+    )
+
+    assert res.status_code == 503

--- a/tests/unit/test_genie_process_trace.py
+++ b/tests/unit/test_genie_process_trace.py
@@ -1,0 +1,232 @@
+"""Deterministic Genie process-trace builder.
+
+The proof panel used to render four identical "Analyzed the request within the
+governed Genie workflow." lines. These tests pin the replacement: distinct,
+server-authored steps describing what the governed pipeline actually did, all
+of which must clear the same visible-text guard every other rendered Genie
+string is held to.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backend.services.genie_answers import GenieReasoningStep
+from backend.services.genie_client import GenieResponse
+from backend.services.genie_message_policy import genie_visible_text_unsafe
+from backend.services.repositories.databricks_genie import _adapt_genie_response
+from backend.services.repositories.databricks_genie_trace import (
+    GENIE_MAX_TRACE_STEPS,
+    NARRATIVE_WITHHELD_CONTENT,
+    SUPERSEDED_TRANSLATED_CONTENTS,
+    WITHHELD_CONTRADICTED,
+    WITHHELD_NO_NARRATIVE,
+    WITHHELD_NO_NARRATIVE_DETERMINISTIC,
+    WITHHELD_UNSAFE_TEXT,
+    WITHHELD_UNVERIFIED_NUMBERS,
+    GenieProcessTrace,
+)
+
+_TRACE_KINDS = {
+    "guardrails",
+    "live",
+    "trust",
+    "repair",
+    "canonical",
+    "execute",
+    "verify",
+    "compose",
+}
+
+
+class _StubSqlClient:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def execute(self, statement: str, parameters: Any = None) -> list[dict[str, Any]]:  # noqa: ARG002
+        return self.rows
+
+    def execute_one(self, statement: str, parameters: Any = None) -> dict[str, Any] | None:  # noqa: ARG002
+        return self.rows[0] if self.rows else None
+
+
+def _fully_populated_traces() -> list[GenieProcessTrace]:
+    """One trace per branch combination that can ship, covering every step."""
+    traces: list[GenieProcessTrace] = []
+    for withheld_reason in (
+        None,
+        WITHHELD_UNSAFE_TEXT,
+        WITHHELD_UNVERIFIED_NUMBERS,
+        WITHHELD_CONTRADICTED,
+        WITHHELD_NO_NARRATIVE,
+        WITHHELD_NO_NARRATIVE_DETERMINISTIC,
+        "unrecognized_reason_falls_back",
+    ):
+        for shape in ("metric", "ranking", "", "unknown-shape"):
+            for assets in (
+                ["mip.gold.borrower_360"],
+                ["mip.gold.lead_population", "mip.gold.borrower_360"],
+                [],
+                None,
+            ):
+                for sql_query in ("SELECT 1 FROM mip.gold.borrower_360", None):
+                    trace = GenieProcessTrace()
+                    trace.guardrails()
+                    trace.repair()
+                    trace.live_turn(sql_query=sql_query, assets=assets)
+                    trace.trust()
+                    trace.canonical(shape=shape)
+                    trace.execute(row_count=0, assets=assets)
+                    trace.execute(row_count=1, assets=assets)
+                    trace.execute(row_count=1_234, assets=assets)
+                    if withheld_reason is None:
+                        trace.verified()
+                    else:
+                        trace.narrative_withheld(reason=withheld_reason)
+                    trace.composed_brief()
+                    traces.append(trace)
+    return traces
+
+
+def test_every_populated_trace_string_passes_the_visible_text_guard() -> None:
+    for trace in _fully_populated_traces():
+        steps = trace.steps()
+        assert steps, "a fully populated trace must emit steps"
+        for step in steps:
+            assert step.kind in _TRACE_KINDS, step.kind
+            assert step.kind == step.kind.lower()
+            assert not genie_visible_text_unsafe(step.kind), step.kind
+            assert not genie_visible_text_unsafe(step.content), step.content
+
+
+def test_every_withheld_reason_string_passes_the_visible_text_guard() -> None:
+    for content in NARRATIVE_WITHHELD_CONTENT.values():
+        assert not genie_visible_text_unsafe(content), content
+
+
+def test_trace_dedupes_identical_contents_and_caps_length() -> None:
+    trace = GenieProcessTrace()
+    for _ in range(5):
+        trace.guardrails()
+        trace.trust()
+    contents = [step.content for step in trace.steps()]
+    assert len(contents) == 2
+    assert len(set(contents)) == 2
+
+    long_trace = GenieProcessTrace()
+    for index in range(GENIE_MAX_TRACE_STEPS * 2):
+        long_trace.execute(row_count=index, assets=["mip.gold.borrower_360"])
+    assert len(long_trace.steps()) == GENIE_MAX_TRACE_STEPS
+
+
+def test_translated_thoughts_only_append_when_they_add_something() -> None:
+    trace = GenieProcessTrace()
+    trace.guardrails()
+    generic = [
+        GenieReasoningStep(kind=kind, content=content)
+        for kind, content in zip(
+            ("analysis", "query"), sorted(SUPERSEDED_TRANSLATED_CONTENTS), strict=False
+        )
+    ]
+    assert [step.content for step in trace.steps(generic)] == [
+        step.content for step in trace.steps()
+    ]
+
+    novel = [GenieReasoningStep(kind="answer", content="Summarized the verified result for review.")]
+    appended = trace.steps(novel)
+    assert appended[-1].kind == "answer"
+    assert appended[-1].content == "Summarized the verified result for review."
+
+
+def test_unsafe_translated_thought_never_reaches_the_trace() -> None:
+    trace = GenieProcessTrace()
+    trace.guardrails()
+    unsafe = [GenieReasoningStep(kind="analysis", content="Contact john smith about the result.")]
+    assert [step.content for step in trace.steps(unsafe)] == [
+        step.content for step in trace.steps()
+    ]
+
+
+def test_repaired_turn_reports_the_repair_step() -> None:
+    live = GenieResponse(
+        answer_text="Two borrowers match the governed screen.",
+        sql_query="SELECT borrower_id FROM mip.gold.borrower_360 LIMIT 2",
+        sql_result_rows=[{"borrower_id": "B-0AAAAAAAAAAAA"}, {"borrower_id": "B-0BBBBBBBBBBBB"}],
+        conversation_id="conv-repair",
+        message_id="msg-repair",
+    )
+    result = _adapt_genie_response(
+        "How many borrowers are eligible?",
+        live,
+        sql_client=None,
+        repaired=True,
+    )
+    kinds = [step.kind for step in result.reasoning_trace]
+    assert kinds[:4] == ["guardrails", "repair", "live", "trust"]
+    assert "regenerate the answer as governed SQL" in result.reasoning_trace[1].content
+
+
+def test_unrepaired_turn_omits_the_repair_step() -> None:
+    live = GenieResponse(
+        answer_text="Two borrowers match the governed screen.",
+        sql_query="SELECT borrower_id FROM mip.gold.borrower_360 LIMIT 2",
+        sql_result_rows=[{"borrower_id": "B-0AAAAAAAAAAAA"}, {"borrower_id": "B-0BBBBBBBBBBBB"}],
+        conversation_id="conv-plain",
+        message_id="msg-plain",
+    )
+    result = _adapt_genie_response("How many borrowers are eligible?", live, sql_client=None)
+    assert "repair" not in [step.kind for step in result.reasoning_trace]
+
+
+def test_withheld_narrative_reports_the_actual_reason() -> None:
+    live = GenieResponse(
+        answer_text="Email borrower@example.com about the two matches.",
+        sql_query="SELECT borrower_id FROM mip.gold.borrower_360 LIMIT 2",
+        sql_result_rows=[{"borrower_id": "B-0AAAAAAAAAAAA"}, {"borrower_id": "B-0BBBBBBBBBBBB"}],
+        conversation_id="conv-withheld",
+        message_id="msg-withheld",
+    )
+    result = _adapt_genie_response("Which borrowers are eligible?", live, sql_client=None)
+    verify = [step for step in result.reasoning_trace if step.kind == "verify"]
+    assert verify == [
+        GenieReasoningStep(
+            kind="verify", content=NARRATIVE_WITHHELD_CONTENT[WITHHELD_UNSAFE_TEXT]
+        )
+    ]
+    assert "borrower@example.com" not in " ".join(
+        step.content for step in result.reasoning_trace
+    )
+
+
+def test_ranking_turn_reports_canonical_execution_and_composition() -> None:
+    live = GenieResponse(
+        answer_text="",
+        sql_query=None,
+        sql_result_rows=[],
+        conversation_id="conv-rank",
+        message_id="msg-rank",
+    )
+    rows = [
+        {
+            "borrower_id": f"B-0{index}AAAAAAAAAA"[:15],
+            "opportunity_score": 90 - index,
+            "state": "IL",
+            "segment_codes": ["in_the_money"],
+        }
+        for index in range(3)
+    ]
+    result = _adapt_genie_response(
+        "Who are the top borrowers by opportunity score across the current coverage?",
+        live,
+        sql_client=_StubSqlClient(rows),  # type: ignore[arg-type]
+    )
+    kinds = [step.kind for step in result.reasoning_trace]
+    assert "canonical" in kinds
+    assert "execute" in kinds
+    contents = {step.kind: step.content for step in result.reasoning_trace}
+    assert "unique-borrower grain" in contents["canonical"]
+    assert "PII columns stripped at the boundary" in contents["execute"]
+    assert result.proof is not None
+    assert [step.model_dump() for step in result.proof.reasoning_trace] == [
+        step.model_dump() for step in result.reasoning_trace
+    ]

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -3827,12 +3827,23 @@ def test_recognized_shape_live_turn_preserves_genie_voice_and_live_fields() -> N
     assert result.answer.startswith("There are roughly 147,742 borrowers in the money right now.")
     # Live-intelligence fields carried through exactly like the generic path.
     assert result.genie_status == "COMPLETED"
-    assert [step.content for step in result.reasoning_trace] == [
-        "Analyzed the request within the governed Genie workflow."
+    # The process summary describes what the governed pipeline actually did,
+    # with one distinct step per stage -- not four repeats of a generic phrase.
+    assert [step.kind for step in result.reasoning_trace] == [
+        "guardrails",
+        "live",
+        "trust",
+        "canonical",
+        "execute",
+        "verify",
     ]
+    contents = [step.content for step in result.reasoning_trace]
+    assert len(set(contents)) == len(contents)
+    assert "mip.gold.borrower_360" in contents[1]
+    assert "Returned 1 row from mip.gold.borrower_360" in contents[4]
     assert result.proof is not None
-    assert [step.content for step in result.proof.reasoning_trace] == [
-        "Analyzed the request within the governed Genie workflow."
+    assert [step.model_dump() for step in result.proof.reasoning_trace] == [
+        step.model_dump() for step in result.reasoning_trace
     ]
     assert result.native_visualization is not None
     assert result.native_visualization.attachment_id == "att-1"
@@ -3861,12 +3872,19 @@ def test_live_reasoning_omits_title_lowercase_and_uppercase_identity_shapes() ->
         sql_client=_StubSqlClient([{"borrowers": 3}]),  # type: ignore[arg-type]
     )
 
-    assert [step.content for step in result.reasoning_trace] == [
-        "Analyzed the request within the governed Genie workflow.",
-        "Analyzed the request within the governed Genie workflow.",
-        "Analyzed the request within the governed Genie workflow.",
-        "Analyzed the request within the governed Genie workflow.",
+    contents = [step.content for step in result.reasoning_trace]
+    # Raw model thoughts never ship: no identity-shaped thought text survives,
+    # in any casing, and the trace is the server-authored pipeline summary.
+    for fragment in ("John Smith", "john smith", "JOHN SMITH", "Filtering to"):
+        assert all(fragment not in content for content in contents)
+    assert [step.kind for step in result.reasoning_trace] == [
+        "guardrails",
+        "live",
+        "trust",
+        "execute",
+        "verify",
     ]
+    assert len(set(contents)) == len(contents)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Nine product-owner improvements in one integrated slice (frontend batch,
backend batch, and data consistency built in parallel):

- Source citations and proof chips deep-link to the workspace Catalog
  Explorer (workspace_host now on the authenticated health body, origin
  validated); Genie table borrower_ids link to Borrower 360 and states
  to the filtered lead queue
- ASK chips never wrap; logo geometry unified to the pixel-measured
  brand mark everywhere; rate spread distribution chart gains
  nearest-point hover with exact x/y values
- Genie process summary is now a real deterministic pipeline trace
  (guardrails -> repair -> live -> trust -> canonical -> execute ->
  verify -> compose), deduped, every line output-guard-clean
- Genie conversations persist across navigation and reopen
  (sessionStorage transcript store), with New thread and a History menu
  over new actor-scoped GET /api/genie/sessions endpoints backed by
  Lakebase (migration 2026_08_06_genie_history_replay; refused/blocked
  turns never recorded, action tokens stripped, payloads bounded,
  governance posture change documented in schema comments)
- The analytics Top Borrowers panel now ranks with the exact governed
  predicate and ordering Genie and the Lead Queue use (one top-10
  everywhere), and bound-clamped rates (1%/15% caps) can no longer mint
  spread economics (ITM 89,325 -> 88,806 after gold rebuild)

Validation: pytest 12,788+ exit 0; vitest 936; eslint/css-lint clean;
build + budget pass.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
