### PR TITLE
feat(api): enforce app-layer authenticated identity on lineage + data-estate

### DIFF
--- a/backend/api/data_estate.py
+++ b/backend/api/data_estate.py
@@ -1,4 +1,11 @@
-"""Data-estate readiness endpoint for source and dependency proof."""
+"""Data-estate readiness endpoint for source and dependency proof.
+
+The payload embeds Catalog Explorer deep-link URLs for the configured
+workspace host, so the route requires an authenticated workspace identity
+at the app layer instead of relying only on the Databricks Apps edge —
+a non-Apps deploy (docs/security/GRANTS.md §11a) must not serve workspace
+URLs to anonymous callers.
+"""
 
 from __future__ import annotations
 
@@ -10,14 +17,21 @@ from backend.schemas.data_estate import DataEstateResponse
 from backend.services.admin_rules import AdminRulesService, get_admin_rules_service
 from backend.services.data_estate import build_data_estate_response
 from backend.services.health_probes import cached_probe, probe_genie, probe_lakebase
+from backend.services.rbac import AuthenticatedActorDep
 
 router = APIRouter(prefix="/data-estate", tags=["data-estate"])
 
-AdminRulesServiceDep = Annotated[AdminRulesService, Depends(get_admin_rules_service)]
+# Plain read-service factory (source-readiness rows sourced by the admin
+# rules service), NOT an authorization gate — auth for this route is
+# ``AuthenticatedActorDep``.
+SourceReadinessDep = Annotated[AdminRulesService, Depends(get_admin_rules_service)]
 
 
 @router.get("", response_model=DataEstateResponse)
-def get_data_estate(service: AdminRulesServiceDep) -> DataEstateResponse:
+def get_data_estate(
+    service: SourceReadinessDep,
+    _actor: AuthenticatedActorDep,
+) -> DataEstateResponse:
     runtime_statuses: dict[str, bool] = {}
     for name, probe in {"genie": probe_genie, "lakebase": probe_lakebase}.items():
         try:

--- a/backend/api/lineage.py
+++ b/backend/api/lineage.py
@@ -2,8 +2,12 @@
 
 Serves the repo-committed lineage manifest resolved for this deployment
 (default catalog + workspace deep links). Static product truth — no
-warehouse or Lakebase read, no PII, so the route is open to any
-authenticated workspace user like the other read surfaces.
+warehouse or Lakebase read, no PII. Because the payload embeds Catalog
+Explorer deep-link URLs for the configured workspace host, the route
+requires an authenticated workspace identity at the app layer instead of
+relying only on the Databricks Apps edge — a non-Apps deploy
+(docs/security/GRANTS.md §11a) must not serve workspace URLs to
+anonymous callers.
 """
 
 from __future__ import annotations
@@ -12,10 +16,11 @@ from fastapi import APIRouter
 
 from backend.schemas.lineage import LineageManifestResponse
 from backend.services.lineage_manifest import get_lineage_manifest_response
+from backend.services.rbac import AuthenticatedActorDep
 
 router = APIRouter(prefix="/lineage", tags=["lineage"])
 
 
 @router.get("/manifest", response_model=LineageManifestResponse)
-def get_lineage_manifest() -> LineageManifestResponse:
+def get_lineage_manifest(_actor: AuthenticatedActorDep) -> LineageManifestResponse:
     return get_lineage_manifest_response()

--- a/backend/services/rbac.py
+++ b/backend/services/rbac.py
@@ -1,4 +1,4 @@
-"""Fail-closed admin and approver authorization.
+"""Fail-closed admin, approver, and authenticated-actor authorization.
 
 Deployed automation is authorized by exact server-configured identities matched
 against the actor resolved from ``X-Forwarded-Email`` / ``X-Forwarded-User``.
@@ -140,3 +140,41 @@ def require_approver(request: Request) -> str:
 
 # ``ApproverDep`` evaluates to ``str`` (the admitted decision-maker email).
 ApproverDep = Annotated[str, Depends(require_approver)]
+
+
+def require_authenticated_actor(request: Request) -> str:
+    """Fail-closed "any authenticated workspace user" gate for read surfaces.
+
+    Admits the identity forwarded by the trusted Databricks Apps edge
+    (``X-Forwarded-Email`` / ``X-Forwarded-User``); everything else is a
+    401. Unlike ``audit_store.resolve_actor`` this never substitutes
+    ``settings.default_actor`` or the untrusted-edge marker, and it never
+    bumps the identity-fallback counter — that counter is a regression
+    signal for audited writes missing the header inside an Apps deploy,
+    not an auth-failure count (same reasoning as
+    ``backend/api/health.py::_trusted_health_actor``).
+
+    With ``trust_forwarded_headers=False`` (non-Apps deploy,
+    docs/security/GRANTS.md §11a) the caller identity is unknowable at
+    this layer, so the gate fails closed instead of serving governed
+    payloads to anonymous or header-spoofing callers.
+    """
+    if settings.trust_forwarded_headers:
+        actor = request.headers.get("X-Forwarded-Email") or request.headers.get(
+            "X-Forwarded-User"
+        )
+        if actor:
+            return actor
+    emit(
+        log,
+        "authenticated_access_denied",
+        outcome="denied",
+        trusted_edge=settings.trust_forwarded_headers,
+    )
+    raise HTTPException(status_code=401, detail="authenticated identity required")
+
+
+# ``AuthenticatedActorDep`` evaluates to ``str`` (the forwarded workspace
+# identity). Weakest gate tier: proves "some authenticated workspace user",
+# not admin or approver membership.
+AuthenticatedActorDep = Annotated[str, Depends(require_authenticated_actor)]

--- a/tests/unit/test_api_boundaries.py
+++ b/tests/unit/test_api_boundaries.py
@@ -132,9 +132,12 @@ def test_hashed_static_assets_are_compressed_and_immutable() -> None:
 
 
 def test_data_estate_does_not_shadow_admin_auth_dependency_name() -> None:
-    """Only RBAC-gated routers should expose an ``AdminDep`` alias."""
+    """Only RBAC-gated routers should expose an ``AdminDep`` alias, and the
+    service alias must not read like one (``AdminRulesServiceDep`` was
+    renamed because it suggested an RBAC gate it never was)."""
     assert "AdminDep" not in data_estate_api.__dict__
-    assert "AdminRulesServiceDep" in data_estate_api.__dict__
+    assert "AdminRulesServiceDep" not in data_estate_api.__dict__
+    assert "SourceReadinessDep" in data_estate_api.__dict__
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_data_estate.py
+++ b/tests/unit/test_data_estate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
 
 from backend.config.settings import settings
@@ -9,13 +10,49 @@ from backend.services.data_estate import build_data_estate_response
 
 client = TestClient(app)
 
+# The payload emits Catalog Explorer deep links, so the route requires the
+# forwarded workspace identity (conftest only defaults the admin group
+# header, never an identity header).
+ACTOR_HEADERS = {"X-Forwarded-Email": "analyst@summit.example"}
+
 
 def test_data_estate_route_returns_lane_inventory() -> None:
-    response = client.get("/api/data-estate")
+    response = client.get("/api/data-estate", headers=ACTOR_HEADERS)
     assert response.status_code == 200
     body = response.json()
     assert body["public_demo_masking"] is True
     assert isinstance(body["lanes"], list)
+
+
+@pytest.mark.parametrize("path", ["/api/data-estate", "/api/v1/data-estate"])
+def test_data_estate_rejects_anonymous_callers(path: str) -> None:
+    """No forwarded identity -> 401. The payload embeds workspace deep-link
+    URLs, so a non-Apps deploy must not serve it to anonymous callers
+    (GRANTS §11a). The conftest default ``X-Forwarded-Groups: mip-admin``
+    header is still present on this request, which also pins that a group
+    claim alone never authenticates."""
+    response = client.get(path)
+    assert response.status_code == 401
+    assert response.json() == {"detail": "authenticated identity required"}
+
+
+def test_data_estate_rejects_spoofed_identity_when_edge_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """trust_forwarded_headers=False (non-Apps deploy) fails closed even
+    when the caller supplies identity headers."""
+    monkeypatch.setattr(settings, "trust_forwarded_headers", False)
+    response = client.get("/api/data-estate", headers=ACTOR_HEADERS)
+    assert response.status_code == 401
+
+
+def test_data_estate_accepts_forwarded_user_without_email() -> None:
+    """Apps may forward only ``X-Forwarded-User`` for service identities."""
+    response = client.get(
+        "/api/data-estate",
+        headers={"X-Forwarded-User": "svc-mip-automation"},
+    )
+    assert response.status_code == 200
 
 
 def test_data_estate_separates_first_party_from_live_cotality() -> None:

--- a/tests/unit/test_lineage_manifest.py
+++ b/tests/unit/test_lineage_manifest.py
@@ -34,6 +34,11 @@ client = TestClient(app)
 
 RAW_COTALITY_CATALOG = "cotality_mortgage_data"
 
+# The manifest emits workspace deep links, so the route requires the
+# forwarded workspace identity (conftest only defaults the admin group
+# header, never an identity header).
+ACTOR_HEADERS = {"X-Forwarded-Email": "analyst@summit.example"}
+
 
 def _node_payload(**overrides: object) -> dict[str, object]:
     payload: dict[str, object] = {
@@ -227,7 +232,7 @@ class TestExplorerUrls:
 
 class TestLineageApiContract:
     def test_manifest_endpoint_serves_resolved_manifest(self) -> None:
-        response = client.get("/api/lineage/manifest")
+        response = client.get("/api/lineage/manifest", headers=ACTOR_HEADERS)
         assert response.status_code == 200
         body = response.json()
         assert body["schema_version"] >= 1
@@ -246,4 +251,35 @@ class TestLineageApiContract:
         assert node["fqn"].count(".") == 2
 
     def test_manifest_endpoint_available_on_canonical_prefix(self) -> None:
-        assert client.get("/api/v1/lineage/manifest").status_code == 200
+        assert (
+            client.get("/api/v1/lineage/manifest", headers=ACTOR_HEADERS).status_code == 200
+        )
+
+    def test_manifest_accepts_forwarded_user_without_email(self) -> None:
+        """Apps may forward only ``X-Forwarded-User`` for service identities."""
+        response = client.get(
+            "/api/lineage/manifest",
+            headers={"X-Forwarded-User": "svc-mip-automation"},
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize("path", ["/api/lineage/manifest", "/api/v1/lineage/manifest"])
+    def test_manifest_rejects_anonymous_callers(self, path: str) -> None:
+        """No forwarded identity -> 401. The payload embeds workspace
+        deep-link URLs, so a non-Apps deploy must not serve it to
+        anonymous callers (GRANTS §11a). The conftest default
+        ``X-Forwarded-Groups: mip-admin`` header is still present on this
+        request, which also pins that a group claim alone never
+        authenticates."""
+        response = client.get(path)
+        assert response.status_code == 401
+        assert response.json() == {"detail": "authenticated identity required"}
+
+    def test_manifest_rejects_spoofed_identity_when_edge_untrusted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """trust_forwarded_headers=False (non-Apps deploy) fails closed even
+        when the caller supplies identity headers."""
+        monkeypatch.setattr(settings, "trust_forwarded_headers", False)
+        response = client.get("/api/lineage/manifest", headers=ACTOR_HEADERS)
+        assert response.status_code == 401


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up from the `/api/health` `workspace_host` governance review (pre-existing gap, not introduced by it). Two routes emit full workspace deep-link URLs (`{DATABRICKS_HOST}/explore/data/...`) with no FastAPI-layer auth dependency:

- `GET /api/lineage/manifest` — module docstring claimed the route is "open to any authenticated workspace user", but nothing in the code enforced *authenticated*.
- `GET /api/data-estate` — its only dependency, `AdminRulesServiceDep`, read like an RBAC gate but is a plain lazy service factory.

In the deployed shape the Databricks Apps platform edge 401s before FastAPI sees the request (confirmed in docs/audits/critical-uncommitted-changes-audit.md), so the deployed app was **not** exposed. The gap only bites the supported-but-unusual non-Apps deploy shape (docs/security/GRANTS.md §11a), which would have served these payloads to fully anonymous callers.

## Changes

- **`backend/services/rbac.py`**: new `require_authenticated_actor` / `AuthenticatedActorDep` — the weakest fail-closed gate tier below `ApproverDep`/`AdminDep`. Admits the edge-forwarded `X-Forwarded-Email` / `X-Forwarded-User`; 401 otherwise, and 401 always when `trust_forwarded_headers=false` (identity is unknowable at the app layer, matching the §11a fail-closed posture). Deliberately does **not** call `resolve_actor()` so anonymous probes never bump the identity-fallback counter — the same reasoning documented in `health.py::_trusted_health_actor`; that counter is a missing-header-on-audited-write regression signal, not an auth-failure count. Consolidates the semantics `backend/api/audit.py::_authenticated_actor` already hand-rolls.
- **`backend/api/lineage.py` / `backend/api/data_estate.py`**: both handlers now take `_actor: AuthenticatedActorDep`; docstrings state the enforced posture.
- **`backend/api/data_estate.py`**: `AdminRulesServiceDep` → `SourceReadinessDep` (name no longer implies an auth gate).
- **Tests**: 401 pins for anonymous callers on both routes and both prefixes (including the conftest group-header-only case, pinning that a group claim alone never authenticates), spoofed-header rejection with trust off, `X-Forwarded-User`-only acceptance, and the `test_api_boundaries.py` alias assertion moved to the new name.

## Notes

- OpenAPI baseline unchanged — a plain callable dependency adds no schema, verified by `test_openapi_contract.py`.
- Local dev without a forwarded identity header now gets 401 from these two routes, consistent with `/api/workspace`, genie actions, and audit reads.
- Not touched: `workspace.py`/`genie.py` private `_actor` helpers keep their deliberate trust-off fallback to `resolve_actor()` (untrusted-edge attribution) — different semantics for workflow surfaces, out of scope here.

## Validation

- `pytest tests/unit -q -k "lineage or data_estate"` — 57 passed
- `ruff check backend tests` — clean
- `tests/unit/test_api_boundaries.py`, `test_openapi_contract.py`, `test_admin_rbac.py`, `test_architecture_boundaries.py` — all pass
- Full `pytest tests/unit -q` — green except pre-existing environmental failure in `test_deploy_dev_workflow_contract.py::test_first_install_dry_run_executes_no_databricks_operations` (`ModuleNotFoundError: dotenv` in a deploy-script subprocess; fails identically on a clean tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)