### PR TITLE
chore(security): allowlist the Genie conversation localStorage key name

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -37,6 +37,11 @@ regexes = [
   # Module 0 masked borrower IDs are synthetic by contract:
   # B-[0-9A-Z]{13}. They are not credentials or real borrower PII.
   '''B-[0-9A-Z]{13}''',
+  # Frontend localStorage key for persisted Genie conversation turns
+  # (frontend/src/lib/genieConversationStore.ts). A browser storage-key
+  # NAME, not a credential; the hyphenated-versioned string trips the
+  # generic-api-key entropy heuristic.
+  '''mip-genie-conversation-v\d+''',
 ]
 
 # Paths where noisy-but-safe strings live. The design_files/ prototypes


### PR DESCRIPTION
gitleaks has failed every CI run repo-wide since 01:19Z today: the scan covers all fetched refs, and the `feat/linkage-history-trace-consistency` branch (parallel session) added `GENIE_CONVERSATION_TURNS_KEY = 'mip-genie-conversation-v1'` in `frontend/src/lib/genieConversationStore.ts`, which trips the generic-api-key entropy heuristic. It is a browser localStorage key **name**, not a credential (verified by reading the line on that branch).

This allowlists the versioned literal via regex — robust to that branch rebasing (a commit-fingerprint entry would break on amend). Restores the secret gate so it can catch real leaks again. The file-size gate failure on main is separate and pre-existing (`backend/schemas/_validators.py` over cap since at least PR #129), flagged as its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)