### PR TITLE
refactor(api): consolidate authenticated-identity gates onto shared rbac helpers

### DIFF
--- a/backend/api/audit.py
+++ b/backend/api/audit.py
@@ -11,7 +11,6 @@ from typing import Annotated, Literal
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel, Field
 
-from backend.config.settings import settings
 from backend.schemas.audit import (
     AuditEvent,
     AuditEventCreateRequest,
@@ -41,7 +40,7 @@ from backend.services.error_sanitizer import safe_dependency_detail
 from backend.services.http_content import JSON_CONTENT_TYPE_RESPONSE, require_json_content_type
 from backend.services.lakebase import LakebaseClient, LakebaseError, get_lakebase_client
 from backend.services.observability import is_safe_correlation_id
-from backend.services.rbac import AdminDep
+from backend.services.rbac import AdminDep, require_authenticated_actor
 
 router = APIRouter(prefix="/audit", tags=["audit"])
 
@@ -80,17 +79,6 @@ def _validate_correlation_filter(value: str) -> str:
     if not is_safe_correlation_id(value):
         raise ValueError("correlation_id must be a non-PII request correlation id")
     return value
-
-
-def _authenticated_actor(request: Request) -> str:
-    """Resolve the current edge identity without admitting a fallback actor."""
-
-    if not settings.trust_forwarded_headers:
-        raise HTTPException(status_code=401, detail="audit identity required")
-    actor = request.headers.get("X-Forwarded-Email") or request.headers.get("X-Forwarded-User")
-    if not actor:
-        raise HTTPException(status_code=401, detail="audit identity required")
-    return actor
 
 
 def _actor_event_summary(event: AuditEvent) -> ActorAuditEventSummary:
@@ -136,7 +124,7 @@ def list_my_events(
 
     if "actor" in request.query_params:
         raise HTTPException(status_code=422, detail="actor filter is not supported")
-    actor = _authenticated_actor(request)
+    actor = require_authenticated_actor(request)
     response.headers["Cache-Control"] = "private, no-store"
     fingerprint = audit_filter_fingerprint(
         {

--- a/backend/api/genie.py
+++ b/backend/api/genie.py
@@ -75,6 +75,7 @@ from backend.services.genie_trusted_assets import trusted_assets
 from backend.services.http_content import JSON_CONTENT_TYPE_RESPONSE, require_json_content_type
 from backend.services.lakebase import LakebaseClient, LakebaseError, get_lakebase_client
 from backend.services.observability import emit
+from backend.services.rbac import resolve_workflow_actor
 from backend.services.repositories import BorrowerRepository, GenieAnswerRepository
 from backend.services.repositories.factory import (
     get_borrower_repository,
@@ -143,18 +144,6 @@ INSERT INTO mip_app.genie_messages (
 )
 ON CONFLICT (conversation_id, message_id) DO NOTHING
 """
-
-
-def _actor(request: Request) -> str:
-    if settings.trust_forwarded_headers:
-        email = request.headers.get("X-Forwarded-Email")
-        if email:
-            return email
-        user = request.headers.get("X-Forwarded-User")
-        if user:
-            return user
-        raise HTTPException(status_code=401, detail="genie action identity required")
-    return resolve_actor(request)
 
 
 def _safe_audit_write(store: AuditStore, **kwargs: Any) -> None:
@@ -711,7 +700,7 @@ def genie_action(
     _: Annotated[None, Depends(require_json_content_type)],
 ) -> GenieActionResponse:
     _ = audit
-    actor = _actor(request)
+    actor = resolve_workflow_actor(request)
     return handle_genie_action(
         payload,
         actor=actor,

--- a/backend/api/workspace.py
+++ b/backend/api/workspace.py
@@ -12,7 +12,6 @@ from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from backend.config.settings import settings
 from backend.schemas.common import validate_public_borrower_id
 from backend.schemas.lead import LeadSummary
 from backend.schemas.workspace import (
@@ -24,7 +23,6 @@ from backend.schemas.workspace import (
     WorkspaceMutationResponse,
     WorkspaceState,
 )
-from backend.services.audit_store import resolve_actor
 from backend.services.disclosures import MissingTenantDisclosureError, resolve_tenant_disclosure
 from backend.services.error_sanitizer import safe_dependency_detail
 from backend.services.http_content import JSON_CONTENT_TYPE_RESPONSE, require_json_content_type
@@ -33,6 +31,7 @@ from backend.services.outreach_draft_proof import (
     GeneratedOutreachDraftProofError,
     load_verified_generated_outreach_draft,
 )
+from backend.services.rbac import resolve_workflow_actor
 from backend.services.repositories import (
     LeadRepository,
     OutreachRepository,
@@ -47,21 +46,6 @@ WorkspaceDep = Annotated[WorkspaceStore, Depends(get_workspace_store)]
 LeadRepoDep = Annotated[LeadRepository, Depends(get_lead_repository)]
 OutreachRepoDep = Annotated[OutreachRepository, Depends(get_outreach_repository)]
 LakebaseDep = Annotated[LakebaseClient, Depends(get_lakebase_client)]
-
-
-def _actor(request: Request) -> str:
-    if settings.trust_forwarded_headers:
-        email = request.headers.get("X-Forwarded-Email")
-        if email:
-            return email
-        user = request.headers.get("X-Forwarded-User")
-        if user:
-            return user
-        raise HTTPException(
-            status_code=401,
-            detail="workspace identity required",
-        )
-    return resolve_actor(request)
 
 
 def _as_lakebase_503() -> HTTPException:
@@ -187,7 +171,7 @@ def read_workspace(
     repo: LeadRepoDep,
 ) -> WorkspaceState:
     try:
-        state = store.list(actor=_actor(request))
+        state = store.list(actor=resolve_workflow_actor(request))
         return _hydrate_saved_leads(state, repo)
     except LakebaseError as exc:
         raise _as_lakebase_503() from exc
@@ -219,7 +203,7 @@ def save_lead(
         raise HTTPException(status_code=404, detail=f"Borrower {borrower_id} not found")
     live_input = _lead_input_from_live(live_rows[0])
     try:
-        return store.save_lead(actor=_actor(request), lead=live_input)
+        return store.save_lead(actor=resolve_workflow_actor(request), lead=live_input)
     except LakebaseError as exc:
         raise _as_lakebase_503() from exc
 
@@ -232,7 +216,7 @@ def delete_lead(
 ) -> WorkspaceMutationResponse:
     borrower_id = _path_borrower_id(borrower_id)
     try:
-        return store.delete_lead(actor=_actor(request), borrower_id=borrower_id)
+        return store.delete_lead(actor=resolve_workflow_actor(request), borrower_id=borrower_id)
     except LakebaseError as exc:
         raise _as_lakebase_503() from exc
 
@@ -258,7 +242,7 @@ def save_draft(
     if borrower is None:
         raise HTTPException(status_code=404, detail=f"Borrower {borrower_id} not found")
     _assert_workspace_marketing_eligible(borrower)
-    actor = _actor(request)
+    actor = resolve_workflow_actor(request)
     try:
         generated = load_verified_generated_outreach_draft(
             lakebase,
@@ -325,7 +309,7 @@ def delete_draft(
     borrower_id = _path_borrower_id(borrower_id)
     try:
         return store.delete_draft(
-            actor=_actor(request),
+            actor=resolve_workflow_actor(request),
             borrower_id=borrower_id,
             channel=channel,
         )

--- a/backend/services/rbac.py
+++ b/backend/services/rbac.py
@@ -178,3 +178,23 @@ def require_authenticated_actor(request: Request) -> str:
 # identity). Weakest gate tier: proves "some authenticated workspace user",
 # not admin or approver membership.
 AuthenticatedActorDep = Annotated[str, Depends(require_authenticated_actor)]
+
+
+def resolve_workflow_actor(request: Request) -> str:
+    """Actor identity for workflow surfaces (workspace inbox, Genie actions).
+
+    Behind a trusted Databricks Apps edge this is exactly
+    ``require_authenticated_actor``: the forwarded identity or a 401.
+
+    With ``trust_forwarded_headers=False`` (non-Apps deploy,
+    docs/security/GRANTS.md §11a) workflow surfaces deliberately KEEP
+    SERVING instead of failing closed: the caller identity is unknowable
+    at this layer, so Lakebase writes and audit rows attribute to
+    ``resolve_actor``'s distinct ``unknown-actor@untrusted-edge`` marker
+    rather than a spoofable header value. Do not adopt this fallback for
+    governed read surfaces — those take ``AuthenticatedActorDep`` and
+    fail closed with a 401.
+    """
+    if settings.trust_forwarded_headers:
+        return require_authenticated_actor(request)
+    return resolve_actor(request)

--- a/tests/unit/test_admin_rbac.py
+++ b/tests/unit/test_admin_rbac.py
@@ -11,11 +11,13 @@ these tests override per-call where they need to exercise deny paths.
 from __future__ import annotations
 
 import pytest
+from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
 
 from backend.config.settings import settings
 from backend.main import app
 from backend.services.audit_store import get_audit_store
+from backend.services.rbac import resolve_workflow_actor
 from tests.fixtures.in_memory_audit_store import InMemoryAuditStore
 
 
@@ -279,3 +281,51 @@ def test_put_rules_is_rejected_without_mutating_or_auditing() -> None:
             del app.dependency_overrides[get_audit_store]
         else:
             app.dependency_overrides[get_audit_store] = previous
+
+
+def _bare_request(headers: dict[str, str] | None = None) -> Request:
+    """Build a minimal Starlette request for direct gate-function tests."""
+    raw = [(key.lower().encode(), value.encode()) for key, value in (headers or {}).items()]
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": raw,
+            "query_string": b"",
+        }
+    )
+
+
+def test_resolve_workflow_actor_trusted_edge_matches_shared_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Behind a trusted edge the workflow resolver IS the shared fail-closed
+    gate: forwarded identity in, actor out; no identity, 401 with the shared
+    detail string.
+    """
+    monkeypatch.setattr(settings, "trust_forwarded_headers", True)
+
+    assert (
+        resolve_workflow_actor(_bare_request({"X-Forwarded-Email": "lo@example.com"}))
+        == "lo@example.com"
+    )
+    assert resolve_workflow_actor(_bare_request({"X-Forwarded-User": "lo.user"})) == "lo.user"
+
+    with pytest.raises(HTTPException) as excinfo:
+        resolve_workflow_actor(_bare_request())
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail == "authenticated identity required"
+
+
+def test_resolve_workflow_actor_untrusted_edge_serves_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GRANTS.md §11a: with trust off, workflow surfaces keep serving with
+    the distinct untrusted-edge marker — forwarded headers are spoofable on
+    a non-Apps edge, so they are ignored rather than admitted or 401'd.
+    """
+    monkeypatch.setattr(settings, "trust_forwarded_headers", False)
+
+    actor = resolve_workflow_actor(_bare_request({"X-Forwarded-Email": "spoofed@example.com"}))
+    assert actor == "unknown-actor@untrusted-edge"

--- a/tests/unit/test_audit_my_events.py
+++ b/tests/unit/test_audit_my_events.py
@@ -83,7 +83,7 @@ def test_my_events_requires_an_edge_authenticated_identity(
     )
 
     assert response.status_code == 401
-    assert response.json()["detail"] == "audit identity required"
+    assert response.json()["detail"] == "authenticated identity required"
 
 
 def test_my_events_fails_closed_when_forwarded_identity_is_untrusted(
@@ -96,7 +96,7 @@ def test_my_events_fails_closed_when_forwarded_identity_is_untrusted(
     response = client.get("/api/v1/audit/my-events", headers=ALICE_HEADERS)
 
     assert response.status_code == 401
-    assert response.json()["detail"] == "audit identity required"
+    assert response.json()["detail"] == "authenticated identity required"
 
 
 def test_my_events_rejects_arbitrary_actor_filters(

--- a/tests/unit/test_genie_actions_api.py
+++ b/tests/unit/test_genie_actions_api.py
@@ -1252,7 +1252,26 @@ def test_genie_actions_require_actor_identity() -> None:
     )
 
     assert res.status_code == 401
-    assert res.json()["detail"] == "genie action identity required"
+    assert res.json()["detail"] == "authenticated identity required"
+
+
+def test_genie_actions_untrusted_edge_serves_as_marker_actor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GRANTS.md §11a: with ``trust_forwarded_headers=False`` the Genie
+    workflow surface does not fail closed at the identity gate. The request
+    proceeds attributed to the untrusted-edge marker actor, where the
+    actor-bound confirmation token (minted for the trusted-edge actor)
+    rejects the replay — a 400, not an authentication 401.
+    """
+
+    payload = _confirmed_payload()
+    monkeypatch.setattr(settings, "trust_forwarded_headers", False)
+
+    res = client.post("/api/genie/actions", json=payload)
+
+    assert res.status_code == 400
+    assert res.json()["detail"] == "Genie action confirmation token is invalid"
 
 
 def test_genie_actions_reject_unknown_action_types() -> None:

--- a/tests/unit/test_workspace_api.py
+++ b/tests/unit/test_workspace_api.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.config.settings import settings
 from backend.main import app
 from backend.schemas.workspace import SavedLead, WorkspaceState
 from backend.services.repositories import get_lead_repository
@@ -293,4 +294,38 @@ def test_workspace_read_omits_saved_leads_missing_from_live_population() -> None
 def test_workspace_requires_actor_identity() -> None:
     res = client.get("/api/workspace")
     assert res.status_code == 401
-    assert res.json()["detail"] == "workspace identity required"
+    assert res.json()["detail"] == "authenticated identity required"
+
+
+def test_workspace_untrusted_edge_serves_with_marker_actor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GRANTS.md §11a: with ``trust_forwarded_headers=False`` the workspace
+    workflow surface deliberately keeps serving instead of failing closed.
+    Forwarded headers are ignored (spoofable on a non-Apps edge) and state
+    reads/writes attribute to the distinct untrusted-edge marker actor.
+    """
+
+    captured: list[str] = []
+
+    class _Store:
+        def list(self, *, actor: str) -> WorkspaceState:
+            captured.append(actor)
+            return WorkspaceState(saved_leads=[], saved_drafts=[])
+
+    monkeypatch.setattr(settings, "trust_forwarded_headers", False)
+    previous_store = app.dependency_overrides.get(get_workspace_store)
+    app.dependency_overrides[get_workspace_store] = lambda: _Store()
+    try:
+        res = client.get(
+            "/api/workspace",
+            headers={"X-Forwarded-Email": "spoofed@example.com"},
+        )
+    finally:
+        if previous_store is None:
+            app.dependency_overrides.pop(get_workspace_store, None)
+        else:
+            app.dependency_overrides[get_workspace_store] = previous_store
+
+    assert res.status_code == 200
+    assert captured == ["unknown-actor@untrusted-edge"]


### PR DESCRIPTION
## Summary

PR #135 added the shared fail-closed gate `rbac.require_authenticated_actor` / `AuthenticatedActorDep`. Three routers still hand-rolled private versions of the same check; this PR consolidates them without changing trust semantics.

- **audit.py** — `_authenticated_actor()` was semantically identical to the shared gate; `/api/audit/my-events` now calls `require_authenticated_actor` directly.
- **workspace.py + genie.py** — their `_actor()` helpers shared the trust-on behavior but deliberately fall back to `resolve_actor()`'s `unknown-actor@untrusted-edge` marker when `trust_forwarded_headers=false` (workflow surfaces keep serving on a non-Apps edge, docs/security/GRANTS.md §11a). That divergence is now encoded **once** as `rbac.resolve_workflow_actor` with the §11a rationale in its docstring; both routers delegate to it. **Trust-off behavior is unchanged on all three surfaces.**

## Justified wire change (401 detail strings)

The 401 detail on these three surfaces unifies to the shared `"authenticated identity required"` (was `"audit identity required"` / `"workspace identity required"` / `"genie action identity required"`). Grep evidence: the old strings appear nowhere in `frontend/src` or e2e — only unit tests pinned them, and those are updated. PR #135 already established the shared string on the data-estate and lineage surfaces. Denied requests on these surfaces now also emit the shared `authenticated_access_denied` observability event (telemetry only).

## New test coverage

The deliberate §11a trust-off semantics were previously **unpinned** — a well-meaning "fail-closed everywhere" sweep could have silently flipped them. Now pinned:

- `test_admin_rbac.py` — direct `resolve_workflow_actor` cases: trust-on email/user/missing-header (401 with shared detail), trust-off spoofed-header → marker actor.
- `test_workspace_api.py` — trust-off GET `/api/workspace` serves 200 and attributes to `unknown-actor@untrusted-edge` (spoofed header ignored).
- `test_genie_actions_api.py` — trust-off POST `/api/genie/actions` does not 401 at the gate; the actor-bound confirmation token rejects with 400 instead.

## Validation

- `ruff check backend tests` — clean.
- `pytest tests/unit -q -k "audit or workspace or genie or rbac"` — all pass.
- Full `pytest tests/unit -q` — all pass except the known pre-existing local-only failure `test_first_install_dry_run_executes_no_databricks_operations` (deploy-workflow contract suite, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)