### PR TITLE
fix(deploy): fail fast when the deploy interpreter lacks tooling deps

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2483,6 +2483,16 @@ if [[ "$_OAUTH_RECOVERY_VALUE_COUNT" -ne 0 && \
   echo "${RED}[deploy] OAuth credential intent recovery and orphan-lease recovery are mutually exclusive.${RST}" >&2
   exit 4
 fi
+# Every remaining phase — dry-run included — executes repo Python helpers with
+# "$PYTHON" (the App deploy payload emitter at minimum). Without .venv the
+# interpreter silently resolved to a bare python3, which would die dozens of
+# steps later on its first third-party import with a raw traceback. Fail here,
+# after the config gates above so their exact errors keep precedence.
+if ! "$PYTHON" -c 'import dotenv, pydantic' >/dev/null 2>&1; then
+  echo "${RED}[deploy] ERROR: ${PYTHON} cannot import the deploy tooling baseline (python-dotenv + pydantic).${RST}" >&2
+  echo "  create the project venv first: make setup — then re-run." >&2
+  exit 2
+fi
 if [[ "$DRY_RUN" -eq 0 ]]; then
   _M2M_MISSING=""
   for _M2M_NAME in \

--- a/tests/unit/test_deploy_dev_workflow_contract.py
+++ b/tests/unit/test_deploy_dev_workflow_contract.py
@@ -229,21 +229,34 @@ def _write_deploy_fixture(path: Path, text: str) -> None:
 
 
 def _sandbox_venv_dir() -> Path:
-    """Locate a real virtualenv whose ``bin/python`` runs the deploy tooling.
+    """Locate a prefix whose ``bin/python`` can run the deploy tooling.
 
     Sandbox checkouts symlink ``.venv`` at this directory so ``deploy.sh``
-    resolves an interpreter that can import the repo's dependencies. The venv
-    running the suite comes first: ``REPO / ".venv"`` does not exist when the
-    suite runs from a worktree or a fresh clone, and a dangling symlink would
-    silently drop ``deploy.sh`` onto a bare ``python3``.
+    resolves an interpreter that can import the repo's dependencies. The
+    prefix running the suite comes first: ``REPO / ".venv"`` does not exist
+    when the suite runs from a worktree, a fresh clone, or CI (which installs
+    requirements into setup-python's base interpreter, not a venv), and a
+    dangling symlink would silently drop ``deploy.sh`` onto a bare
+    ``python3``. The probe is functional on purpose — a venv passes via
+    ``pyvenv.cfg`` adjacency through the symlink, a base prefix passes via
+    its own site-packages, and anything else fails loud here instead of
+    thirty steps into the dry run.
     """
 
     for candidate in (Path(sys.prefix), REPO / ".venv"):
-        if (candidate / "pyvenv.cfg").is_file() and (candidate / "bin" / "python").exists():
+        python = candidate / "bin" / "python"
+        if not python.exists():
+            continue
+        probe = subprocess.run(
+            [str(python), "-c", "import dotenv, pydantic"],
+            capture_output=True,
+            check=False,
+        )
+        if probe.returncode == 0:
             return candidate
     pytest.fail(
-        "no usable virtualenv for the deploy dry-run sandbox; "
-        "run the suite from the project venv (make setup)"
+        "no interpreter prefix with the deploy tooling deps for the dry-run "
+        "sandbox; run the suite from the project venv (make setup)"
     )
 
 

--- a/tests/unit/test_deploy_dev_workflow_contract.py
+++ b/tests/unit/test_deploy_dev_workflow_contract.py
@@ -228,6 +228,25 @@ def _write_deploy_fixture(path: Path, text: str) -> None:
         )
 
 
+def _sandbox_venv_dir() -> Path:
+    """Locate a real virtualenv whose ``bin/python`` runs the deploy tooling.
+
+    Sandbox checkouts symlink ``.venv`` at this directory so ``deploy.sh``
+    resolves an interpreter that can import the repo's dependencies. The venv
+    running the suite comes first: ``REPO / ".venv"`` does not exist when the
+    suite runs from a worktree or a fresh clone, and a dangling symlink would
+    silently drop ``deploy.sh`` onto a bare ``python3``.
+    """
+
+    for candidate in (Path(sys.prefix), REPO / ".venv"):
+        if (candidate / "pyvenv.cfg").is_file() and (candidate / "bin" / "python").exists():
+            return candidate
+    pytest.fail(
+        "no usable virtualenv for the deploy dry-run sandbox; "
+        "run the suite from the project venv (make setup)"
+    )
+
+
 def test_sql_contract_scanner_rejects_commented_ddl_without_corrupting_literals() -> None:
     sql = """
     -- CREATE TABLE IF NOT EXISTS mip.gold.hidden_line (id INT);
@@ -4623,7 +4642,7 @@ def test_first_install_dry_run_executes_no_databricks_operations(
         cwd=checkout,
         check=True,
     )
-    (checkout / ".venv").symlink_to(REPO / ".venv", target_is_directory=True)
+    (checkout / ".venv").symlink_to(_sandbox_venv_dir(), target_is_directory=True)
     with (checkout / ".git" / "info" / "exclude").open("a", encoding="utf-8") as exclude:
         exclude.write(".venv\n")
     (checkout / ".env.local").write_text(
@@ -4708,6 +4727,32 @@ def test_first_install_dry_run_executes_no_databricks_operations(
     assert "would verify: campaign treatment table append-only" in result.stdout
     assert "would inspect/create: scope mip and write-once pii-salt-v1" in result.stdout
     assert "deploy Databricks App snapshot with Agent Evaluation proof" in result.stdout
+
+
+def test_deploy_fails_fast_when_python_lacks_repo_tooling_deps() -> None:
+    """A missing .venv must fail with remediation, not a mid-run traceback.
+
+    Without this gate, PYTHON silently falls back to a bare python3 and the
+    run (dry or real) dies at the App deploy payload emitter's dotenv import
+    dozens of steps in. The gate must follow the config validations whose
+    exact errors the sandbox tests above pin, and precede all planning.
+    """
+
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    guard = script.index("import dotenv, pydantic")
+    mask_gate = script.index("MIP_COTALITY_ID_MASK_SECRET is required for target")
+    oauth_gate = script.index(
+        "OAuth credential intent recovery and orphan-lease recovery are mutually exclusive"
+    )
+    m2m_gate = script.index("missing required per-run M2M credential(s)")
+    lease_root = script.index("tools.databricks.app_deployment_lease recovery-root")
+    assert mask_gate < oauth_gate < guard < m2m_gate < lease_root
+
+    guard_block = script[guard : script.index("\nfi\n", guard)]
+    assert "cannot import the deploy tooling baseline (python-dotenv + pydantic)" in guard_block
+    assert "make setup" in guard_block
+    assert "exit 2" in guard_block
 
 
 def test_deploy_dev_wires_separate_required_gateway_signing_keys() -> None:


### PR DESCRIPTION
## Root cause

`test_first_install_dry_run_executes_no_databricks_operations` fails on any checkout whose root has no `.venv` — a fresh clean clone, a git worktree, or after `git stash --all` (which stashes gitignored dirs including `.venv`). The test wires the sandbox interpreter as a symlink `checkout/.venv -> REPO/.venv`; when that target is absent the symlink dangles, `deploy.sh` silently falls back to bare `python3`, and the dry run crashes at step 32 — the first `$PYTHON` execution needing a third-party package (`tools/databricks/app_deploy_payload.py` imports `python-dotenv`).

Verified both directions: pristine clones of 7645de6d and b081031d with a root `.venv` pass; the same clone without one reproduces the exact reported failure. **No Databricks operation leaks into dry-run** (stub log stays `--version` only) and no assertion is stale — the contract itself is intact and unweakened.

## Fix

- **`scripts/deploy.sh`** — fail-fast guard: if `$PYTHON` cannot `import dotenv, pydantic`, exit 2 at step 1 with `make setup` remediation instead of a raw traceback dozens of steps in. Positioned after the config gates (action-secret, mask-secret, signing-key, OAuth-recovery) so their exact pinned errors keep precedence — the venv-less sandbox tests in the contract file exercise exactly that ordering.
- **Contract test** — `_sandbox_venv_dir()` resolves the sandbox venv from `sys.prefix` (the interpreter actually running the suite) with `REPO/.venv` as fallback, failing loud with remediation if neither is a real venv.
- **New pin** — `test_deploy_fails_fast_when_python_lacks_repo_tooling_deps` asserts the guard's position between the config gates and the first planning step, plus its message and exit code.

## Validation

- Target test: red → green from a worktree (no root `.venv`), green in pristine clones at 7645de6d and b081031d
- Full contract file: 203 passed
- Full `tests/unit`: exit 0
- `ruff check backend tests tools`: clean; `bash -n scripts/deploy.sh`: OK; shellcheck: no new findings
- Negative path (no venv): dry run now stops at step 1 with `[deploy] ERROR: python3 cannot import the deploy tooling baseline (python-dotenv + pydantic)` + remediation

🤖 Generated with [Claude Code](https://claude.com/claude-code)