### PR TITLE
feat(genie): live-first — Genie's own governed work is the answer; canonical demotes to rescue + cross-check

### DIFF
--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, NamedTuple
 
 from backend.config.settings import settings
 from backend.services.databricks_sql import DatabricksSqlClient, DatabricksSqlError
@@ -460,22 +460,29 @@ def _adapt_genie_response(
             or _pending_feed_gaps_from_rows(rows)
         )
     )
-    # Trusted SQL overlays are allowed to answer known grain-sensitive
-    # questions only when the live Genie turn is not unsafe. They must not
-    # mask untrusted SQL or pending-feed dependence. Text-only turns can
-    # still be answered through this explicit `trusted_sql` source so users see
-    # that the app used a governed canonical query rather than the raw Genie
-    # narrative. A narrative that trips the output text guard does NOT forfeit
-    # a recognized shape: the canonical answer replaces the model prose
-    # entirely (never renders it) and the withholding is disclosed in the
-    # proof, so a prose false positive degrades to a governed deterministic
-    # answer instead of a refusal.
+    # Live-first posture (2026-08-07, product decision): when the live Genie
+    # turn produced policy-trusted SQL, GENIE'S OWN work is the answer — its
+    # query, its rows, its narrative (still subject to the claims guard and
+    # the prose-withholding floor below). The reviewed canonical layer is a
+    # RESCUE for turns without trusted SQL proof (text-only, or stale-enum
+    # SQL the repair retry could not fix), never a replacement for a good
+    # live turn. Accuracy comes from curated data and a curated space; the
+    # deterministic layer verifies and rescues, it does not overwrite.
     unsafe_live_sql = bool(result.sql_query and not trusted_sql)
     stale_evidence_enum_only = bool(
         result.sql_query
         and _trusted_sql_policy_allowing_stale_evidence_enum(result.sql_query, trusted_assets)
     )
-    if (not unsafe_live_sql or stale_evidence_enum_only) and not depends_on_pending_feeds:
+    semantically_broken_sql = bool(
+        result.sql_query
+        and _sql_uses_impossible_retention_conjunction(question, result.sql_query)
+    )
+    canonical_rescue_eligible = (
+        lacks_trusted_proof
+        or (unsafe_live_sql and stale_evidence_enum_only)
+        or semantically_broken_sql
+    ) and not depends_on_pending_feeds
+    if canonical_rescue_eligible:
         canonical = _canonical_genie_answer(
             question=question,
             result=result,
@@ -484,9 +491,8 @@ def _adapt_genie_response(
         if canonical is not None:
             # Governance (re-executed counts, trusted-asset policy, proof,
             # visualization, actions, scrubbing) is done. Restore Genie's own
-            # narrative and live-intelligence fields so a recognized-shape turn
-            # is not flattened into canned phrasing with the live artifacts
-            # dropped.
+            # narrative and live-intelligence fields so a rescued turn is not
+            # flattened into canned phrasing with the live artifacts dropped.
             return _restore_live_voice(
                 canonical,
                 result,
@@ -537,6 +543,13 @@ def _adapt_genie_response(
     if result.sql_query and trusted_sql and not rows and sql_client is not None:
         rows = _redact_genie_rows(_execute_trusted_genie_sql(sql_client, result.sql_query))
     trace.execute(row_count=len(rows) if rows else 0, assets=trusted_assets)
+    # Governed cross-check (verification, never replacement): on recognized
+    # ranking/metric shapes, compare Genie's OWN result against the reviewed
+    # canonical framing and disclose material divergence. Genie's work stays
+    # the answer either way; only a metric that contradicts the governed
+    # unique-borrower definition additionally withholds the prose below.
+    cross = _governed_cross_check(question, rows, sql_client, trace)
+    cross_check_gaps = list(cross.gaps)
     # Trusted SQL is a floor, not a coin flip: from here the governed query,
     # rows, proof, and actions ALWAYS ship. Only the model PROSE is
     # conditionally withheld — when the output safety guard flags its wording,
@@ -545,7 +558,27 @@ def _adapt_genie_response(
     # numbers and guard-flagged prose still never render.
     prose_withheld_gap: str | None = None
     prose_withheld_reason: str | None = None
-    if text_contains_pii:
+    answer_override: str | None = None
+    if cross.count_reference is not None:
+        # Audit teeth (2026-07-08 lineage): a live metric whose grain
+        # contradicts the governed unique-borrower definition must not render
+        # as fact. Genie's query and rows still ship; the answer teaches the
+        # grain difference and cites the governed figure.
+        prose_withheld_gap = (
+            "Genie's draft narrative presented a count whose grain or scope differs "
+            "from the governed unique-borrower definition; the prose was "
+            "withheld and both governed framings are disclosed."
+        )
+        answer_override = (
+            f"The governed definition for this metric counts "
+            f"{cross.count_reference:,} — the canonical unique-borrower "
+            "grain, scoped exactly to the question, where a multi-segment "
+            "borrower counts once. Genie's live framing returned a different "
+            "figure; its query and rows are shown, and the difference comes "
+            "from counting grain or question scope, not data drift."
+        )
+        trace.narrative_withheld(reason=WITHHELD_CONTRADICTED)
+    elif text_contains_pii:
         prose_withheld_gap = (
             "Genie's draft narrative was withheld by the output safety guard; "
             "the governed query results are shown instead."
@@ -582,9 +615,14 @@ def _adapt_genie_response(
         elapsed_ms=result.elapsed_ms,
         reasoning_trace=[step.model_dump() for step in reasoning_trace],
     )
-    if prose_withheld_gap and prose_withheld_gap not in proof.known_data_gaps:
+    extra_gaps = [
+        gap
+        for gap in [prose_withheld_gap, *cross_check_gaps]
+        if gap and gap not in proof.known_data_gaps
+    ]
+    if extra_gaps:
         proof = proof.model_copy(
-            update={"known_data_gaps": [*proof.known_data_gaps, prose_withheld_gap]}
+            update={"known_data_gaps": [*proof.known_data_gaps, *extra_gaps]}
         )
     visualization = _plan_genie_visualization(question, rows)
     actions = _suggest_genie_actions(
@@ -597,10 +635,12 @@ def _adapt_genie_response(
         question_hash=question_hash,
         sql_query=result.sql_query,
     )
-    if prose_withheld_reason:
+    if answer_override is not None:
+        answer_text: str | None = answer_override
+    elif prose_withheld_reason:
         row_count = len(rows) if rows else 0
         row_word = "row" if row_count == 1 else "rows"
-        answer_text: str | None = (
+        answer_text = (
             f"Genie ran a governed query against {trusted_assets[0]} and returned "
             f"{row_count:,} {row_word}, shown with the generated SQL. The draft "
             f"narrative was withheld: {prose_withheld_reason}"
@@ -627,6 +667,120 @@ def _adapt_genie_response(
         reasoning_trace=reasoning_trace,
         genie_status=result.genie_status,
     )
+
+
+class _CrossCheckOutcome(NamedTuple):
+    gaps: list[str]
+    # Canonical unique-borrower count when the live metric materially
+    # diverges from the governed definition; None otherwise.
+    count_reference: int | None
+
+
+_CROSS_CHECK_CLEAN = _CrossCheckOutcome(gaps=[], count_reference=None)
+
+
+def _governed_cross_check(
+    question: str,
+    rows: list[dict[str, Any]] | None,
+    sql_client: DatabricksSqlClient | None,
+    trace: GenieProcessTrace,
+) -> _CrossCheckOutcome:
+    """Verify a trusted LIVE result against the governed canonical framing.
+
+    Verification, never replacement: Genie's own result remains the answer.
+    Adds a verify step to the trace and returns disclosure notes only when the
+    two governed framings materially diverge. Any warehouse error skips the
+    check silently — a failed verification must never degrade a good answer.
+    """
+
+    if sql_client is None or not rows:
+        return _CROSS_CHECK_CLEAN
+    try:
+        ranking_sql: str | None = None
+        params: dict[str, object] | None = None
+        if _canonical_top_borrowers_all_segments_scope(question):
+            ranking_sql = _CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL
+        else:
+            spec_state = _canonical_specific_top_borrowers_state_scope(question)
+            spec_global = _canonical_specific_top_borrowers_global_scope(question)
+            state_scope = _canonical_top_borrowers_state_scope(question)
+            if spec_state is not None:
+                intent, _state_name, state_code = spec_state
+                ranking_sql = _CANONICAL_TOP_BORROWERS_BY_STATE_INTENT_SQL[intent]
+                params = {"state": state_code}
+            elif spec_global is not None:
+                ranking_sql = _CANONICAL_TOP_BORROWERS_GLOBAL_INTENT_SQL[spec_global]
+            elif state_scope is not None:
+                ranking_sql = _CANONICAL_TOP_BORROWERS_BY_STATE_SQL
+                params = {"state": state_scope[1]}
+            elif _canonical_top_borrowers_global_scope(question):
+                ranking_sql = _CANONICAL_TOP_BORROWERS_GLOBAL_SQL
+        if ranking_sql is not None:
+            live_ids = [str(r.get("borrower_id") or "") for r in rows if r.get("borrower_id")]
+            if not live_ids:
+                return _CROSS_CHECK_CLEAN
+            canonical_rows = sql_client.execute(ranking_sql, params) or []
+            canonical_ids = [
+                str(r.get("borrower_id") or "") for r in canonical_rows if r.get("borrower_id")
+            ]
+            if not canonical_ids:
+                return _CROSS_CHECK_CLEAN
+            top_n = min(len(live_ids), len(canonical_ids), 10)
+            overlap = len(set(live_ids[:top_n]) & set(canonical_ids[:top_n]))
+            trace.cross_check_ranking(overlap=overlap, total=top_n)
+            if overlap * 2 < top_n:
+                return _CrossCheckOutcome(
+                    gaps=[
+                        "Governed cross-check: this answer's framing overlaps "
+                        f"{overlap} of {top_n} borrowers with the canonical "
+                        "opportunity ranking; both are governed views — the "
+                        "Lead Queue holds the operational list."
+                    ],
+                    count_reference=None,
+                )
+            return _CROSS_CHECK_CLEAN
+        count_scope = _canonical_in_the_money_count_scope(question)
+        city_scope = None if count_scope else _canonical_itm_city_scope(question)
+        if count_scope or city_scope:
+            if city_scope:
+                count_sql = _CANONICAL_ITM_COUNT_BY_CITY_SQL
+                count_params: dict[str, object] | None = {"city": city_scope}
+            else:
+                count_state = count_scope if isinstance(count_scope, tuple) else None
+                count_sql = (
+                    _CANONICAL_ITM_COUNT_BY_STATE_SQL if count_state else _CANONICAL_ITM_COUNT_SQL
+                )
+                count_params = {"state": count_state[1]} if count_state else None
+            row = sql_client.execute_one(count_sql, count_params) or {}
+            canonical_count = row.get("in_the_money_borrowers")
+            if canonical_count is None:
+                return _CROSS_CHECK_CLEAN
+            canonical_f = float(canonical_count)
+            live_values: list[float] = []
+            for live_row in rows:
+                for value in live_row.values():
+                    try:
+                        live_values.append(float(value))
+                    except (TypeError, ValueError):
+                        continue
+            if not live_values:
+                return _CROSS_CHECK_CLEAN
+            tolerance = max(1.0, 0.01 * canonical_f)
+            consistent = any(abs(value - canonical_f) <= tolerance for value in live_values)
+            trace.cross_check_count(consistent=consistent)
+            if not consistent:
+                return _CrossCheckOutcome(
+                    gaps=[
+                        "Governed cross-check: the canonical unique-borrower "
+                        f"recomputation returns {int(canonical_f):,} for this "
+                        "metric; the live framing differs — compare both "
+                        "governed queries in the proof."
+                    ],
+                    count_reference=int(canonical_f),
+                )
+    except DatabricksSqlError:
+        return _CROSS_CHECK_CLEAN
+    return _CROSS_CHECK_CLEAN
 
 
 def _ensure_answer_cites_source(answer: str | None, trusted_assets: list[str]) -> str:

--- a/backend/services/repositories/databricks_genie_trace.py
+++ b/backend/services/repositories/databricks_genie_trace.py
@@ -186,6 +186,40 @@ class GenieProcessTrace:
             "Composed the per-candidate analyst brief from governed row values.",
         )
 
+    def cross_check_ranking(self, *, overlap: int, total: int) -> None:
+        """Record the governed ranking cross-check verdict (verification, not
+        replacement: Genie's own result always remains the answer)."""
+
+        overlap_n = max(int(overlap), 0)
+        total_n = max(int(total), 1)
+        if overlap_n >= total_n:
+            self._add(
+                "verify",
+                "Governed cross-check: matches the canonical opportunity ranking.",
+            )
+        else:
+            self._add(
+                "verify",
+                f"Governed cross-check: overlaps {overlap_n} of {total_n} rows "
+                "with the canonical opportunity ranking; framings differ, both "
+                "are governed.",
+            )
+
+    def cross_check_count(self, *, consistent: bool) -> None:
+        if consistent:
+            self._add(
+                "verify",
+                "Governed cross-check: the metric matches the canonical "
+                "unique-borrower recomputation.",
+            )
+        else:
+            self._add(
+                "verify",
+                "Governed cross-check: the metric differs from the canonical "
+                "unique-borrower recomputation; see the proof drawer for both "
+                "framings.",
+            )
+
     # -- rendering ----------------------------------------------------
 
     def steps(

--- a/genie/mortgage_lead_intelligence_space.yml
+++ b/genie/mortgage_lead_intelligence_space.yml
@@ -178,6 +178,15 @@ instructions: |
       generate an executable SELECT over the trusted assets, do not provide a
       numeric or strategic answer; say you cannot produce a governed SQL
       answer for that question and cite the closest trusted asset or data gap.
+    - Default ranking policy: when asked for "top borrowers" or "top
+      candidates" without an explicit metric, rank marketing-eligible,
+      opt-in borrowers by opportunity_score, then rate_spread_bps, then
+      borrower_id — the same order the Lead Queue uses — and say so in the
+      narrative. Use a different ordering only when the user names one.
+    - Choose the most specific trusted asset for the question: metric views
+      for aggregates, funnel_snapshot_daily for trends over time,
+      lockin_cohort for loan-vintage questions, evidence_events for trigger
+      timelines, borrower_360/lead_population for borrower-level detail.
     - For top-N and ranking questions, make the narrative a per-row analysis:
       for each returned borrower cite its drivers from the result columns
       (rate spread, equity, listing, related-property count, retention, and

--- a/tests/unit/test_genie_no_refusal_battery.py
+++ b/tests/unit/test_genie_no_refusal_battery.py
@@ -129,3 +129,51 @@ def test_fair_lending_asks_refuse_with_the_protected_class_reason() -> None:
     assert identity_prompt_match(age_proxy) is False
     assert protected_prompt_match("Target Hispanic neighborhoods with this offer.") is not None
     assert protected_prompt_match("Focus outreach on elderly borrowers.") is not None
+
+
+def test_flagship_trusted_turn_is_live_first_with_cross_check() -> None:
+    """The product's central promise, restated as a pin: when live Genie does
+    the work well (trusted SQL, self-consistent narrative), GENIE's work is
+    the answer — no canonical override — and the governed cross-check runs as
+    verification in the process trace."""
+
+    live = GenieResponse(
+        answer_text="Top candidates ranked by opportunity score.",
+        sql_query=(
+            "SELECT borrower_id, opportunity_score, rate_spread_bps, equity_pct, "
+            "recommended_offer, why_now FROM mip.gold.borrower_360 "
+            "WHERE marketing_eligible = TRUE AND consent_status = 'opt_in' "
+            "ORDER BY opportunity_score DESC, rate_spread_bps DESC LIMIT 10"
+        ),
+        sql_result_rows=[
+            {"borrower_id": f"B-{i:013d}", "opportunity_score": 90 - i}
+            for i in range(10)
+        ],
+        conversation_id="conv-flagship",
+        message_id="msg-flagship",
+    )
+
+    class _Sql:
+        def __init__(self) -> None:
+            self.statements: list[str] = []
+
+        def execute(self, statement: str, parameters: object = None) -> list[dict[str, object]]:
+            self.statements.append(statement)
+            return [{"borrower_id": f"B-{i:013d}"} for i in range(10)]
+
+        def execute_one(self, statement: str, parameters: object = None) -> dict[str, object]:
+            self.statements.append(statement)
+            return {}
+
+    result = _adapt_genie_response(
+        VALID_ANALYTICAL_QUESTIONS[0],
+        live,
+        sql_client=_Sql(),  # type: ignore[arg-type]
+    )
+
+    assert result.source == "genie"
+    assert result.sql_query == live.sql_query
+    assert result.answer.startswith("Top candidates ranked by opportunity score.")
+    assert any(
+        "Governed cross-check" in step.content for step in result.reasoning_trace
+    )

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -3066,28 +3066,23 @@ def test_in_the_money_count_uses_canonical_gold_grain() -> None:
 
     result = repo.respond("How many borrowers are currently in-the-money?")
 
-    assert result.source == "trusted_sql"
-    # Trust boundary (external audit 2026-07-08): the model's 277,139 claim
-    # CONTRADICTS the governed recomputation (147,742), so the verified
-    # deterministic statement leads and the wrong figure never appears in the
-    # answer. The discrepancy is disclosed as a proof gap, not shown as fact.
+    # Live-first with teeth (2026-08-07): Genie's own trusted query and rows
+    # ship, but the audited trust boundary holds — a metric whose grain
+    # contradicts the governed unique-borrower recomputation (147,742) never
+    # renders as fact. The answer teaches the grain and cites the governed
+    # figure; the wrong 277,139 appears only as row data under its own query.
+    assert result.source == "genie"
     assert "277,139" not in result.answer
     assert "147,742" in result.answer
     assert result.proof is not None
-    assert any("unsupported prose was removed" in gap for gap in result.proof.known_data_gaps)
+    assert any("grain or scope" in gap for gap in result.proof.known_data_gaps)
     assert all("277,139" not in gap for gap in result.proof.known_data_gaps)
-    assert result.table_rows == [
-        {
-            "in_the_money_borrowers": 147742,
-            "refreshed_at": "2026-05-04T22:08:34.662Z",
-        }
-    ]
-    assert result.metric_value == "147,742"
+    assert result.table_rows == [{"borrowers": 277139}]
+    assert result.metric_value is None
     assert result.sql_query == (
-        "SELECT COUNT(*) AS in_the_money_borrowers\n"
-        "     , MAX(refreshed_at) AS refreshed_at\n"
-        "FROM mip.gold.borrower_360\n"
-        "WHERE in_the_money = TRUE"
+        "SELECT COUNT(*) AS borrowers "
+        "FROM mip.semantics.borrower_opportunity_metric_view "
+        "WHERE in_the_money = true"
     )
 
 
@@ -3287,25 +3282,19 @@ def test_in_the_money_count_applies_state_scope_when_present() -> None:
 
     result = repo.respond("How many borrowers in Illinois are in the money?")
 
-    # The model's all-footprint 277,139 contradicts the state-scoped verified
-    # count: the governed figure leads, the wrong figure is disclosed as a gap.
+    # Live-first with teeth: the mis-scoped all-footprint figure never renders
+    # as fact; the state-scoped governed count is taught instead. Genie's own
+    # query and rows still ship.
+    assert result.source == "genie"
     assert "277,139" not in result.answer
     assert "70,939" in result.answer
     assert result.proof is not None
-    assert any("unsupported prose was removed" in gap for gap in result.proof.known_data_gaps)
-    assert result.table_rows == [
-        {
-            "in_the_money_borrowers": 70939,
-            "refreshed_at": "2026-05-04T22:08:34.662Z",
-            "state": "IL",
-        }
-    ]
+    assert any("grain or scope" in gap for gap in result.proof.known_data_gaps)
+    assert result.table_rows == [{"borrowers": 277139}]
     assert result.sql_query == (
-        "SELECT COUNT(*) AS in_the_money_borrowers\n"
-        "     , MAX(refreshed_at) AS refreshed_at\n"
-        "FROM mip.gold.borrower_360\n"
-        "WHERE in_the_money = TRUE\n"
-        "  AND state = :state"
+        "SELECT COUNT(*) AS borrowers "
+        "FROM mip.semantics.borrower_opportunity_metric_view "
+        "WHERE in_the_money = true"
     )
     assert sql.parameters == [{"state": "IL"}]
 
@@ -3331,9 +3320,12 @@ def test_in_the_money_count_applies_lowercase_ambiguous_state_code_when_contextu
 
     result = repo.respond("How many borrowers in ok are in the money?")
 
-    assert result.sql_query is not None
-    assert "AND state = :state" in result.sql_query
+    # Live-first: Genie's own consistent count ships; the contextual "ok" ->
+    # OK disambiguation now drives the governed cross-check scoping.
+    assert result.source == "genie"
     assert sql.parameters == [{"state": "OK"}]
+    assert result.proof is not None
+    assert not any("grain or scope" in gap for gap in result.proof.known_data_gaps)
 
 
 def test_in_the_money_count_does_not_scope_common_words_as_state_codes() -> None:
@@ -3397,26 +3389,17 @@ def test_in_the_money_count_applies_city_scope_when_present(
 
     result = repo.respond(question)
 
-    # Unsupported all-footprint claims are removed regardless of their
-    # magnitude relative to the governed city-scoped count.
+    # Live-first with teeth: the mis-scoped all-footprint figure never
+    # renders as fact; the governed city-scoped count is taught instead while
+    # Genie's own query and rows still ship.
+    assert result.source == "genie"
     assert "147,742" not in result.answer
     assert f"{count:,}" in result.answer
     assert result.proof is not None
-    assert any("unsupported prose was removed" in gap for gap in result.proof.known_data_gaps)
-    assert result.table_rows == [
-        {
-            "city": city,
-            "in_the_money_borrowers": count,
-            "refreshed_at": "2026-05-04T22:08:34.662Z",
-        }
-    ]
-    assert result.sql_query == (
-        "SELECT COUNT(*) AS in_the_money_borrowers\n"
-        "     , MAX(refreshed_at) AS refreshed_at\n"
-        "FROM mip.gold.borrower_360\n"
-        "WHERE in_the_money = TRUE\n"
-        "  AND LOWER(city) = LOWER(:city)"
-    )
+    assert any("grain or scope" in gap for gap in result.proof.known_data_gaps)
+    assert result.table_rows == [{"borrowers": 147742}]
+    assert result.sql_query is not None
+    assert "LOWER(city)" not in result.sql_query
     assert sql.parameters == [{"city": city}]
 
 
@@ -3822,25 +3805,26 @@ def test_recognized_shape_live_turn_preserves_genie_voice_and_live_fields() -> N
         sql_client=sql,  # type: ignore[arg-type]
     )
 
-    assert result.source == "trusted_sql"
-    # Genie's own narrative leads (not replaced by canned template phrasing).
+    # Live-first: Genie's own consistent turn IS the answer.
+    assert result.source == "genie"
     assert result.answer.startswith("There are roughly 147,742 borrowers in the money right now.")
-    # Live-intelligence fields carried through exactly like the generic path.
     assert result.genie_status == "COMPLETED"
     # The process summary describes what the governed pipeline actually did,
-    # with one distinct step per stage -- not four repeats of a generic phrase.
+    # with one distinct step per stage: the governed cross-check verifies the
+    # metric and the narrative verification follows -- no canonical override.
     assert [step.kind for step in result.reasoning_trace] == [
         "guardrails",
         "live",
         "trust",
-        "canonical",
         "execute",
+        "verify",
         "verify",
     ]
     contents = [step.content for step in result.reasoning_trace]
     assert len(set(contents)) == len(contents)
     assert "mip.gold.borrower_360" in contents[1]
-    assert "Returned 1 row from mip.gold.borrower_360" in contents[4]
+    assert "Returned 1 row from mip.gold.borrower_360" in contents[3]
+    assert any("Governed cross-check" in c and "matches" in c for c in contents)
     assert result.proof is not None
     assert [step.model_dump() for step in result.proof.reasoning_trace] == [
         step.model_dump() for step in result.reasoning_trace
@@ -3848,8 +3832,7 @@ def test_recognized_shape_live_turn_preserves_genie_voice_and_live_fields() -> N
     assert result.native_visualization is not None
     assert result.native_visualization.attachment_id == "att-1"
     assert result.follow_up_questions == ["Which ZIPs lead on refinance savings?"]
-    # Governance preserved: the re-executed gold-grain count.
-    assert result.metric_value == "147,742"
+    assert result.metric_value is None
 
 
 def test_live_reasoning_omits_title_lowercase_and_uppercase_identity_shapes() -> None:
@@ -3967,11 +3950,16 @@ def test_recognized_shape_verification_note_appends_not_replaces() -> None:
         sql_client=sql,  # type: ignore[arg-type]
     )
 
-    # Agreeing figures: Genie's own narrative remains AND the verified
-    # gold-grain figure is appended after it.
+    # Live-first: agreeing figures mean Genie's own narrative ships as the
+    # answer, and verification is recorded as the consistent governed
+    # cross-check in the process trace instead of an appended note.
+    assert result.source == "genie"
     assert result.answer.startswith("There are about 147,742 borrowers in the money.")
-    assert "Verified against mip.gold.borrower_360: 147,742" in result.answer
-    assert result.answer.index("about 147,742") < result.answer.index("Verified against")
+    assert "Verified against" not in result.answer
+    assert any(
+        "Governed cross-check" in step.content and "matches" in step.content
+        for step in result.reasoning_trace
+    )
 
 
 def test_recognized_shape_strips_entire_narrative_when_any_financial_claim_is_unsupported() -> None:
@@ -3995,12 +3983,15 @@ def test_recognized_shape_strips_entire_narrative_when_any_financial_claim_is_un
         ),  # type: ignore[arg-type]
     )
 
-    assert result.source == "trusted_sql"
-    assert "147,742" in result.answer
+    assert result.source == "genie"
     assert "$999,999" not in result.answer
     assert "7.25%" not in result.answer
+    assert "withheld" in result.answer
     assert result.proof is not None
-    assert any("unsupported prose was removed" in gap for gap in result.proof.known_data_gaps)
+    assert any(
+        "could not be verified against the returned rows" in gap
+        for gap in result.proof.known_data_gaps
+    )
 
 
 def test_recognized_shape_empty_narrative_falls_back_with_honest_gap() -> None:
@@ -4023,12 +4014,13 @@ def test_recognized_shape_empty_narrative_falls_back_with_honest_gap() -> None:
         sql_client=sql,  # type: ignore[arg-type]
     )
 
-    assert result.source == "trusted_sql"
-    # No usable narrative even after repair -> precise deterministic summary,
-    # disclosed honestly in the proof gap notes.
+    assert result.source == "genie"
+    # Live-first with teeth: the empty narrative plus a grain-divergent count
+    # produces the teaching answer citing the governed figure, with Genie's
+    # own query and rows still shipping.
     assert "147,742" in result.answer
     assert result.proof is not None
-    assert any("Genie returned no narrative" in gap for gap in result.proof.known_data_gaps)
+    assert any("grain or scope" in gap for gap in result.proof.known_data_gaps)
 
 
 def test_contradiction_detector_zero_claim_and_identifier_guard() -> None:

--- a/tests/unit/test_genie_retention_risk.py
+++ b/tests/unit/test_genie_retention_risk.py
@@ -246,26 +246,17 @@ def test_genie_retention_list_uses_canonical_row_lookup_not_count_metric() -> No
 
     response = _adapt_genie_response(question, result, sql_client=_SqlClient())  # type: ignore[arg-type]
 
-    assert response.source == "trusted_sql"
+    # Live-first: Genie chose the correct governed signal enum and a row
+    # lookup on its own — its query, rows, and narrative ship as the answer.
+    assert response.source == "genie"
     assert "COUNT(*) AS retention_risk_borrowers" not in (response.sql_query or "")
     assert "e.signal_type = 'competitor_lien'" in (response.sql_query or "")
     assert "e.signal_type = 'lien-change'" not in (response.sql_query or "")
     assert response.table_rows == [
-        {
-            "borrower_id": "B-102FL7THC6Q3L",
-            "city": "Calumet City",
-            "state": "IL",
-            "recommended_offer_code": "retention",
-            "opportunity_score": 88,
-            "latest_competitor_lien_at": "2026-05-09T00:00:00Z",
-            "total_matching_borrowers": 304,
-        }
+        {"borrower_id": "B-102FL7THC6Q3L", "signal_type": "competitor_lien"}
     ]
-    assert response.metric_value == "304"
-    # Voice-first: Genie's narrative leads; the verified total is appended.
+    assert response.metric_value is None
     assert response.answer.startswith("Rows.")
-    assert "Verified against" in response.answer
-    assert "304" in response.answer
 
 
 def test_genie_retention_list_uses_canonical_competitor_lien_signal() -> None:


### PR DESCRIPTION
Product-owner direction: accuracy must come from curated data and a
curated space, not from a deterministic overlay. Previously the
canonical layer hijacked recognized shapes even when live Genie
produced policy-trusted SQL — which is also why every flagship answer
cited borrower_360 regardless of what Genie chose.

- Trusted live turns now SHIP GENIE'S OWN query, rows, and narrative
  (claims guard and prose-withholding floor unchanged). The canonical
  layer fires only as rescue: no trusted SQL proof, stale-enum SQL the
  repair could not fix, or the audited impossible retention conjunction.
- New governed CROSS-CHECK on recognized ranking/metric shapes:
  verification, never replacement. Rankings compare top-10 membership
  and disclose divergence in the trace and proof; a metric whose grain
  or scope contradicts the governed unique-borrower recomputation keeps
  its audited teeth — Genie's query and rows still ship, but the wrong
  figure never renders as fact and the answer teaches the grain with
  the governed number (external-audit 2026-07-08 lineage preserved).
- Space curation replaces overlay force: the YAML now teaches the
  default ranking policy (score, then spread, eligible + opt-in — the
  Lead Queue's order) and most-specific-asset selection, so Genie's
  independent answers align with the product by shared definition.
- 24 tests re-pinned from hijack expectations to live-first + teeth;
  flagship live-first behavior pinned in the no-refusal battery.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
