### PR TITLE
fix(lakebase): fail fast when deployed schema/seed revisions mix

### DIFF
--- a/jobs/lakebase_migrate.py
+++ b/jobs/lakebase_migrate.py
@@ -213,8 +213,11 @@ from jobs.lakebase_migration_schema_hooks import (
 from jobs.lakebase_migration_schema_hooks import (
     _schema_hook_function_calls as _schema_hook_function_calls,
 )
-from jobs.lakebase_migration_seed import _sql_literal as _sql_literal
 from jobs.lakebase_migration_seed import (  # noqa: E402
+    _preflight_seed_schema_parity as _preflight_seed_schema_parity,
+)
+from jobs.lakebase_migration_seed import _sql_literal as _sql_literal
+from jobs.lakebase_migration_seed import (
     _tenant_disclosure_seed_sql as _tenant_disclosure_seed_sql,
 )
 from jobs.lakebase_migration_transaction import (  # noqa: E402
@@ -389,6 +392,11 @@ def main(
     repo_root = _repo_root()
     schema_sql = (repo_root / "lakebase" / "schema.sql").read_text(encoding="utf-8")
     seed_sql = (repo_root / "lakebase" / "seed_campaigns.sql").read_text(encoding="utf-8")
+    try:
+        _preflight_seed_schema_parity(schema_sql, seed_sql)
+    except Exception as exc:  # noqa: BLE001 -- static repo-authored diagnostic; no secrets
+        print(f"[lakebase-migrate] {exc}", file=sys.stderr)
+        sys.exit(2)
     tenant_disclosure_seed_sql = _tenant_disclosure_seed_sql(
         lender_name=lender_name,
         lender_nmls_id=lender_nmls_id,

--- a/jobs/lakebase_migration_seed.py
+++ b/jobs/lakebase_migration_seed.py
@@ -1,13 +1,49 @@
-"""Configured lender disclosure seed rendering."""
+"""Configured lender disclosure seed rendering and schema/seed parity preflight."""
 
 from __future__ import annotations
 
 import hashlib
+import re
 
 from backend.schemas.lender_identity import (
     effective_public_tenant_id,
     validate_public_lender_identity,
 )
+
+_ACTIVE_REQUIRES_READY_CONSTRAINT = "campaigns_active_requires_ready_treatment_chk"
+_CAMPAIGN_SEED_INSERT_RE = re.compile(r"INSERT INTO mip_app\.campaigns\b.*?;", re.DOTALL)
+
+
+def _preflight_seed_schema_parity(schema_sql: str, seed_sql: str) -> None:
+    """Reject schema/seed texts that cannot replay together, before any mutation.
+
+    File-level delta ships can leave the deployed tree mixed: a schema.sql that
+    enforces treatment readiness next to an older seed_campaigns.sql that still
+    inserts pre-treatment campaigns as ``'active'``. Postgres validates the
+    proposed insert tuple against table CHECK constraints before ON CONFLICT
+    arbitration, so that mix aborts mid-transaction with a bare constraint
+    violation minutes into the run. Fail here instead with a remediation path.
+    """
+
+    if _ACTIVE_REQUIRES_READY_CONSTRAINT not in schema_sql:
+        return
+    campaign_inserts = _CAMPAIGN_SEED_INSERT_RE.findall(seed_sql)
+    if not campaign_inserts:
+        raise RuntimeError(
+            "lakebase/seed_campaigns.sql contains no mip_app.campaigns seed; "
+            "re-ship lakebase/schema.sql and lakebase/seed_campaigns.sql from "
+            "the same revision, then re-run the migration"
+        )
+    for statement in campaign_inserts:
+        if "'active'" in statement:
+            raise RuntimeError(
+                "lakebase/seed_campaigns.sql still seeds pre-treatment campaigns "
+                f"as active, but lakebase/schema.sql enforces "
+                f"{_ACTIVE_REQUIRES_READY_CONSTRAINT}; the deployed tree mixes "
+                "revisions -- re-ship lakebase/schema.sql and "
+                "lakebase/seed_campaigns.sql from the same commit, then re-run "
+                "the migration"
+            )
 
 
 def _sql_literal(value: str) -> str:

--- a/tests/unit/test_campaign_treatment_contracts.py
+++ b/tests/unit/test_campaign_treatment_contracts.py
@@ -155,6 +155,7 @@ def test_lakebase_manifest_is_ready_only_after_fenced_finalize() -> None:
         LAKEBASE_SCHEMA
     )
     assert "'archived'" in SEED
+    assert "'active'" not in SEED
     assert "status = EXCLUDED.status" in SEED
     assert "WHERE campaigns.treatment_state = 'legacy_unbound'" in SEED
 

--- a/tests/unit/test_lakebase_schema_immutability.py
+++ b/tests/unit/test_lakebase_schema_immutability.py
@@ -82,6 +82,31 @@ def test_seed_precedes_legacy_proof_backfill_and_hard_validation() -> None:
     assert "CREATE TRIGGER trg_generated_outreach_drafts_immutable" in post_seed
 
 
+def test_seed_schema_parity_preflight_blocks_mixed_revision_trees() -> None:
+    from jobs import lakebase_migrate
+
+    # The repo's own schema + seed must replay together in one transaction.
+    lakebase_migrate._preflight_seed_schema_parity(_SCHEMA, _SEED)
+
+    # A stale seed blob (pre-treatment campaigns still seeded as active) next
+    # to the current schema is the delta-ship skew that broke the migrate job
+    # on 2026-08-07; the preflight must refuse it before any mutation.
+    stale_seed = _SEED.replace("'archived',", "'active',")
+    assert stale_seed != _SEED
+    with pytest.raises(RuntimeError, match="same commit"):
+        lakebase_migrate._preflight_seed_schema_parity(_SCHEMA, stale_seed)
+
+    # A seed with no campaigns insert at all is a truncated or foreign text.
+    with pytest.raises(RuntimeError, match="same revision"):
+        lakebase_migrate._preflight_seed_schema_parity(
+            _SCHEMA, "SET search_path TO mip_app, public;"
+        )
+
+    # Pre-constraint schemas accept either seed generation.
+    legacy_schema = _SCHEMA.replace("campaigns_active_requires_ready_treatment_chk", "")
+    lakebase_migrate._preflight_seed_schema_parity(legacy_schema, stale_seed)
+
+
 def test_campaign_json_shape_checks_are_post_seed_not_valid_and_deploy_probed() -> None:
     from jobs import lakebase_migrate
 


### PR DESCRIPTION
## Why

The 2026-08-07 `[dev skyler] mip_lakebase_migrate` run (job 897446441064360, run 823105467797045) failed in `apply_schema_and_seed`:

```
new row for relation "campaigns" violates check constraint "campaigns_active_requires_ready_treatment_chk"
DETAIL: Failing row contains (11111111-1111-4111-8111-111111111111, …, active, …, legacy_unbound, …)
```

Root cause is **deployed-tree revision skew, not the repo seed**: `dev/files/lakebase/schema.sql` on paychex is at current main (enforces the treatment-readiness constraint pre-seed), but `dev/files/lakebase/seed_campaigns.sql` was still the pre-`0330dde5` blob (`513aad7e`) that seeds the three Summit campaigns as `'active'`. Postgres validates the proposed insert tuple against CHECK constraints **before** ON CONFLICT arbitration, so the stale seed aborts mid-transaction even though its ON CONFLICT update path would have been harmless. The failing row's `created_at` (`now() - interval '7 days'` at run time) proves it was the proposed insert tuple, not a stored row.

The repo seed has been correct ('archived' + legacy-guarded upsert) since 0330dde5; delta-shipping it to `dev/files` unblocks the job. This PR closes the failure class.

## What

- **`jobs/lakebase_migration_seed.py`**: add `_preflight_seed_schema_parity(schema_sql, seed_sql)` — refuses to start the migration when the schema text enforces `campaigns_active_requires_ready_treatment_chk` but the seed text still inserts campaigns with a quoted `'active'` status (or has no campaigns insert at all), with a re-ship-both-files remediation message. Runs before any database mutation.
- **`jobs/lakebase_migrate.py`**: wire the preflight between reading the SQL texts and `_run_transaction`, exiting 2 with the sanitized-diagnostic style used by the other preflights.
- **`tests/unit/test_lakebase_schema_immutability.py`**: cover repo parity, the exact 2026-08-07 stale-seed skew, truncated seed text, and pre-constraint schemas.
- **`tests/unit/test_campaign_treatment_contracts.py`**: pin `"'active'" not in SEED` so a campaign row can never reintroduce the restricted status literal.

## Validation

- `pytest tests/unit` green (includes the merged PR #139 interpreter preflight; full suite exit 0)
- `ruff check backend tests tools jobs` clean
- Post-merge: delta-ship `lakebase/seed_campaigns.sql` + the two `jobs/` files to paychex `dev/files` and re-run job 897446441064360 (validation run tracked in session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)