### PR TITLE
fix(lakebase): review pg_column_size so migrate re-runs survive d9e5cf44

### DIFF
--- a/jobs/lakebase_migration_contracts.py
+++ b/jobs/lakebase_migration_contracts.py
@@ -466,6 +466,9 @@ _SAFE_SCHEMA_HOOK_FUNCTION_NAMES = frozenset(
         "now",
         "nullif",
         "or",
+        # Storage-size measurement only (genie_messages response budget check);
+        # no I/O, settings, or side effects -- same review class as length().
+        "pg_column_size",
     }
     | {
         name

--- a/tests/unit/test_lakebase_schema_immutability.py
+++ b/tests/unit/test_lakebase_schema_immutability.py
@@ -82,6 +82,52 @@ def test_seed_precedes_legacy_proof_backfill_and_hard_validation() -> None:
     assert "CREATE TRIGGER trg_generated_outreach_drafts_immutable" in post_seed
 
 
+def test_every_check_constraint_function_call_is_reviewed_for_replay() -> None:
+    """Every builtin a schema CHECK expression calls must pass the hook preflight.
+
+    The executable-hook inventory only sees a constraint once it exists in the
+    live catalog -- i.e. on the run AFTER the one that created it. A constraint
+    calling an unreviewed function therefore passes fresh installs and CI, then
+    breaks every subsequent migrate re-run (d9e5cf44's pg_column_size check
+    took down mip_lakebase_migrate on 2026-08-07 exactly this way).
+    """
+
+    from jobs.lakebase_migration_contracts import _SAFE_SCHEMA_HOOK_FUNCTION_NAMES
+    from jobs.lakebase_migration_schema_hooks import _schema_hook_function_calls
+
+    expressions: list[tuple[str, str]] = []
+    for match in re.finditer(r"ADD CONSTRAINT\s+([a-z0-9_]+)\s+CHECK\s*\(", _SCHEMA):
+        depth, start = 1, match.end()
+        position = start
+        while depth and position < len(_SCHEMA):
+            if _SCHEMA[position] == "(":
+                depth += 1
+            elif _SCHEMA[position] == ")":
+                depth -= 1
+            position += 1
+        expressions.append((match.group(1), _SCHEMA[start : position - 1]))
+    assert expressions, "schema.sql lost its ADD CONSTRAINT ... CHECK statements"
+
+    # Source-only spellings the live inventory can never report: the catalog
+    # renders `x IN (...)` as `x = ANY (ARRAY[...])`, and `any` is reviewed.
+    source_only_spellings = {"in"}
+    unreviewed = sorted(
+        (name, tuple(sorted(unknown)))
+        for name, expression in expressions
+        if (
+            unknown := _schema_hook_function_calls(expression)
+            - _SAFE_SCHEMA_HOOK_FUNCTION_NAMES
+            - source_only_spellings
+        )
+    )
+    assert not unreviewed, (
+        "schema.sql CHECK constraints call functions missing from "
+        f"_SAFE_SCHEMA_HOOK_FUNCTION_NAMES; the NEXT migrate re-run will fail "
+        f"its executable-hook preflight: {unreviewed}"
+    )
+    assert "pg_column_size" in _SAFE_SCHEMA_HOOK_FUNCTION_NAMES
+
+
 def test_seed_schema_parity_preflight_blocks_mixed_revision_trees() -> None:
     from jobs import lakebase_migrate
 


### PR DESCRIPTION
## Why

After PR #141's parity preflight cleared the stale-seed skew, re-running `mip_lakebase_migrate` on paychex (job 897446441064360) surfaced a second, independent failure — this time a genuine repo bug:

```
Lakebase schema preflight executable-hook inventory mismatch: unexpected=[('unreviewed_function_call',
'constraint_expression', 'mip_app', 'genie_messages', 'genie_messages_response_json_size_chk',
'CHECK (response_json IS NULL OR pg_column_size(response_json) <= 1048576)', ['pg_column_size'])]
```

d9e5cf44 added that constraint to schema.sql without adding `pg_column_size` to the reviewed-builtin allowlist. The executable-hook preflight inventories the **live catalog before applying**, so the run that creates the constraint passes, and every later re-run fails. Fresh-install CI can never catch this class; the paychex roll-forward did.

## What

- `jobs/lakebase_migration_contracts.py`: add `pg_column_size` to `_SAFE_SCHEMA_HOOK_FUNCTION_NAMES` — pure storage-size measurement, no I/O or settings access, same review class as `length()`.
- `tests/unit/test_lakebase_schema_immutability.py`: new `test_every_check_constraint_function_call_is_reviewed_for_replay` — extracts every function call from schema.sql `ADD CONSTRAINT … CHECK` expressions using the production `_schema_hook_function_calls` extractor and requires each to be in the reviewed set (source-only `IN(…)` spelling excluded; the catalog renders it `= ANY(ARRAY[…])`). Kills the whole passes-once-breaks-forever fossil class at commit time.

## Validation

- Rollback-only replay of the full migration transaction against the live paychex `mip-app-state` database: every preflight, all four SQL chunks (pre-seed schema, seed, disclosures, post-seed), the outreach integrity probe, every postflight, **plus a post-apply re-run of the executable-hook preflight on a fresh-session search_path** (simulating the next run) — ALL PASSED, then rolled back.
- `pytest tests/unit/test_lakebase_schema_immutability.py tests/unit/test_campaign_treatment_contracts.py tests/unit/test_lakebase_migrate_grants.py tests/unit/test_lakebase_bootstrap.py` → 247 passed.
- `ruff check jobs tests` clean.
- Post-merge: delta-ship `jobs/lakebase_migration_contracts.py` to paychex `dev/files` and re-run job 897446441064360 to land the migration for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)