### PR TITLE
feat(genie): codify live-first doctrine; curate and certify asset breadth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ The product is ready when:
 - Every route queries live Unity Catalog / Lakebase; there is no mock runtime path.
 - Evidence drawer opens from every KPI/score/recommendation and cites real Cotality source rows.
 - Human approval writes a row to the Lakebase audit table.
-- `/ask-genie` is grounded in the real `mortgage_lead_intelligence` Genie Space with deterministic prompt-answer guards.
+- `/ask-genie` is grounded in the real `mortgage_lead_intelligence` Genie Space, **live-first**: Genie's own governed SQL, rows, and narrative ARE the answer. Accuracy comes from curated data and a curated space, never from deterministic answer overlays — overlaying a good live turn is 'faking it' and is prohibited. The deterministic layer has exactly two jobs: RESCUE (turns without trusted SQL proof, disclosed in the process trace) and CROSS-CHECK (verify against the governed framing; disclose divergence; never replace). The claims verifier, SQL trust policy, and fair-lending/PII guards are the accuracy-and-compliance contract and stay; any guard that blocks a legitimate analytics question is a bug — fix it by enumerating the real failing case (capture the live turn), never by weakening fail-closed defaults.
 - Resilience is demonstrable: warehouse warm-start hook, retry + circuit breaker around SQL + Genie calls, short-TTL cache for hot KPIs, explicit degraded-state UI when a dependency is down.
 - Backend health, portfolio, leads, borrower, offers, outreach, and audit endpoints return data from real tables.
 - Frontend build passes.

--- a/genie/mortgage_lead_intelligence_space.yml
+++ b/genie/mortgage_lead_intelligence_space.yml
@@ -695,6 +695,41 @@ example_question_sqls:
         GROUP BY state
         ORDER BY listed_borrowers DESC, avg_listing_days_on_market ASC, state ASC
         LIMIT 5
+  - question: How did the lead population and approvals change over the last 30 days?
+    sql:
+      - |
+        SELECT
+          snapshot_date,
+          addressable_borrowers,
+          in_the_money_borrowers,
+          approved_borrowers,
+          actioned_borrowers
+        FROM mip.gold.funnel_snapshot_daily
+        WHERE snapshot_date >= DATE_SUB(CURRENT_DATE(), 30)
+          AND state = '_ALL'
+          AND segment_code = '_ALL'
+        ORDER BY snapshot_date
+  - question: How big is the rate lock-in cohort and what is its median origination rate?
+    sql:
+      - |
+        SELECT
+          COUNT(*) AS lockin_borrowers,
+          ROUND(PERCENTILE(origination_rate, 0.5) * 100, 3) AS median_origination_rate_pct,
+          ROUND(AVG(equity_pct), 1) AS avg_equity_pct,
+          MAX(refreshed_at) AS refreshed_at
+        FROM mip.gold.lockin_cohort
+  - question: What trigger evidence fired in the last 7 days, grouped by signal type?
+    sql:
+      - |
+        SELECT
+          signal_type,
+          COUNT(*) AS events,
+          ROUND(AVG(confidence), 2) AS avg_confidence,
+          MAX(`timestamp`) AS latest_event_at
+        FROM mip.gold.evidence_events
+        WHERE `timestamp` >= CURRENT_TIMESTAMP() - INTERVAL 7 DAYS
+        GROUP BY signal_type
+        ORDER BY events DESC
   - question: Simulate a stricter top-tier threshold by state.
     sql:
       - |

--- a/tools/genie_eval_questions.yml
+++ b/tools/genie_eval_questions.yml
@@ -337,3 +337,41 @@ questions:
       - ask a scoped question
     min_rows: 5
     max_latency_s: 60
+
+  # ---------------------------------------------------------------------------
+  # Breadth certification (2026-08-07, live-first): Genie must be genuinely
+  # capable across the asset catalog, not just borrower_360. Any refusal or
+  # wrong-asset answer here is a curation regression.
+  # ---------------------------------------------------------------------------
+  - id: breadth_funnel_trend_30d
+    category: breadth
+    question: How did the lead population and approvals change over the last 30 days?
+    must_cite:
+      - mip.gold.funnel_snapshot_daily
+    forbid_keywords:
+      - did not display the result
+      - not pass the governed output policy
+    min_rows: 3
+    max_latency_s: 60
+
+  - id: breadth_lockin_cohort
+    category: breadth
+    question: How big is the rate lock-in cohort and what is its median origination rate?
+    must_cite:
+      - mip.gold.lockin_cohort
+    forbid_keywords:
+      - did not display the result
+      - not pass the governed output policy
+    min_rows: 0
+    max_latency_s: 60
+
+  - id: breadth_evidence_signals_7d
+    category: breadth
+    question: What trigger evidence fired in the last 7 days, grouped by signal type?
+    must_cite:
+      - mip.gold.evidence_events
+    forbid_keywords:
+      - did not display the result
+      - not pass the governed output policy
+    min_rows: 1
+    max_latency_s: 60


### PR DESCRIPTION
Product-owner doctrine, now durable: agentic analysis first and
foremost — Genie's own governed work is the answer, accuracy comes
from curated data and a curated space, and overlaying a good live turn
is 'faking it' (prohibited). CLAUDE.md's completion definition now
states it, including the two legitimate deterministic jobs (disclosed
rescue, verify-don't-replace cross-check) and the rule that a guard
blocking a legitimate question is a bug fixed by enumerating the real
live failing case, never by weakening fail-closed defaults.

Capability comes from curation: the space gains three breadth examples
(funnel_snapshot_daily 30-day trend, lockin_cohort sizing with median
origination rate, evidence_events 7-day signal rollup) and the
release-gating eval pack gains a breadth category pinning that Genie
answers from the RIGHT asset for trend, vintage, and trigger questions.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
