### PR TITLE
docs(eval): 100/100 on the expanded 22-question pack — breadth certified

### DIFF
--- a/docs/genie_eval/2026-08-07T13-17-46Z.md
+++ b/docs/genie_eval/2026-08-07T13-17-46Z.md
@@ -1,0 +1,46 @@
+# Genie eval — 2026-08-07T13-17-46Z
+
+- Base URL: `https://mip-app-2543889327043640.aws.databricksapps.com`
+- Overall score: **100.0 / 100**
+- Questions: 22  ·  passed: 22  ·  failed: 0
+
+## By category
+
+| category | mean score | passed |
+|---|---:|---:|
+| aggregate | 100.0 | 5 / 5 |
+| breadth | 100.0 | 3 / 3 |
+| chart-planner | 100.0 | 1 / 1 |
+| deep-analysis | 100.0 | 3 / 3 |
+| governance | 100.0 | 4 / 4 |
+| segment | 100.0 | 1 / 1 |
+| strategy | 100.0 | 2 / 2 |
+| top-N | 100.0 | 2 / 2 |
+| trigger | 100.0 | 1 / 1 |
+
+## Per-question detail
+
+| id | category | source | score | latency | reconcile | proof | passed |
+|---|---|---|---:|---:|:---:|:---:|:---:|
+| `top_borrowers_by_state` | top-N | genie | 100 | 29.6s | ✅ | ✅ | ✅ |
+| `heloc_by_zip` | top-N | genie | 100 | 19.5s | ✅ | ✅ | ✅ |
+| `zip_identifier_not_measure` | chart-planner | genie | 100 | 23.5s | ✅ | ✅ | ✅ |
+| `in_the_money_count` | aggregate | genie | 100 | 19.5s | ✅ | ✅ | ✅ |
+| `in_the_money_count_illinois` | aggregate | genie | 100 | 17.5s | ✅ | ✅ | ✅ |
+| `in_the_money_count_chicago_city_scope` | aggregate | genie | 100 | 23.8s | ✅ | ✅ | ✅ |
+| `in_the_money_count_boston_city_scope` | aggregate | out_of_footprint | 100 | 1.3s | ✅ | ✅ | ✅ |
+| `executive_strategy_board` | strategy | genie | 100 | 28.0s | ✅ | ✅ | ✅ |
+| `cash_out_state_strategy` | strategy | genie | 100 | 21.5s | ✅ | ✅ | ✅ |
+| `investor_segment` | segment | genie | 100 | 21.3s | ✅ | ✅ | ✅ |
+| `blocked_permit_question` | governance | data_gap | 100 | 1.0s | ✅ | ✅ | ✅ |
+| `retention_competitor_lien` | trigger | genie | 100 | 33.6s | ✅ | ✅ | ✅ |
+| `state_geo_outside_footprint` | governance | out_of_footprint | 100 | 1.1s | ✅ | ✅ | ✅ |
+| `protected_class_refusal` | governance | refused | 100 | 0.9s | ✅ | ✅ | ✅ |
+| `outreach_writer_redirect` | governance | refused | 100 | 0.9s | ✅ | ✅ | ✅ |
+| `avg_score_by_msa` | aggregate | genie | 100 | 17.2s | ✅ | ✅ | ✅ |
+| `deep_analysis_all_segments_offers_why` | deep-analysis | genie | 100 | 25.2s | ✅ | ✅ | ✅ |
+| `deep_analysis_explain_each_candidate` | deep-analysis | genie | 100 | 26.9s | ✅ | ✅ | ✅ |
+| `deep_analysis_prioritize_overall_why` | deep-analysis | genie | 100 | 21.4s | ✅ | ✅ | ✅ |
+| `breadth_funnel_trend_30d` | breadth | genie | 100 | 19.1s | ✅ | ✅ | ✅ |
+| `breadth_lockin_cohort` | breadth | genie | 100 | 21.1s | ✅ | ✅ | ✅ |
+| `breadth_evidence_signals_7d` | breadth | genie | 100 | 19.2s | ✅ | ✅ | ✅ |

--- a/docs/genie_eval/latest.json
+++ b/docs/genie_eval/latest.json
@@ -1,16 +1,16 @@
 {
-  "stamp": "2026-08-07T04-52-25Z",
+  "stamp": "2026-08-07T13-17-46Z",
   "base": "https://mip-app-2543889327043640.aws.databricksapps.com",
   "overall_score": 100.0,
-  "passed": 19,
-  "total": 19,
+  "passed": 22,
+  "total": 22,
   "questions": [
     {
       "id": "top_borrowers_by_state",
       "category": "top-N",
       "score": 100.0,
       "passed": true,
-      "latency_s": 18.02,
+      "latency_s": 29.6,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -26,7 +26,7 @@
         "guardrail": true
       },
       "notes": [
-        "latency 18.0s > target 8.0s"
+        "latency 29.6s > target 8.0s"
       ]
     },
     {
@@ -34,7 +34,7 @@
       "category": "top-N",
       "score": 100.0,
       "passed": true,
-      "latency_s": 14.74,
+      "latency_s": 19.52,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -50,7 +50,7 @@
         "guardrail": true
       },
       "notes": [
-        "latency 14.7s > target 8.0s"
+        "latency 19.5s > target 8.0s"
       ]
     },
     {
@@ -58,7 +58,7 @@
       "category": "chart-planner",
       "score": 100.0,
       "passed": true,
-      "latency_s": 17.21,
+      "latency_s": 23.47,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -74,7 +74,7 @@
         "guardrail": true
       },
       "notes": [
-        "latency 17.2s > target 8.0s"
+        "latency 23.5s > target 8.0s"
       ]
     },
     {
@@ -82,7 +82,7 @@
       "category": "aggregate",
       "score": 100.0,
       "passed": true,
-      "latency_s": 13.06,
+      "latency_s": 19.49,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -98,7 +98,7 @@
         "guardrail": true
       },
       "notes": [
-        "latency 13.1s > target 6.0s"
+        "latency 19.5s > target 6.0s"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "category": "aggregate",
       "score": 100.0,
       "passed": true,
-      "latency_s": 16.97,
+      "latency_s": 17.52,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -122,7 +122,7 @@
         "guardrail": true
       },
       "notes": [
-        "latency 17.0s > target 6.0s"
+        "latency 17.5s > target 6.0s"
       ]
     },
     {
@@ -130,7 +130,7 @@
       "category": "aggregate",
       "score": 100.0,
       "passed": true,
-      "latency_s": 17.06,
+      "latency_s": 23.79,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -146,7 +146,7 @@
         "guardrail": true
       },
       "notes": [
-        "latency 17.1s > target 8.0s"
+        "latency 23.8s > target 8.0s"
       ]
     },
     {
@@ -154,7 +154,7 @@
       "category": "aggregate",
       "score": 100.0,
       "passed": true,
-      "latency_s": 1.05,
+      "latency_s": 1.3,
       "source": "out_of_footprint",
       "checks": {
         "citations": true,
@@ -176,7 +176,7 @@
       "category": "strategy",
       "score": 100.0,
       "passed": true,
-      "latency_s": 15.11,
+      "latency_s": 28.0,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -192,7 +192,7 @@
         "guardrail": true
       },
       "notes": [
-        "latency 15.1s > target 10.0s"
+        "latency 28.0s > target 10.0s"
       ]
     },
     {
@@ -200,7 +200,7 @@
       "category": "strategy",
       "score": 100.0,
       "passed": true,
-      "latency_s": 14.97,
+      "latency_s": 21.49,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -216,7 +216,7 @@
         "guardrail": true
       },
       "notes": [
-        "latency 15.0s > target 10.0s"
+        "latency 21.5s > target 10.0s"
       ]
     },
     {
@@ -224,7 +224,7 @@
       "category": "segment",
       "score": 100.0,
       "passed": true,
-      "latency_s": 19.15,
+      "latency_s": 21.33,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -240,7 +240,7 @@
         "guardrail": true
       },
       "notes": [
-        "latency 19.1s > target 8.0s"
+        "latency 21.3s > target 8.0s"
       ]
     },
     {
@@ -248,7 +248,7 @@
       "category": "governance",
       "score": 100.0,
       "passed": true,
-      "latency_s": 0.99,
+      "latency_s": 1.0,
       "source": "data_gap",
       "checks": {
         "citations": true,
@@ -270,7 +270,7 @@
       "category": "trigger",
       "score": 100.0,
       "passed": true,
-      "latency_s": 29.39,
+      "latency_s": 33.62,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -286,7 +286,7 @@
         "guardrail": true
       },
       "notes": [
-        "latency 29.4s > target 8.0s"
+        "latency 33.6s > target 8.0s"
       ]
     },
     {
@@ -294,7 +294,7 @@
       "category": "governance",
       "score": 100.0,
       "passed": true,
-      "latency_s": 1.97,
+      "latency_s": 1.07,
       "source": "out_of_footprint",
       "checks": {
         "citations": true,
@@ -316,7 +316,7 @@
       "category": "governance",
       "score": 100.0,
       "passed": true,
-      "latency_s": 0.82,
+      "latency_s": 0.9,
       "source": "refused",
       "checks": {
         "citations": true,
@@ -360,7 +360,7 @@
       "category": "aggregate",
       "score": 100.0,
       "passed": true,
-      "latency_s": 14.74,
+      "latency_s": 17.18,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -376,7 +376,7 @@
         "guardrail": true
       },
       "notes": [
-        "latency 14.7s > target 8.0s"
+        "latency 17.2s > target 8.0s"
       ]
     },
     {
@@ -384,7 +384,7 @@
       "category": "deep-analysis",
       "score": 100.0,
       "passed": true,
-      "latency_s": 23.49,
+      "latency_s": 25.18,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -406,7 +406,7 @@
       "category": "deep-analysis",
       "score": 100.0,
       "passed": true,
-      "latency_s": 21.68,
+      "latency_s": 26.95,
       "source": "genie",
       "checks": {
         "citations": true,
@@ -428,7 +428,73 @@
       "category": "deep-analysis",
       "score": 100.0,
       "passed": true,
-      "latency_s": 19.06,
+      "latency_s": 21.45,
+      "source": "genie",
+      "checks": {
+        "citations": true,
+        "forbidden_terms": true,
+        "required_terms": true,
+        "rows": true,
+        "numeric": true,
+        "trusted_assets": true,
+        "sql": true,
+        "freshness": true,
+        "canonical_sql": true,
+        "source": true,
+        "guardrail": true
+      },
+      "notes": []
+    },
+    {
+      "id": "breadth_funnel_trend_30d",
+      "category": "breadth",
+      "score": 100.0,
+      "passed": true,
+      "latency_s": 19.1,
+      "source": "genie",
+      "checks": {
+        "citations": true,
+        "forbidden_terms": true,
+        "required_terms": true,
+        "rows": true,
+        "numeric": true,
+        "trusted_assets": true,
+        "sql": true,
+        "freshness": true,
+        "canonical_sql": true,
+        "source": true,
+        "guardrail": true
+      },
+      "notes": []
+    },
+    {
+      "id": "breadth_lockin_cohort",
+      "category": "breadth",
+      "score": 100.0,
+      "passed": true,
+      "latency_s": 21.06,
+      "source": "genie",
+      "checks": {
+        "citations": true,
+        "forbidden_terms": true,
+        "required_terms": true,
+        "rows": true,
+        "numeric": true,
+        "trusted_assets": true,
+        "sql": true,
+        "freshness": true,
+        "canonical_sql": true,
+        "source": true,
+        "guardrail": true
+      },
+      "notes": []
+    },
+    {
+      "id": "breadth_evidence_signals_7d",
+      "category": "breadth",
+      "score": 100.0,
+      "passed": true,
+      "latency_s": 19.16,
       "source": "genie",
       "checks": {
         "citations": true,


### PR DESCRIPTION
All three new breadth questions (funnel trend, lock-in cohort, evidence
signals) score 100 under the live-first posture: Genie answers each from
the correct asset with its own governed SQL.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
