### PR TITLE
feat(genie): agentic full-analysis sweep — 'analyze everything' becomes seven live Genie turns

### DIFF
--- a/backend/api/genie.py
+++ b/backend/api/genie.py
@@ -84,6 +84,9 @@ from backend.services.http_content import JSON_CONTENT_TYPE_RESPONSE, require_js
 from backend.services.lakebase import LakebaseClient, LakebaseError, get_lakebase_client
 from backend.services.observability import emit
 from backend.services.repositories import BorrowerRepository, GenieAnswerRepository
+from backend.services.repositories.databricks_genie_sweep import (
+    is_full_analysis_question,
+)
 from backend.services.repositories.factory import (
     get_borrower_repository,
     get_genie_answer_repository,
@@ -521,6 +524,11 @@ def genie_message_submit(
         # BEFORE any live Genie call. The async lifecycle honors the same
         # posture by resolving the whole turn here instead of creating a live
         # message (QA review H2 — submit previously bypassed the posture).
+        return _inline_repo_resolution()
+    if is_full_analysis_question(payload.question):
+        # "Analyze everything" turns are a multi-part LIVE sweep, not one
+        # Genie message — resolve through the repository pipeline, which
+        # orchestrates the themed sub-turns itself.
         return _inline_repo_resolution()
     try:
         conversation_id, message_id = get_genie_client().submit_message(

--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -101,6 +101,10 @@ from backend.services.repositories.databricks_genie_policy_helpers import (
 from backend.services.repositories.databricks_genie_strategy import (
     _canonical_strategy_board_answer,
 )
+from backend.services.repositories.databricks_genie_sweep import (
+    is_full_analysis_question,
+    run_full_analysis_sweep,
+)
 from backend.services.repositories.databricks_genie_trace import (
     WITHHELD_CONTRADICTED,
     WITHHELD_NO_NARRATIVE,
@@ -235,6 +239,8 @@ class DatabricksGenieRepository:
         self,
         question: str,
         conversation_id: str | None = None,
+        *,
+        allow_sweep: bool = True,
     ) -> GenieMessageResponse:
         # Product posture (mip_genie_live_first=True): LIVE Genie is the primary
         # answer path for every guardrail-passing question so the answer is
@@ -254,6 +260,14 @@ class DatabricksGenieRepository:
                 question,
                 kind=DependencyDownError.KIND_BREAKER_OPEN,
             )
+        if allow_sweep and is_full_analysis_question(question):
+            # "Analyze everything" cannot be one SQL statement. Decompose into
+            # themed LIVE Genie analyses (each through the full policy
+            # pipeline) and assemble the verified results; fall through to the
+            # normal single-turn pipeline when the sweep cannot stand one up.
+            sweep = run_full_analysis_sweep(self, question)
+            if sweep is not None:
+                return sweep
         repaired = False
         try:
             result = self._genie.ask(question, conversation_id=conversation_id)

--- a/backend/services/repositories/databricks_genie_sweep.py
+++ b/backend/services/repositories/databricks_genie_sweep.py
@@ -1,0 +1,267 @@
+"""Full-analysis sweep: agentic decomposition for "analyze everything" asks.
+
+"Do a full analysis on all of the data" can never be one SQL statement, so the
+single-turn pipeline used to dead-end in a governed refusal. Under the
+live-first doctrine the answer must still be GENIE'S OWN WORK — so this module
+decomposes the ask into a fixed set of themed sub-questions, conducts a real
+live Genie turn for each (every sub-turn runs the complete policy pipeline:
+prompt guards upstream, SQL trust policy, claims verification, PII redaction,
+disclosed rescue), and assembles the verified results into one executive
+answer. Deterministic code here ORCHESTRATES and FORMATS; it never authors an
+analytic figure. Sections quote the sub-answers verbatim and the proof carries
+every generated SQL statement, labeled per section.
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+from backend.services.genie_answers import (
+    GenieMessageResponse,
+    GenieProof,
+    GenieReasoningStep,
+    default_follow_up_questions,
+)
+from backend.services.repositories.databricks_genie_canonical import (
+    _canonical_itm_state_scope,
+    _normalized_question,
+    _specific_top_borrower_intent,
+)
+from backend.services.repositories.databricks_genie_trust import _genie_question_hash
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from backend.services.repositories.databricks_genie import (
+        DatabricksGenieRepository,
+    )
+
+# Sources that mean a sub-turn produced governed analytic content.
+_DATA_BEARING_SOURCES = frozenset({"genie", "trusted_sql"})
+
+# Sweep fan-out cap. The Genie Conversation API tolerates concurrent
+# conversations; four keeps the burst polite while holding wall time near the
+# slowest single turn.
+_SWEEP_MAX_WORKERS = 4
+
+_FULL_ANALYSIS_PHRASES = (
+    "full analysis",
+    "complete analysis",
+    "comprehensive analysis",
+    "deep analysis",
+    "deep-dive analysis",
+    "executive summary",
+    "executive briefing",
+    "state of the book",
+    "state of the portfolio",
+    "full picture",
+    "complete picture",
+)
+
+_BROAD_SCOPE_TERMS = (
+    "all of the data",
+    "all the data",
+    "all our data",
+    "everything",
+    "entire book",
+    "whole book",
+    "entire portfolio",
+    "whole portfolio",
+    "across the board",
+)
+
+_INSIGHT_TERMS = (
+    "analysis",
+    "analyze",
+    "analyse",
+    "insight",
+    "insights",
+    "summary",
+    "overview",
+    "briefing",
+    "deep dive",
+    "picture",
+)
+
+# Themed sub-questions. Every entry is a phrasing the live space handles well
+# (several are pinned by the release eval pack, including the breadth
+# category). Order is the presentation order.
+FULL_ANALYSIS_SWEEP: tuple[tuple[str, str], ...] = (
+    (
+        "Refinance economics",
+        "How many borrowers are currently in-the-money, and what is the average rate spread?",
+    ),
+    (
+        "Home-equity capacity",
+        "How many borrowers have at least 35% modeled equity across the current Cotality data coverage?",
+    ),
+    (
+        "Where the opportunity concentrates",
+        "Break down in-the-money borrowers by current coverage state; which state leads?",
+    ),
+    (
+        "30-day funnel trend",
+        "How did the lead population and approvals change over the last 30 days?",
+    ),
+    (
+        "The rate lock-in cohort",
+        "How big is the rate lock-in cohort and what is its median origination rate?",
+    ),
+    (
+        "What triggered recently",
+        "What trigger evidence fired in the last 7 days, grouped by signal type?",
+    ),
+    (
+        "Who to act on first",
+        "What are the top borrower candidates across all segments overall, what makes "
+        "them such good candidates exactly (for each one), and what is the exact offer "
+        "we should make to each and why?",
+    ),
+)
+
+
+def is_full_analysis_question(question: str) -> bool:
+    """True for open-ended analyze-everything asks; narrow scopes stay single-turn."""
+
+    q = _normalized_question(question)
+    if _canonical_itm_state_scope(question) is not None:
+        return False
+    if _specific_top_borrower_intent(q) is not None:
+        return False
+    if any(phrase in q for phrase in _FULL_ANALYSIS_PHRASES):
+        return True
+    return any(term in q for term in _BROAD_SCOPE_TERMS) and any(
+        term in q for term in _INSIGHT_TERMS
+    )
+
+
+def _labeled_sql(sections: list[tuple[str, GenieMessageResponse]]) -> str | None:
+    parts: list[str] = []
+    for title, response in sections:
+        if response.sql_query:
+            parts.append(f"-- [{title}]\n{response.sql_query.strip()}")
+    return "\n\n".join(parts) if parts else None
+
+
+def run_full_analysis_sweep(
+    repo: DatabricksGenieRepository,
+    question: str,
+) -> GenieMessageResponse | None:
+    """Conduct the themed live sweep and assemble the executive answer.
+
+    Returns ``None`` when fewer than three sub-analyses produce governed
+    content — the caller then falls through to the normal single-turn
+    pipeline, which fails honestly.
+    """
+
+    started = time.monotonic()
+
+    def _one(sub_question: str) -> GenieMessageResponse | None:
+        try:
+            return repo.respond(sub_question, allow_sweep=False)
+        except Exception:  # noqa: BLE001 - a failed theme becomes a disclosed gap
+            return None
+
+    with ThreadPoolExecutor(max_workers=_SWEEP_MAX_WORKERS) as pool:
+        results = list(pool.map(_one, [q for _, q in FULL_ANALYSIS_SWEEP]))
+
+    sections: list[tuple[str, GenieMessageResponse]] = []
+    gaps: list[str] = []
+    for (title, _), response in zip(FULL_ANALYSIS_SWEEP, results, strict=True):
+        if (
+            response is not None
+            and response.source in _DATA_BEARING_SOURCES
+            and (response.answer or "").strip()
+        ):
+            sections.append((title, response))
+        else:
+            gaps.append(
+                f"The '{title}' analysis returned no governed result on this run "
+                "and was omitted."
+            )
+    if len(sections) < 3:
+        return None
+
+    assets: list[str] = []
+    for _, response in sections:
+        for asset in response.trusted_assets:
+            if asset not in assets:
+                assets.append(asset)
+
+    intro = (
+        f"I ran a {len(sections)}-part live analysis across the governed assets "
+        f"({', '.join(assets)}). Each section below is Genie's own governed answer — "
+        "its generated SQL for every section is in the proof drawer — assembled "
+        "here into one lender briefing."
+    )
+    body_parts = [intro]
+    for title, response in sections:
+        body_parts.append(f"**{title}**\n\n{(response.answer or '').strip()}")
+    answer = "\n\n".join(body_parts)
+
+    # The action table comes from the ranking section when it survived,
+    # otherwise the largest data-bearing section.
+    anchor = next(
+        (resp for title, resp in sections if title == "Who to act on first"),
+        max((resp for _, resp in sections), key=lambda r: r.row_count or 0),
+    )
+
+    trace = [
+        GenieReasoningStep(
+            kind="orchestrate",
+            content=(
+                f"Decomposed the full-analysis ask into {len(FULL_ANALYSIS_SWEEP)} "
+                "themed live Genie analyses; every figure comes from Genie's own "
+                "governed SQL."
+            ),
+        )
+    ]
+    for title, response in sections:
+        cited = ", ".join(response.trusted_assets) or "the trusted assets"
+        trace.append(
+            GenieReasoningStep(
+                kind="live",
+                content=f"'{title}' answered live over {cited}.",
+            )
+        )
+    for _, response in sections:
+        if response.proof is not None:
+            for gap in response.proof.known_data_gaps:
+                if gap not in gaps:
+                    gaps.append(gap)
+
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    proof = GenieProof(
+        source_assets=assets,
+        row_count=anchor.row_count or 0,
+        trusted=all(
+            resp.proof is not None and resp.proof.trusted for _, resp in sections
+        ),
+        filters=[],
+        known_data_gaps=gaps[:12],
+        conversation_id=anchor.conversation_id or None,
+        message_id=anchor.message_id,
+        elapsed_ms=elapsed_ms,
+        generated_at=anchor.proof.generated_at if anchor.proof is not None else None,
+        sql_query=_labeled_sql(sections),
+        reasoning_trace=trace,
+    )
+    return GenieMessageResponse(
+        conversation_id=anchor.conversation_id or "",
+        message_id=anchor.message_id,
+        elapsed_ms=elapsed_ms,
+        question=question,
+        question_hash=_genie_question_hash(question),
+        answer=answer,
+        source="genie",
+        trusted_assets=assets,
+        sql_query=_labeled_sql(sections),
+        row_count=anchor.row_count or 0,
+        proof=proof,
+        visualization=anchor.visualization,
+        actions=anchor.actions,
+        table_rows=anchor.table_rows,
+        follow_up_questions=default_follow_up_questions(),
+        reasoning_trace=trace,
+    )
+

--- a/tests/unit/test_genie_full_analysis_sweep.py
+++ b/tests/unit/test_genie_full_analysis_sweep.py
@@ -1,0 +1,121 @@
+"""Full-analysis sweep: matcher scope and live-first orchestration contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.genie_answers import GenieMessageResponse, GenieProof
+from backend.services.repositories.databricks_genie_sweep import (
+    FULL_ANALYSIS_SWEEP,
+    is_full_analysis_question,
+    run_full_analysis_sweep,
+)
+
+_USER_QUESTION = (
+    "Do a full analysis on all of the data -- what are the deepest and most "
+    "useful insights from everything as a lender?"
+)
+
+
+@pytest.mark.parametrize(
+    ("question", "expected"),
+    [
+        (_USER_QUESTION, True),
+        ("Give me an executive summary of the book.", True),
+        ("Analyze everything and tell me the biggest insights.", True),
+        ("What is the state of the portfolio?", True),
+        # Narrow scopes stay single-turn.
+        ("Do a full analysis of Texas refinance candidates.", False),
+        ("Deep analysis of the HELOC segment, please.", False),
+        ("How many borrowers are currently in-the-money?", False),
+        ("Show me the top 10 borrowers by lead score in Illinois.", False),
+    ],
+)
+def test_full_analysis_matcher(question: str, expected: bool) -> None:
+    assert is_full_analysis_question(question) is expected
+
+
+def test_sweep_sub_questions_do_not_recurse() -> None:
+    for _, sub_question in FULL_ANALYSIS_SWEEP:
+        assert is_full_analysis_question(sub_question) is False, sub_question
+
+
+class _StubRepo:
+    """Stands in for DatabricksGenieRepository; records sub-question fan-out."""
+
+    def __init__(self, failures: frozenset[str] = frozenset()) -> None:
+        self.calls: list[tuple[str, bool]] = []
+        self._failures = failures
+
+    def respond(
+        self,
+        question: str,
+        conversation_id: str | None = None,
+        *,
+        allow_sweep: bool = True,
+    ) -> GenieMessageResponse:
+        self.calls.append((question, allow_sweep))
+        if question in self._failures:
+            return GenieMessageResponse(
+                conversation_id="",
+                question=question,
+                question_hash="h",
+                answer="blocked",
+                source="policy_blocked",
+                trusted_assets=[],
+            )
+        return GenieMessageResponse(
+            conversation_id=f"conv-{len(self.calls)}",
+            message_id=f"msg-{len(self.calls)}",
+            question=question,
+            question_hash="h",
+            answer=f"Governed answer for: {question[:40]}",
+            source="genie",
+            trusted_assets=["mip.gold.borrower_360"],
+            sql_query="SELECT 1 FROM mip.gold.borrower_360",
+            row_count=3,
+            proof=GenieProof(
+                source_assets=["mip.gold.borrower_360"],
+                row_count=3,
+                trusted=True,
+                generated_at="2026-08-07T00:00:00Z",
+            ),
+            table_rows=[{"borrower_id": "B-1ABCDEFGHIJKL"}],
+        )
+
+
+def test_sweep_composes_all_sections_with_live_sub_turns() -> None:
+    repo = _StubRepo()
+    result = run_full_analysis_sweep(repo, _USER_QUESTION)  # type: ignore[arg-type]
+
+    assert result is not None
+    assert result.source == "genie"
+    # Every themed sub-question ran as its own live turn with recursion off.
+    assert len(repo.calls) == len(FULL_ANALYSIS_SWEEP)
+    assert all(allow_sweep is False for _, allow_sweep in repo.calls)
+    for title, _ in FULL_ANALYSIS_SWEEP:
+        assert f"**{title}**" in result.answer
+    assert result.sql_query is not None
+    assert result.sql_query.count("-- [") == len(FULL_ANALYSIS_SWEEP)
+    assert result.proof is not None
+    assert result.proof.trusted is True
+    kinds = [step.kind for step in result.reasoning_trace]
+    assert kinds[0] == "orchestrate"
+    assert kinds.count("live") == len(FULL_ANALYSIS_SWEEP)
+
+
+def test_sweep_discloses_failed_sections_and_keeps_going() -> None:
+    failing = FULL_ANALYSIS_SWEEP[1][1]
+    repo = _StubRepo(failures=frozenset({failing}))
+    result = run_full_analysis_sweep(repo, _USER_QUESTION)  # type: ignore[arg-type]
+
+    assert result is not None
+    assert f"**{FULL_ANALYSIS_SWEEP[1][0]}**" not in result.answer
+    assert result.proof is not None
+    assert any("returned no governed result" in gap for gap in result.proof.known_data_gaps)
+
+
+def test_sweep_returns_none_when_too_few_sections_survive() -> None:
+    failures = frozenset(q for _, q in FULL_ANALYSIS_SWEEP[:5])
+    repo = _StubRepo(failures=failures)
+    assert run_full_analysis_sweep(repo, _USER_QUESTION) is None  # type: ignore[arg-type]


### PR DESCRIPTION
'Do a full analysis on all of the data' can never be one SQL statement,
so the single-turn pipeline dead-ended in a governed refusal on the most
important open-ended question a lender can ask. Doctrine-compliant fix:
decompose the ask into seven themed sub-questions (economics, equity,
geography, 30-day trend, lock-in cohort, recent triggers, who to act on
first) and conduct a REAL live Genie turn for each in parallel — every
sub-turn runs the complete policy pipeline (guards, trust, claims,
redaction, disclosed rescue) — then assemble the verified results into
one executive briefing. Deterministic code orchestrates and formats
only; every analytic figure is Genie's own governed work, every
section's generated SQL ships in the proof, and failed themes are
disclosed as gaps rather than faked. Falls through to the honest
single-turn pipeline when fewer than three themes survive. The async
submit endpoint resolves sweep questions through the repository instead
of creating a single live message.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
