### PR TITLE
chore(eval): release-gate the full-analysis sweep

### DIFF
--- a/tools/genie_eval_questions.yml
+++ b/tools/genie_eval_questions.yml
@@ -375,3 +375,16 @@ questions:
       - not pass the governed output policy
     min_rows: 1
     max_latency_s: 60
+
+  - id: deep_full_analysis_sweep
+    category: deep-analysis
+    question: Do a full analysis on all of the data -- what are the deepest and most useful insights from everything as a lender?
+    must_cite:
+      - mip.gold.borrower_360
+      - mip.gold.funnel_snapshot_daily
+    forbid_keywords:
+      - did not display the result
+      - not pass the governed output policy
+    min_rows: 1
+    # Seven parallel live Genie turns; wall time tracks the slowest turn.
+    max_latency_s: 180


### PR DESCRIPTION
Pins the exact product-owner question that used to refuse: must cite
at least the borrower and funnel assets, must carry rows, and any
refusal phrasing fails the run. Verified live at 46s (cap 180s for
seven parallel turns).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
