### PR TITLE
feat(genie): the sweep is now planned by Genie itself — no keyword routing, no fixed template

### DIFF
--- a/backend/api/genie.py
+++ b/backend/api/genie.py
@@ -84,9 +84,6 @@ from backend.services.http_content import JSON_CONTENT_TYPE_RESPONSE, require_js
 from backend.services.lakebase import LakebaseClient, LakebaseError, get_lakebase_client
 from backend.services.observability import emit
 from backend.services.repositories import BorrowerRepository, GenieAnswerRepository
-from backend.services.repositories.databricks_genie_sweep import (
-    is_full_analysis_question,
-)
 from backend.services.repositories.factory import (
     get_borrower_repository,
     get_genie_answer_repository,
@@ -524,11 +521,6 @@ def genie_message_submit(
         # BEFORE any live Genie call. The async lifecycle honors the same
         # posture by resolving the whole turn here instead of creating a live
         # message (QA review H2 — submit previously bypassed the posture).
-        return _inline_repo_resolution()
-    if is_full_analysis_question(payload.question):
-        # "Analyze everything" turns are a multi-part LIVE sweep, not one
-        # Genie message — resolve through the repository pipeline, which
-        # orchestrates the themed sub-turns itself.
         return _inline_repo_resolution()
     try:
         conversation_id, message_id = get_genie_client().submit_message(

--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -102,8 +102,7 @@ from backend.services.repositories.databricks_genie_strategy import (
     _canonical_strategy_board_answer,
 )
 from backend.services.repositories.databricks_genie_sweep import (
-    is_full_analysis_question,
-    run_full_analysis_sweep,
+    run_planned_sweep,
 )
 from backend.services.repositories.databricks_genie_trace import (
     WITHHELD_CONTRADICTED,
@@ -260,14 +259,6 @@ class DatabricksGenieRepository:
                 question,
                 kind=DependencyDownError.KIND_BREAKER_OPEN,
             )
-        if allow_sweep and is_full_analysis_question(question):
-            # "Analyze everything" cannot be one SQL statement. Decompose into
-            # themed LIVE Genie analyses (each through the full policy
-            # pipeline) and assemble the verified results; fall through to the
-            # normal single-turn pipeline when the sweep cannot stand one up.
-            sweep = run_full_analysis_sweep(self, question)
-            if sweep is not None:
-                return sweep
         repaired = False
         try:
             result = self._genie.ask(question, conversation_id=conversation_id)
@@ -282,6 +273,15 @@ class DatabricksGenieRepository:
                 # signal for "the repair actually changed this turn".
                 repaired = regenerated is not result
                 result = regenerated
+                if allow_sweep and not _genie_response_has_query_proof(result):
+                    # Behavioral trigger, no keywords: the live turn AND its
+                    # repair both came back without governed SQL — the ask is
+                    # too broad for one statement. Let the live space plan its
+                    # own decomposition and answer each part itself; fall
+                    # through to the normal pipeline when it cannot.
+                    sweep = run_planned_sweep(self, question)
+                    if sweep is not None:
+                        return sweep
         except DependencyDownError as exc:
             return self._degraded(question, kind=exc.kind)
         except GenieClientError:
@@ -329,6 +329,13 @@ class DatabricksGenieRepository:
                 )
                 repaired = regenerated is not result
                 result = regenerated
+                if not _genie_response_has_query_proof(result):
+                    # Same behavioral trigger as :meth:`respond`: the live
+                    # turn and its repair both lack governed SQL, so the live
+                    # space plans and executes its own decomposition.
+                    sweep = run_planned_sweep(self, question)
+                    if sweep is not None:
+                        return sweep
         except DependencyDownError as exc:
             return self._degraded(question, kind=exc.kind)
         except GenieClientError:
@@ -339,6 +346,16 @@ class DatabricksGenieRepository:
             sql_client=self._sql_client,
             repaired=repaired,
         )
+
+    def ask_raw(self, prompt: str) -> str | None:
+        """Raw narrative text of one live turn (planner use only).
+
+        No adaptation, no policy verdicts — the caller screens and never
+        renders this text; it is parsed for planned sub-questions which then
+        re-enter the full pipeline individually.
+        """
+        result = self._genie.ask(prompt, conversation_id=None)
+        return result.answer_text
 
     def _repair_text_only_genie_answer(
         self,

--- a/backend/services/repositories/databricks_genie_sweep.py
+++ b/backend/services/repositories/databricks_genie_sweep.py
@@ -1,33 +1,35 @@
-"""Full-analysis sweep: agentic decomposition for "analyze everything" asks.
+"""Agentic decomposition: Genie plans and executes its own analysis sweep.
 
-"Do a full analysis on all of the data" can never be one SQL statement, so the
-single-turn pipeline used to dead-end in a governed refusal. Under the
-live-first doctrine the answer must still be GENIE'S OWN WORK — so this module
-decomposes the ask into a fixed set of themed sub-questions, conducts a real
-live Genie turn for each (every sub-turn runs the complete policy pipeline:
-prompt guards upstream, SQL trust policy, claims verification, PII redaction,
-disclosed rescue), and assembles the verified results into one executive
-answer. Deterministic code here ORCHESTRATES and FORMATS; it never authors an
-analytic figure. Sections quote the sub-answers verbatim and the proof carries
-every generated SQL statement, labeled per section.
+Some questions ("do a full analysis on all of the data") can never be one SQL
+statement. Nothing here decides that with keywords: the trigger is behavioral
+— the live turn (and its one-shot repair) came back without SQL proof — and
+the decomposition itself is planned BY GENIE, fresh for each question. The
+planner turn asks the governed space to break the user's request into
+self-contained analytics questions over its own trusted assets; every planned
+sub-question is screened by the same prompt guard battery the router applies
+(planned questions are model-authored text), then executed as its own live
+turn through the complete policy pipeline (SQL trust, claims verification, PII
+redaction, disclosed rescue). Deterministic code here orchestrates, screens,
+and formats; it never authors a question, a figure, or an analytic choice.
 """
 
 from __future__ import annotations
 
+import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
+from backend.api import genie_guardrails as prompt_guardrails
 from backend.services.genie_answers import (
     GenieMessageResponse,
     GenieProof,
     GenieReasoningStep,
     default_follow_up_questions,
 )
-from backend.services.repositories.databricks_genie_canonical import (
-    _canonical_itm_state_scope,
-    _normalized_question,
-    _specific_top_borrower_intent,
+from backend.services.genie_message_policy import (
+    identity_prompt_match,
+    protected_prompt_match,
 )
 from backend.services.repositories.databricks_genie_trust import _genie_question_hash
 
@@ -39,100 +41,97 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 # Sources that mean a sub-turn produced governed analytic content.
 _DATA_BEARING_SOURCES = frozenset({"genie", "trusted_sql"})
 
-# Sweep fan-out cap. The Genie Conversation API tolerates concurrent
-# conversations; four keeps the burst polite while holding wall time near the
+# Fan-out cap: polite to the Conversation API while keeping wall time near the
 # slowest single turn.
 _SWEEP_MAX_WORKERS = 4
 
-_FULL_ANALYSIS_PHRASES = (
-    "full analysis",
-    "complete analysis",
-    "comprehensive analysis",
-    "deep analysis",
-    "deep-dive analysis",
-    "executive summary",
-    "executive briefing",
-    "state of the book",
-    "state of the portfolio",
-    "full picture",
-    "complete picture",
-)
+_MIN_PLANNED = 3
+_MAX_PLANNED = 7
 
-_BROAD_SCOPE_TERMS = (
-    "all of the data",
-    "all the data",
-    "all our data",
-    "everything",
-    "entire book",
-    "whole book",
-    "entire portfolio",
-    "whole portfolio",
-    "across the board",
-)
-
-_INSIGHT_TERMS = (
-    "analysis",
-    "analyze",
-    "analyse",
-    "insight",
-    "insights",
-    "summary",
-    "overview",
-    "briefing",
-    "deep dive",
-    "picture",
-)
-
-# Themed sub-questions. Every entry is a phrasing the live space handles well
-# (several are pinned by the release eval pack, including the breadth
-# category). Order is the presentation order.
-FULL_ANALYSIS_SWEEP: tuple[tuple[str, str], ...] = (
-    (
-        "Refinance economics",
-        "How many borrowers are currently in-the-money, and what is the average rate spread?",
-    ),
-    (
-        "Home-equity capacity",
-        "How many borrowers have at least 35% modeled equity across the current Cotality data coverage?",
-    ),
-    (
-        "Where the opportunity concentrates",
-        "Break down in-the-money borrowers by current coverage state; which state leads?",
-    ),
-    (
-        "30-day funnel trend",
-        "How did the lead population and approvals change over the last 30 days?",
-    ),
-    (
-        "The rate lock-in cohort",
-        "How big is the rate lock-in cohort and what is its median origination rate?",
-    ),
-    (
-        "What triggered recently",
-        "What trigger evidence fired in the last 7 days, grouped by signal type?",
-    ),
-    (
-        "Who to act on first",
-        "What are the top borrower candidates across all segments overall, what makes "
-        "them such good candidates exactly (for each one), and what is the exact offer "
-        "we should make to each and why?",
-    ),
-)
+_PLAN_LINE_RE = re.compile(r"^\s*(?:\d{1,2}[.)]|[-*•])\s+(.{10,240})\s*$")
 
 
-def is_full_analysis_question(question: str) -> bool:
-    """True for open-ended analyze-everything asks; narrow scopes stay single-turn."""
-
-    q = _normalized_question(question)
-    if _canonical_itm_state_scope(question) is not None:
-        return False
-    if _specific_top_borrower_intent(q) is not None:
-        return False
-    if any(phrase in q for phrase in _FULL_ANALYSIS_PHRASES):
-        return True
-    return any(term in q for term in _BROAD_SCOPE_TERMS) and any(
-        term in q for term in _INSIGHT_TERMS
+def _planning_prompt(question: str) -> str:
+    return (
+        "Plan, do not query: for this message only, do not generate SQL and do "
+        "not execute anything. The user asked a broad question that cannot be "
+        "answered by a single SQL statement:\n\n"
+        f'"{question}"\n\n'
+        "Break it into the specific analytics questions YOU judge most useful, "
+        f"between {_MIN_PLANNED} and {_MAX_PLANNED} of them, each self-contained "
+        "and answerable with one SQL query over your trusted assets. Choose the "
+        "angles yourself based on what the question is really asking and which "
+        "of your assets can answer it. Reply ONLY with a numbered list, one "
+        "question per line, no preamble and no closing text."
     )
+
+
+def _parse_planned_questions(text: str | None) -> list[str]:
+    if not text:
+        return []
+    planned: list[str] = []
+    for line in text.splitlines():
+        match = _PLAN_LINE_RE.match(line)
+        if not match:
+            continue
+        candidate = match.group(1).strip().strip("\"'")
+        if not candidate:
+            continue
+        if not candidate.endswith("?"):
+            candidate = f"{candidate}?"
+        if candidate not in planned:
+            planned.append(candidate)
+    return planned[:_MAX_PLANNED]
+
+
+def _planned_question_guard_hit(question: str) -> str | None:
+    """Screen a model-authored planned question with the router's guard battery.
+
+    Planned questions are model text used as prompts, so they get the same
+    treatment user prompts get at the router. Any hit drops the question from
+    the plan (disclosed), never executes it.
+    """
+
+    if protected_prompt_match(question):
+        return "protected-class screen"
+    if identity_prompt_match(question):
+        return "PII / identity screen"
+    if prompt_guardrails.pii_prompt_match(question):
+        return "PII screen"
+    if prompt_guardrails.instruction_override_prompt_match(question):
+        return "instruction-override screen"
+    if prompt_guardrails.scope_bypass_prompt_match(question):
+        return "scope screen"
+    if prompt_guardrails.cross_lender_prompt_match(question):
+        return "cross-lender screen"
+    return None
+
+
+def plan_sub_questions(
+    repo: DatabricksGenieRepository,
+    question: str,
+) -> tuple[list[str], list[str]]:
+    """Ask the live space to decompose the question; screen what comes back.
+
+    Returns (planned, dropped_disclosures). Planning failures return ([], []).
+    """
+
+    try:
+        planning_turn = repo.ask_raw(_planning_prompt(question))
+    except Exception:  # noqa: BLE001 - planner failure falls through honestly
+        return [], []
+    planned_raw = _parse_planned_questions(planning_turn)
+    planned: list[str] = []
+    dropped: list[str] = []
+    for candidate in planned_raw:
+        hit = _planned_question_guard_hit(candidate)
+        if hit is not None:
+            dropped.append(
+                f"One planned sub-analysis was dropped by the {hit} before execution."
+            )
+            continue
+        planned.append(candidate)
+    return planned, dropped
 
 
 def _labeled_sql(sections: list[tuple[str, GenieMessageResponse]]) -> str | None:
@@ -143,18 +142,21 @@ def _labeled_sql(sections: list[tuple[str, GenieMessageResponse]]) -> str | None
     return "\n\n".join(parts) if parts else None
 
 
-def run_full_analysis_sweep(
+def run_planned_sweep(
     repo: DatabricksGenieRepository,
     question: str,
 ) -> GenieMessageResponse | None:
-    """Conduct the themed live sweep and assemble the executive answer.
+    """Plan the decomposition live, execute each sub-question live, assemble.
 
-    Returns ``None`` when fewer than three sub-analyses produce governed
-    content — the caller then falls through to the normal single-turn
-    pipeline, which fails honestly.
+    Returns ``None`` when the plan cannot be formed or fewer than three
+    sub-analyses produce governed content — the caller then continues the
+    normal single-turn pipeline, which fails honestly.
     """
 
     started = time.monotonic()
+    planned, dropped = plan_sub_questions(repo, question)
+    if len(planned) < _MIN_PLANNED:
+        return None
 
     def _one(sub_question: str) -> GenieMessageResponse | None:
         try:
@@ -163,23 +165,23 @@ def run_full_analysis_sweep(
             return None
 
     with ThreadPoolExecutor(max_workers=_SWEEP_MAX_WORKERS) as pool:
-        results = list(pool.map(_one, [q for _, q in FULL_ANALYSIS_SWEEP]))
+        results = list(pool.map(_one, planned))
 
     sections: list[tuple[str, GenieMessageResponse]] = []
-    gaps: list[str] = []
-    for (title, _), response in zip(FULL_ANALYSIS_SWEEP, results, strict=True):
+    gaps: list[str] = list(dropped)
+    for sub_question, response in zip(planned, results, strict=True):
         if (
             response is not None
             and response.source in _DATA_BEARING_SOURCES
             and (response.answer or "").strip()
         ):
-            sections.append((title, response))
+            sections.append((sub_question, response))
         else:
             gaps.append(
-                f"The '{title}' analysis returned no governed result on this run "
-                "and was omitted."
+                f"The planned analysis '{sub_question}' returned no governed "
+                "result on this run and was omitted."
             )
-    if len(sections) < 3:
+    if len(sections) < _MIN_PLANNED:
         return None
 
     assets: list[str] = []
@@ -189,39 +191,34 @@ def run_full_analysis_sweep(
                 assets.append(asset)
 
     intro = (
-        f"I ran a {len(sections)}-part live analysis across the governed assets "
-        f"({', '.join(assets)}). Each section below is Genie's own governed answer — "
-        "its generated SQL for every section is in the proof drawer — assembled "
-        "here into one lender briefing."
+        f"I asked the governed space to plan this request itself; it decomposed "
+        f"the question into {len(planned)} sub-analyses and answered each with "
+        f"its own governed SQL over {', '.join(assets)}. Every section below is "
+        "Genie's own answer — the generated SQL for each is in the proof drawer."
     )
     body_parts = [intro]
-    for title, response in sections:
-        body_parts.append(f"**{title}**\n\n{(response.answer or '').strip()}")
+    for sub_question, response in sections:
+        body_parts.append(f"**{sub_question}**\n\n{(response.answer or '').strip()}")
     answer = "\n\n".join(body_parts)
 
-    # The action table comes from the ranking section when it survived,
-    # otherwise the largest data-bearing section.
-    anchor = next(
-        (resp for title, resp in sections if title == "Who to act on first"),
-        max((resp for _, resp in sections), key=lambda r: r.row_count or 0),
-    )
+    anchor = max((resp for _, resp in sections), key=lambda r: r.row_count or 0)
 
     trace = [
         GenieReasoningStep(
             kind="orchestrate",
             content=(
-                f"Decomposed the full-analysis ask into {len(FULL_ANALYSIS_SWEEP)} "
-                "themed live Genie analyses; every figure comes from Genie's own "
-                "governed SQL."
+                "The broad ask returned no single governed query, so the live "
+                f"space planned its own decomposition: {len(planned)} "
+                "sub-analyses, each executed as its own governed turn."
             ),
         )
     ]
-    for title, response in sections:
+    for _, response in sections:
         cited = ", ".join(response.trusted_assets) or "the trusted assets"
         trace.append(
             GenieReasoningStep(
                 kind="live",
-                content=f"'{title}' answered live over {cited}.",
+                content=f"Planned analysis answered live over {cited}.",
             )
         )
     for _, response in sections:
@@ -264,4 +261,3 @@ def run_full_analysis_sweep(
         follow_up_questions=default_follow_up_questions(),
         reasoning_trace=trace,
     )
-

--- a/tests/unit/test_genie_full_analysis_sweep.py
+++ b/tests/unit/test_genie_full_analysis_sweep.py
@@ -1,14 +1,19 @@
-"""Full-analysis sweep: matcher scope and live-first orchestration contract."""
+"""Agentic planned sweep: fresh per-question decomposition, no keyword routing.
+
+The trigger is behavioral (live turn + repair both lack SQL proof) and the
+decomposition is planned by the live space itself. These tests pin the
+contract: the plan is parsed and guard-screened, every planned sub-question
+executes as its own live turn with recursion off, failures are disclosed, and
+an unusable plan falls through to the honest single-turn pipeline.
+"""
 
 from __future__ import annotations
 
-import pytest
-
 from backend.services.genie_answers import GenieMessageResponse, GenieProof
 from backend.services.repositories.databricks_genie_sweep import (
-    FULL_ANALYSIS_SWEEP,
-    is_full_analysis_question,
-    run_full_analysis_sweep,
+    _parse_planned_questions,
+    _planned_question_guard_hit,
+    run_planned_sweep,
 )
 
 _USER_QUESTION = (
@@ -16,36 +21,56 @@ _USER_QUESTION = (
     "useful insights from everything as a lender?"
 )
 
-
-@pytest.mark.parametrize(
-    ("question", "expected"),
-    [
-        (_USER_QUESTION, True),
-        ("Give me an executive summary of the book.", True),
-        ("Analyze everything and tell me the biggest insights.", True),
-        ("What is the state of the portfolio?", True),
-        # Narrow scopes stay single-turn.
-        ("Do a full analysis of Texas refinance candidates.", False),
-        ("Deep analysis of the HELOC segment, please.", False),
-        ("How many borrowers are currently in-the-money?", False),
-        ("Show me the top 10 borrowers by lead score in Illinois.", False),
-    ],
-)
-def test_full_analysis_matcher(question: str, expected: bool) -> None:
-    assert is_full_analysis_question(question) is expected
+_PLAN_TEXT = """Here is the plan:
+1. How many borrowers are currently in-the-money, and what is the average rate spread?
+2. Which states concentrate the most refinance opportunity right now?
+3) How did the lead population and approvals change over the last 30 days?
+- What trigger evidence fired in the last 7 days, grouped by signal type?
+"""
 
 
-def test_sweep_sub_questions_do_not_recurse() -> None:
-    for _, sub_question in FULL_ANALYSIS_SWEEP:
-        assert is_full_analysis_question(sub_question) is False, sub_question
+def test_plan_parsing_accepts_numbered_and_bulleted_lines() -> None:
+    planned = _parse_planned_questions(_PLAN_TEXT)
+    assert len(planned) == 4
+    assert planned[0].endswith("?")
+    assert "states concentrate" in planned[1]
+    assert planned[3].startswith("What trigger evidence")
+
+
+def test_plan_parsing_handles_empty_and_prose_only_text() -> None:
+    assert _parse_planned_questions(None) == []
+    assert _parse_planned_questions("I cannot break this down.") == []
+
+
+def test_planned_questions_are_guard_screened() -> None:
+    assert _planned_question_guard_hit(
+        "How many borrowers are currently in-the-money?"
+    ) is None
+    # Model-authored plans get the same fair-lending screen user prompts get.
+    assert _planned_question_guard_hit(
+        "Break down average lead score by borrower race?"
+    ) is not None
+    assert _planned_question_guard_hit(
+        "Give me the names of every borrower in ZIP 60601?"
+    ) is not None
 
 
 class _StubRepo:
-    """Stands in for DatabricksGenieRepository; records sub-question fan-out."""
+    """Stands in for DatabricksGenieRepository: planner turn + sub-turns."""
 
-    def __init__(self, failures: frozenset[str] = frozenset()) -> None:
+    def __init__(
+        self,
+        plan_text: str | None = _PLAN_TEXT,
+        failures: frozenset[str] = frozenset(),
+    ) -> None:
+        self.plan_text = plan_text
         self.calls: list[tuple[str, bool]] = []
+        self.raw_prompts: list[str] = []
         self._failures = failures
+
+    def ask_raw(self, prompt: str) -> str | None:
+        self.raw_prompts.append(prompt)
+        return self.plan_text
 
     def respond(
         self,
@@ -55,7 +80,7 @@ class _StubRepo:
         allow_sweep: bool = True,
     ) -> GenieMessageResponse:
         self.calls.append((question, allow_sweep))
-        if question in self._failures:
+        if any(marker in question for marker in self._failures):
             return GenieMessageResponse(
                 conversation_id="",
                 question=question,
@@ -69,7 +94,7 @@ class _StubRepo:
             message_id=f"msg-{len(self.calls)}",
             question=question,
             question_hash="h",
-            answer=f"Governed answer for: {question[:40]}",
+            answer=f"Governed answer for: {question[:44]}",
             source="genie",
             trusted_assets=["mip.gold.borrower_360"],
             sql_query="SELECT 1 FROM mip.gold.borrower_360",
@@ -84,38 +109,45 @@ class _StubRepo:
         )
 
 
-def test_sweep_composes_all_sections_with_live_sub_turns() -> None:
+def test_sweep_plans_fresh_and_executes_each_sub_question_live() -> None:
     repo = _StubRepo()
-    result = run_full_analysis_sweep(repo, _USER_QUESTION)  # type: ignore[arg-type]
+    result = run_planned_sweep(repo, _USER_QUESTION)  # type: ignore[arg-type]
 
     assert result is not None
     assert result.source == "genie"
-    # Every themed sub-question ran as its own live turn with recursion off.
-    assert len(repo.calls) == len(FULL_ANALYSIS_SWEEP)
+    # One planning turn carrying the user's question verbatim, no templates.
+    assert len(repo.raw_prompts) == 1
+    assert _USER_QUESTION in repo.raw_prompts[0]
+    # Every planned sub-question ran as its own live turn with recursion off.
+    assert len(repo.calls) == 4
     assert all(allow_sweep is False for _, allow_sweep in repo.calls)
-    for title, _ in FULL_ANALYSIS_SWEEP:
-        assert f"**{title}**" in result.answer
-    assert result.sql_query is not None
-    assert result.sql_query.count("-- [") == len(FULL_ANALYSIS_SWEEP)
-    assert result.proof is not None
-    assert result.proof.trusted is True
+    # Sections are headed by the PLANNED questions themselves.
+    assert "**How many borrowers are currently in-the-money" in result.answer
+    assert result.sql_query is not None and result.sql_query.count("-- [") == 4
     kinds = [step.kind for step in result.reasoning_trace]
     assert kinds[0] == "orchestrate"
-    assert kinds.count("live") == len(FULL_ANALYSIS_SWEEP)
+    assert kinds.count("live") == 4
+    assert result.proof is not None and result.proof.trusted is True
 
 
 def test_sweep_discloses_failed_sections_and_keeps_going() -> None:
-    failing = FULL_ANALYSIS_SWEEP[1][1]
-    repo = _StubRepo(failures=frozenset({failing}))
-    result = run_full_analysis_sweep(repo, _USER_QUESTION)  # type: ignore[arg-type]
+    repo = _StubRepo(failures=frozenset({"trigger evidence"}))
+    result = run_planned_sweep(repo, _USER_QUESTION)  # type: ignore[arg-type]
 
     assert result is not None
-    assert f"**{FULL_ANALYSIS_SWEEP[1][0]}**" not in result.answer
+    assert "trigger evidence fired" not in result.answer.split("**", 1)[1]
     assert result.proof is not None
-    assert any("returned no governed result" in gap for gap in result.proof.known_data_gaps)
+    assert any("returned no governed" in gap for gap in result.proof.known_data_gaps)
+
+
+def test_sweep_returns_none_when_plan_unusable() -> None:
+    assert run_planned_sweep(_StubRepo(plan_text=None), _USER_QUESTION) is None  # type: ignore[arg-type]
+    assert (
+        run_planned_sweep(_StubRepo(plan_text="No list here."), _USER_QUESTION)  # type: ignore[arg-type]
+        is None
+    )
 
 
 def test_sweep_returns_none_when_too_few_sections_survive() -> None:
-    failures = frozenset(q for _, q in FULL_ANALYSIS_SWEEP[:5])
-    repo = _StubRepo(failures=failures)
-    assert run_full_analysis_sweep(repo, _USER_QUESTION) is None  # type: ignore[arg-type]
+    repo = _StubRepo(failures=frozenset({"in-the-money", "states", "lead population"}))
+    assert run_planned_sweep(repo, _USER_QUESTION) is None  # type: ignore[arg-type]

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -1244,8 +1244,11 @@ def test_text_only_all_segments_top_candidates_returns_driver_rich_answer() -> N
     assert "refinance-propensity model" in result.answer
     assert result.proof is not None
     assert result.proof.trusted is True
-    # The live path still tried an ask plus one governed SQL-repair retry.
-    assert len(stub.ask_calls) == 2
+    # The live path tried the ask, one governed SQL-repair retry, and one
+    # agentic planning turn (whose text-only stub reply yields no plan, so the
+    # sweep falls through to the canonical rescue).
+    assert len(stub.ask_calls) == 3
+    assert "numbered list" in stub.ask_calls[2]
 
 
 def test_pii_flagged_narrative_is_withheld_not_refused_for_canonical_shape() -> None:
@@ -1272,9 +1275,10 @@ def test_pii_flagged_narrative_is_withheld_not_refused_for_canonical_shape() -> 
     assert result.proof is not None
     assert any("withheld by the output safety guard" in gap for gap in result.proof.known_data_gaps)
     assert not any("returned no narrative" in gap for gap in result.proof.known_data_gaps)
-    # The repair retry now runs even for guard-flagged narratives (the repair
-    # prompt carries only the question), so the live path made two asks.
-    assert len(stub.ask_calls) == 2
+    # The repair retry runs even for guard-flagged narratives, and the failed
+    # repair then attempts one agentic planning turn (no plan in the stub
+    # reply), so the live path made three asks before the canonical rescue.
+    assert len(stub.ask_calls) == 3
 
 
 def test_top_zip_question_uses_direct_canonical_gold_sql_without_genie_call() -> None:


### PR DESCRIPTION
Product-owner doctrine, second pass: the fixed seven-question template
and phrase matcher were still deterministic scaffolding. Both are gone.

- Trigger is BEHAVIORAL: every question runs its normal live turn; only
  when the turn AND its one-shot repair come back without governed SQL
  (the ask is too broad for one statement) does decomposition begin.
  No phrase lists anywhere; the async lifecycle inherits the same hook.
- The decomposition is PLANNED BY THE LIVE SPACE, fresh per question: a
  planning turn asks Genie to break the user's actual question into the
  sub-analyses IT judges most useful over its own assets. Planned
  questions are model-authored text, so each is screened by the same
  fair-lending/PII/injection/scope/cross-lender battery user prompts
  get; drops are disclosed, survivors execute as their own live turns
  through the full policy pipeline, in parallel, recursion off.
- Section headers are the planned questions themselves; the proof
  carries each section's generated SQL labeled by its planned question;
  an unusable plan or fewer than three surviving sections falls through
  to the honest single-turn pipeline.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
