### PR TITLE
fix(genie): the planner fires on the OUTCOME, not inside the repair branch

### DIFF
--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -273,15 +273,6 @@ class DatabricksGenieRepository:
                 # signal for "the repair actually changed this turn".
                 repaired = regenerated is not result
                 result = regenerated
-                if allow_sweep and not _genie_response_has_query_proof(result):
-                    # Behavioral trigger, no keywords: the live turn AND its
-                    # repair both came back without governed SQL — the ask is
-                    # too broad for one statement. Let the live space plan its
-                    # own decomposition and answer each part itself; fall
-                    # through to the normal pipeline when it cannot.
-                    sweep = run_planned_sweep(self, question)
-                    if sweep is not None:
-                        return sweep
         except DependencyDownError as exc:
             return self._degraded(question, kind=exc.kind)
         except GenieClientError:
@@ -289,12 +280,21 @@ class DatabricksGenieRepository:
             # 500, malformed JSON). Re-raise so the router translates
             # to 503 + degraded UI. No silent mock fallback.
             raise
-        return _adapt_genie_response(
+        adapted = _adapt_genie_response(
             question,
             result,
             sql_client=self._sql_client,
             repaired=repaired,
         )
+        if allow_sweep and adapted.source == "policy_blocked":
+            # Outcome-triggered, no keywords: no guardrail-passing question is
+            # allowed to end in a governed refusal until the live space has
+            # been given the chance to PLAN its own decomposition and answer
+            # each part itself. An unusable plan returns the honest refusal.
+            sweep = run_planned_sweep(self, question)
+            if sweep is not None:
+                return sweep
+        return adapted
 
     def respond_existing(
         self,
@@ -329,23 +329,22 @@ class DatabricksGenieRepository:
                 )
                 repaired = regenerated is not result
                 result = regenerated
-                if not _genie_response_has_query_proof(result):
-                    # Same behavioral trigger as :meth:`respond`: the live
-                    # turn and its repair both lack governed SQL, so the live
-                    # space plans and executes its own decomposition.
-                    sweep = run_planned_sweep(self, question)
-                    if sweep is not None:
-                        return sweep
         except DependencyDownError as exc:
             return self._degraded(question, kind=exc.kind)
         except GenieClientError:
             raise
-        return _adapt_genie_response(
+        adapted = _adapt_genie_response(
             question,
             result,
             sql_client=self._sql_client,
             repaired=repaired,
         )
+        if adapted.source == "policy_blocked":
+            # Same outcome-triggered planner as :meth:`respond`.
+            sweep = run_planned_sweep(self, question)
+            if sweep is not None:
+                return sweep
+        return adapted
 
     def ask_raw(self, prompt: str) -> str | None:
         """Raw narrative text of one live turn (planner use only).

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -1244,11 +1244,10 @@ def test_text_only_all_segments_top_candidates_returns_driver_rich_answer() -> N
     assert "refinance-propensity model" in result.answer
     assert result.proof is not None
     assert result.proof.trusted is True
-    # The live path tried the ask, one governed SQL-repair retry, and one
-    # agentic planning turn (whose text-only stub reply yields no plan, so the
-    # sweep falls through to the canonical rescue).
-    assert len(stub.ask_calls) == 3
-    assert "numbered list" in stub.ask_calls[2]
+    # The live path still tried an ask plus one governed SQL-repair retry;
+    # the canonical rescue answered, so the outcome-triggered planner never
+    # ran (it only fires on would-be refusals).
+    assert len(stub.ask_calls) == 2
 
 
 def test_pii_flagged_narrative_is_withheld_not_refused_for_canonical_shape() -> None:
@@ -1275,10 +1274,9 @@ def test_pii_flagged_narrative_is_withheld_not_refused_for_canonical_shape() -> 
     assert result.proof is not None
     assert any("withheld by the output safety guard" in gap for gap in result.proof.known_data_gaps)
     assert not any("returned no narrative" in gap for gap in result.proof.known_data_gaps)
-    # The repair retry runs even for guard-flagged narratives, and the failed
-    # repair then attempts one agentic planning turn (no plan in the stub
-    # reply), so the live path made three asks before the canonical rescue.
-    assert len(stub.ask_calls) == 3
+    # The repair retry runs even for guard-flagged narratives; the canonical
+    # rescue answered, so the outcome-triggered planner never ran.
+    assert len(stub.ask_calls) == 2
 
 
 def test_top_zip_question_uses_direct_canonical_gold_sql_without_genie_call() -> None:
@@ -1970,8 +1968,12 @@ def test_conversation_id_is_forwarded_to_live_genie() -> None:
     result = repo.respond("why?", conversation_id="conv-existing")
 
     assert result.conversation_id == "conv-existing"
-    assert stub.ask_calls == ["why?"]
-    assert stub.ask_conversation_ids == ["conv-existing"]
+    # The blocked outcome triggers one agentic planning attempt (whose stub
+    # reply yields no plan), after the original ask.
+    assert stub.ask_calls[0] == "why?"
+    assert len(stub.ask_calls) == 2 and "numbered list" in stub.ask_calls[1]
+    # The planning attempt runs in a fresh conversation by design.
+    assert stub.ask_conversation_ids == ["conv-existing", None]
 
 
 def test_untrusted_sql_is_policy_blocked_and_not_rendered() -> None:


### PR DESCRIPTION
Live verification caught the hole: the full-analysis question contains
none of the repair gate's data words, so the planner (nested in the
repair branch) never ran and the turn still refused. New invariant with
zero keyword dependencies: no guardrail-passing question may end
policy_blocked until the live space has been given the chance to plan
its own decomposition — the planner now runs exactly when the adapted
turn would otherwise refuse, after the fast canonical rescue has had
its shot, and an unusable plan returns the honest refusal.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
