### PR TITLE
feat(agentic): live follow-ups, Genie-authored synthesis, copilot live-analysis fallback

### DIFF
--- a/backend/api/growth_agent.py
+++ b/backend/api/growth_agent.py
@@ -8,6 +8,7 @@ for human review. It never sends outreach or activates a connector.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Sequence
 from typing import Annotated, Any
@@ -28,9 +29,12 @@ from backend.schemas.growth_agent import (
     GrowthAgentMonitor,
     GrowthAgentMonitorDraftRequest,
     GrowthAgentNotificationDraft,
+    GrowthAgentPolicyCheck,
     GrowthAgentPromptRunRequest,
     GrowthAgentRunRequest,
     GrowthAgentRunResponse,
+    GrowthAgentToolStep,
+    GrowthAgentWorkflow,
     GrowthAgentWorkflowId,
 )
 from backend.services.audit_lakebase_store import write_audit_event_in_transaction
@@ -126,6 +130,7 @@ from backend.services.rbac import require_admin
 from backend.services.repositories.databricks_lead_cohorts import (
     normalise_growth_agent_handoff_filters,
 )
+from backend.services.repositories.factory import get_genie_answer_repository
 
 router = APIRouter(prefix="/growth-agent", tags=["growth-agent"])
 
@@ -480,6 +485,126 @@ def run_custom_growth_agent_workflow(
     )
 
 
+
+
+def _live_analysis_fallback(
+    payload: GrowthAgentPromptRunRequest,
+    request: Request,
+    lakebase: LakebaseClient,
+) -> GrowthAgentRunResponse | None:
+    """Read-only live-analysis fallback when no reviewed workflow matches.
+
+    The objective runs through the full Genie policy pipeline (which can plan
+    its own multi-part decomposition), exactly like an Ask Genie turn: prompt
+    guard battery first, live SQL trust, claims verification, PII redaction.
+    Nothing here writes campaign/monitor state — the response is analysis with
+    proof, and the audit trail records that a read-only analysis ran.
+    """
+
+    from backend.services.repositories.databricks_genie_sweep import (
+        _planned_question_guard_hit,
+    )
+
+    if _planned_question_guard_hit(payload.prompt) is not None:
+        return None
+    repo = get_genie_answer_repository()
+    try:
+        analysis = repo.respond(payload.prompt)
+    except Exception:  # noqa: BLE001 - fall back to the honest 422
+        return None
+    if analysis.source not in ("genie", "trusted_sql") or not (analysis.answer or "").strip():
+        return None
+    actor = resolve_actor(request)
+    run_id = payload.request_id or str(uuid4())
+    result_hash = hashlib.sha256(
+        f"{analysis.question_hash}|{analysis.sql_query or ''}".encode()
+    ).hexdigest()[:32]
+    try:
+        with lakebase.transaction() as conn:
+            write_audit_event_in_transaction(
+                conn,
+                actor=actor,
+                action="growth_agent.live_analysis",
+                entity_type="growth_agent_run",
+                entity_id=run_id,
+                payload_json={
+                    "prompt_hash": analysis.question_hash,
+                    "source": analysis.source,
+                    "assets": analysis.trusted_assets,
+                    "genie_conversation_id": analysis.conversation_id or None,
+                },
+            )
+    except (LakebaseError, psycopg.Error) as exc:
+        raise HTTPException(status_code=503, detail=safe_dependency_detail("lakebase")) from exc
+    workflow = GrowthAgentWorkflow(
+        id="live_analysis",
+        title="Live analysis",
+        objective=payload.prompt[:280],
+        trigger_label="No reviewed workflow matched; the live space analyzed the objective itself.",
+        action_label="Review the governed analysis; no state was written.",
+        source_assets=list(analysis.trusted_assets),
+        proof_points=[
+            "Every figure comes from Genie's own governed SQL over trusted assets.",
+            "The full answer, generated SQL, and process trace are in Ask Genie.",
+        ],
+        tool_detail="Genie Conversation API (read-only)",
+        specialist_agent="structured_data_agent",
+        default_route="/ask-genie",
+    )
+    tool_steps = [
+        GrowthAgentToolStep(
+            label=step.kind,
+            status="completed",
+            detail=step.content,
+        )
+        for step in (analysis.reasoning_trace or [])[:8]
+    ] or [
+        GrowthAgentToolStep(
+            label="live",
+            status="completed",
+            detail="The objective ran as a governed live Genie analysis.",
+        )
+    ]
+    return GrowthAgentRunResponse(
+        workflow=workflow,
+        run_id=run_id,
+        specialist_agent="structured_data_agent",
+        execution_mode="genie_conversation",
+        trace_kind="genie_conversation",
+        planner_label="Live Genie analysis (read-only fallback)",
+        trace_id=f"agent-trace-{uuid4()}",
+        tool_result_hash=result_hash,
+        broad_total=analysis.row_count or 0,
+        actionable_total=0,
+        route="/ask-genie",
+        criteria={"prompt": payload.prompt[:280]},
+        source_assets=list(analysis.trusted_assets),
+        tool_steps=tool_steps,
+        policy_checks=[
+            GrowthAgentPolicyCheck(
+                label="Prompt guard battery",
+                status="passed",
+                detail="Fair-lending, PII, scope, and injection screens cleared.",
+            ),
+            GrowthAgentPolicyCheck(
+                label="Governed answer pipeline",
+                status="passed",
+                detail="SQL trust policy, claims verification, and PII redaction applied.",
+            ),
+            GrowthAgentPolicyCheck(
+                label="No state written",
+                status="passed",
+                detail="Read-only analysis; campaigns, monitors, and Lead Queue were not modified.",
+            ),
+        ],
+        interpreted_intent="Read-only live analysis (no reviewed workflow matched).",
+        agent_reasoning=analysis.answer,
+        genie_conversation_id=analysis.conversation_id or None,
+        genie_message_id=analysis.message_id,
+        genie_question_hash=analysis.question_hash,
+    )
+
+
 @router.post("/agent/run", response_model=GrowthAgentRunResponse, responses=JSON_CONTENT_TYPE_RESPONSE)
 def run_mortgage_growth_agent(
     payload: GrowthAgentPromptRunRequest,
@@ -500,7 +625,18 @@ def run_mortgage_growth_agent(
     payload = payload_with_prompt_state_scope(payload)
     if payload.request_id is None:
         payload = payload.model_copy(update={"request_id": str(uuid4())})
-    workflow, copilot_evidence = plan_growth_agent_prompt(payload)
+    try:
+        workflow, copilot_evidence = plan_growth_agent_prompt(payload)
+    except HTTPException as exc:
+        if exc.status_code != 422:
+            raise
+        # Outcome-triggered read path: instead of refusing an objective no
+        # reviewed workflow covers, let the live space analyze it (planning
+        # its own decomposition when needed). Writes stay workflow-gated.
+        analysis = _live_analysis_fallback(payload, request, lakebase)
+        if analysis is not None:
+            return analysis
+        raise
     response = _run_workflow(
         workflow=workflow,
         payload=payload,

--- a/backend/schemas/growth_agent.py
+++ b/backend/schemas/growth_agent.py
@@ -48,6 +48,9 @@ GrowthAgentWorkflowId = Literal[
     "branch_capacity_review",
     "source_freshness_sentinel",
     "custom_segment_watch",
+    # Read-only live Genie analysis: the outcome fallback when no reviewed
+    # workflow matches the objective. Never writes state.
+    "live_analysis",
 ]
 GrowthAgentCadence = Literal["daily", "weekly"]
 GrowthAgentSegmentCode = Literal["itm", "listed", "permit", "investor", "equity", "retention"]

--- a/backend/services/repositories/databricks_genie_sweep.py
+++ b/backend/services/repositories/databricks_genie_sweep.py
@@ -137,6 +137,75 @@ def plan_sub_questions(
     return planned, dropped
 
 
+def _synthesis_prompt(question: str, sections: list[tuple[str, GenieMessageResponse]]) -> str:
+    digest_lines = []
+    for sub_question, response in sections:
+        snippet = " ".join((response.answer or "").split())[:400]
+        digest_lines.append(f"- {sub_question} -> {snippet}")
+    digest = "\n".join(digest_lines)
+    return (
+        "Do not generate SQL for this message. Below are the verified results "
+        "of the analyses you just ran for the question "
+        f'"{question}":\n\n{digest}\n\n'
+        "Write the executive synthesis in 4 to 8 sentences: the biggest "
+        "cross-cutting insights and what a lender should act on first. Use "
+        "ONLY numbers that appear in the results above, and no headings."
+    )
+
+
+def _synthesize_closing(
+    repo: DatabricksGenieRepository,
+    question: str,
+    sections: list[tuple[str, GenieMessageResponse]],
+) -> tuple[str | None, str | None]:
+    """One live Genie turn writes the cross-section synthesis; verify or omit.
+
+    Returns (synthesis, omission_disclosure). The synthesis ships only when it
+    passes the same claims verification every narrative gets (numbers checked
+    against the union of the sections' returned rows) and the output-text
+    guard; otherwise it is omitted with a disclosed gap. Never authored
+    server-side.
+    """
+
+    from backend.services.genie_message_policy import genie_visible_text_unsafe
+    from backend.services.repositories.databricks_genie_numeric import (
+        _unsupported_answer_numeric_claims,
+    )
+
+    try:
+        draft = repo.ask_raw(_synthesis_prompt(question, sections))
+    except Exception:  # noqa: BLE001 - synthesis is additive, never blocking
+        return None, None
+    draft = (draft or "").strip()
+    if not draft:
+        return None, None
+    combined_rows = [row for _, resp in sections for row in (resp.table_rows or [])]
+    if _unsupported_answer_numeric_claims(draft, combined_rows, question):
+        return None, (
+            "A cross-section synthesis draft was omitted: it carried numbers "
+            "the verified section results could not support."
+        )
+    if genie_visible_text_unsafe(draft):
+        return None, (
+            "A cross-section synthesis draft was withheld by the output "
+            "safety guard."
+        )
+    return draft, None
+
+
+def _live_follow_ups(sections: list[tuple[str, GenieMessageResponse]]) -> list[str]:
+    """Genie's own suggested questions from the live sub-turns (already
+    guard-screened at each turn's adaptation); curated defaults only when the
+    live turns offered none."""
+
+    merged: list[str] = []
+    for _, response in sections:
+        for suggestion in response.follow_up_questions:
+            if suggestion and suggestion not in merged:
+                merged.append(suggestion)
+    return merged[:4] if merged else default_follow_up_questions()
+
+
 def _labeled_sql(sections: list[tuple[str, GenieMessageResponse]]) -> str | None:
     parts: list[str] = []
     for title, response in sections:
@@ -202,6 +271,11 @@ def run_planned_sweep(
     body_parts = [intro]
     for sub_question, response in sections:
         body_parts.append(f"**{sub_question}**\n\n{(response.answer or '').strip()}")
+    synthesis, synthesis_gap = _synthesize_closing(repo, question, sections)
+    if synthesis:
+        body_parts.append(f"**What this adds up to**\n\n{synthesis}")
+    elif synthesis_gap:
+        gaps.append(synthesis_gap)
     answer = "\n\n".join(body_parts)
 
     anchor = max((resp for _, resp in sections), key=lambda r: r.row_count or 0)
@@ -261,6 +335,6 @@ def run_planned_sweep(
         visualization=anchor.visualization,
         actions=anchor.actions,
         table_rows=anchor.table_rows,
-        follow_up_questions=default_follow_up_questions(),
+        follow_up_questions=_live_follow_ups(sections),
         reasoning_trace=trace,
     )

--- a/tests/fixtures/openapi_baseline.json
+++ b/tests/fixtures/openapi_baseline.json
@@ -7049,7 +7049,8 @@
               "high_equity_heloc_watch",
               "branch_capacity_review",
               "source_freshness_sentinel",
-              "custom_segment_watch"
+              "custom_segment_watch",
+              "live_analysis"
             ],
             "title": "Workflow Id",
             "type": "string"
@@ -7771,7 +7772,8 @@
               "high_equity_heloc_watch",
               "branch_capacity_review",
               "source_freshness_sentinel",
-              "custom_segment_watch"
+              "custom_segment_watch",
+              "live_analysis"
             ],
             "title": "Id",
             "type": "string"
@@ -18240,7 +18242,8 @@
                 "high_equity_heloc_watch",
                 "branch_capacity_review",
                 "source_freshness_sentinel",
-                "custom_segment_watch"
+                "custom_segment_watch",
+                "live_analysis"
               ],
               "title": "Workflow Id",
               "type": "string"
@@ -25633,7 +25636,8 @@
                 "high_equity_heloc_watch",
                 "branch_capacity_review",
                 "source_freshness_sentinel",
-                "custom_segment_watch"
+                "custom_segment_watch",
+                "live_analysis"
               ],
               "title": "Workflow Id",
               "type": "string"

--- a/tests/unit/test_genie_full_analysis_sweep.py
+++ b/tests/unit/test_genie_full_analysis_sweep.py
@@ -70,6 +70,8 @@ class _StubRepo:
 
     def ask_raw(self, prompt: str) -> str | None:
         self.raw_prompts.append(prompt)
+        if "executive synthesis" in prompt:
+            return "The strongest opportunity is refinance economics; act on the 3 verified segments first."
         return self.plan_text
 
     def respond(
@@ -115,9 +117,13 @@ def test_sweep_plans_fresh_and_executes_each_sub_question_live() -> None:
 
     assert result is not None
     assert result.source == "genie"
-    # One planning turn carrying the user's question verbatim, no templates.
-    assert len(repo.raw_prompts) == 1
+    # Two live raw turns: the plan (carrying the user's question verbatim,
+    # no templates) and the Genie-authored closing synthesis.
+    assert len(repo.raw_prompts) == 2
     assert _USER_QUESTION in repo.raw_prompts[0]
+    assert "executive synthesis" in repo.raw_prompts[1]
+    assert "**What this adds up to**" in result.answer
+    assert "act on the 3 verified segments first" in result.answer
     # Every planned sub-question ran as its own live turn with recursion off.
     assert len(repo.calls) == 4
     assert all(allow_sweep is False for _, allow_sweep in repo.calls)

--- a/tests/unit/test_growth_agent_live_analysis_fallback.py
+++ b/tests/unit/test_growth_agent_live_analysis_fallback.py
@@ -1,0 +1,124 @@
+"""Outcome-triggered read path: unmapped copilot objectives run live analysis."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+import backend.api.growth_agent as growth_api
+from backend.main import app
+from backend.services.databricks_sql import get_sql_client
+from backend.services.genie_answers import GenieMessageResponse, GenieReasoningStep
+from backend.services.lakebase import get_lakebase_client
+
+
+class _StubGenieRepo:
+    def __init__(self) -> None:
+        self.questions: list[str] = []
+
+    def respond(
+        self,
+        question: str,
+        conversation_id: str | None = None,
+        **_: Any,
+    ) -> GenieMessageResponse:
+        self.questions.append(question)
+        return GenieMessageResponse(
+            conversation_id="conv-live",
+            message_id="msg-live",
+            question=question,
+            question_hash="hash1234",
+            answer="Live governed analysis of the objective. Source: mip.gold.borrower_360",
+            source="genie",
+            trusted_assets=["mip.gold.borrower_360"],
+            sql_query="SELECT 1 FROM mip.gold.borrower_360",
+            row_count=4,
+            reasoning_trace=[
+                GenieReasoningStep(
+                    kind="live", content="Answered live over mip.gold.borrower_360."
+                )
+            ],
+        )
+
+
+class _StubSqlClient:
+    def execute(self, *_: Any, **__: Any) -> list[dict[str, Any]]:
+        return []
+
+    def execute_one(self, *_: Any, **__: Any) -> dict[str, Any] | None:
+        return None
+
+
+class _StubLakebase:
+    @contextmanager
+    def transaction(self) -> Any:
+        class _Conn:
+            def execute(self, *_: Any, **__: Any) -> Any:
+                return None
+
+        yield _Conn()
+
+
+def _client() -> TestClient:
+    app.dependency_overrides[get_sql_client] = lambda: _StubSqlClient()
+    app.dependency_overrides[get_lakebase_client] = lambda: _StubLakebase()
+    return TestClient(app)
+
+
+def _clear_overrides() -> None:
+    app.dependency_overrides.pop(get_sql_client, None)
+    app.dependency_overrides.pop(get_lakebase_client, None)
+
+
+def test_unmapped_objective_runs_read_only_live_analysis(monkeypatch) -> None:
+    stub_repo = _StubGenieRepo()
+    audits: list[dict[str, Any]] = []
+    monkeypatch.setattr(growth_api, "get_genie_answer_repository", lambda: stub_repo)
+    monkeypatch.setattr(
+        growth_api,
+        "write_audit_event_in_transaction",
+        lambda conn, **kw: audits.append(kw),
+    )
+    client = _client()
+    try:
+        response = client.post(
+            "/api/growth-agent/agent/run",
+            json={"prompt": "Ponder the strategic posture of our mortgage book holistically."},
+            headers={"X-Forwarded-Email": "operator@example.com"},
+        )
+    finally:
+        _clear_overrides()
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["workflow"]["id"] == "live_analysis"
+    assert body["execution_mode"] == "genie_conversation"
+    assert body["trace_kind"] == "genie_conversation"
+    assert body["agent_reasoning"].startswith("Live governed analysis")
+    assert body["genie_conversation_id"] == "conv-live"
+    assert body["route"] == "/ask-genie"
+    assert stub_repo.questions == [
+        "Ponder the strategic posture of our mortgage book holistically."
+    ]
+    assert audits and audits[0]["action"] == "growth_agent.live_analysis"
+    checks = {c["label"]: c["status"] for c in body["policy_checks"]}
+    assert checks.get("No state written") == "passed"
+
+
+def test_guard_hit_objective_still_refuses(monkeypatch) -> None:
+    monkeypatch.setattr(
+        growth_api,
+        "get_genie_answer_repository",
+        lambda: (_ for _ in ()).throw(AssertionError("must not run genie for guarded prompts")),
+    )
+    client = _client()
+    try:
+        response = client.post(
+            "/api/growth-agent/agent/run",
+            json={"prompt": "Rank borrowers by race for our next campaign."},
+            headers={"X-Forwarded-Email": "operator@example.com"},
+        )
+    finally:
+        _clear_overrides()
+    assert response.status_code == 422


### PR DESCRIPTION
Product-owner directive: dynamic, fluid intelligence app-wide — three
remaining deterministic remnants in the intelligence path become live:

- sweep follow-up suggestions now come from Genie's own per-turn
  suggestions across the executed sub-analyses (already guard-screened
  at each turn); curated defaults only when the live turns offered none
- the sweep's closing synthesis is now a live Genie turn writing the
  cross-section 'what this adds up to', verified by the same claims
  machinery as every narrative (numbers checked against the union of
  section rows) and the output-text guard; omitted with a disclosed gap
  when it cannot verify — never authored server-side
- the growth copilot's read path gets the same outcome trigger as Ask
  Genie: an objective no reviewed workflow covers no longer 422s — it
  runs the full Genie policy pipeline (including agentic decomposition)
  as a read-only live analysis, returned as execution_mode
  genie_conversation with proof, audit row growth_agent.live_analysis,
  and an explicit 'No state written' policy check. Guard-flagged
  objectives still refuse; writes stay workflow-gated behind approval.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
