### PR TITLE
fix(growth-agent): the live-analysis fallback degrades to 422, never 500

### DIFF
--- a/backend/api/growth_agent.py
+++ b/backend/api/growth_agent.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from collections.abc import Sequence
 from typing import Annotated, Any
 from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
@@ -487,6 +488,9 @@ def run_custom_growth_agent_workflow(
 
 
 
+_LIVE_ANALYSIS_LOG = logging.getLogger("backend.api.growth_agent.live_analysis")
+
+
 def _live_analysis_fallback(
     payload: GrowthAgentPromptRunRequest,
     request: Request,
@@ -633,7 +637,15 @@ def run_mortgage_growth_agent(
         # Outcome-triggered read path: instead of refusing an objective no
         # reviewed workflow covers, let the live space analyze it (planning
         # its own decomposition when needed). Writes stay workflow-gated.
-        analysis = _live_analysis_fallback(payload, request, lakebase)
+        # A defect in the fallback must degrade to the honest 422 refusal,
+        # never a 500 masking it.
+        try:
+            analysis = _live_analysis_fallback(payload, request, lakebase)
+        except HTTPException:
+            raise
+        except Exception:
+            _LIVE_ANALYSIS_LOG.exception("live_analysis_fallback_failed")
+            analysis = None
         if analysis is not None:
             return analysis
         raise


### PR DESCRIPTION
Production validation 500'd after the analysis ran (locally green — the
test stubs hid the environment-specific failure). The fallback is now
wrapped so any defect logs the real exception and returns the honest
refusal instead of masking it with a server error.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
