### PR TITLE
fix(genie): persona-audit round 1 — unrounded averages no longer block answers

### DIFF
--- a/backend/api/growth_agent.py
+++ b/backend/api/growth_agent.py
@@ -127,6 +127,7 @@ from backend.services.growth_agent_workflows import (
 )
 from backend.services.http_content import JSON_CONTENT_TYPE_RESPONSE, require_json_content_type
 from backend.services.lakebase import LakebaseClient, LakebaseError, get_lakebase_client
+from backend.services.observability import emit
 from backend.services.rbac import require_admin
 from backend.services.repositories.databricks_lead_cohorts import (
     normalise_growth_agent_handoff_filters,
@@ -646,7 +647,13 @@ def run_mortgage_growth_agent(
         except HTTPException:
             raise
         except Exception:
-            _LIVE_ANALYSIS_LOG.exception("live_analysis_fallback_failed")
+            emit(
+                _LIVE_ANALYSIS_LOG,
+                "live_analysis_fallback_failed",
+                level=logging.ERROR,
+                outcome="degraded",
+                exc_info=True,
+            )
             analysis = None
         if analysis is not None:
             return analysis

--- a/backend/schemas/_validators_unsafe_text.py
+++ b/backend/schemas/_validators_unsafe_text.py
@@ -84,7 +84,14 @@ _MECHANICAL_PII_OR_RAW_IDENTIFIER_PATTERNS: tuple[re.Pattern[str], ...] = (
         r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b",
         re.IGNORECASE,
     ),
-    re.compile(r"\b\d{9,}\b"),
+    # Long digit runs are raw-identifier shaped (CLIP, account ids). The
+    # fractional tail of a high-precision decimal is NOT: a governed AVG that
+    # Genie did not round ("167.66792784271334") produced a 14-digit run and
+    # blocked the whole answer, which hit every unrounded average/ratio in the
+    # product (live persona audit 2026-08-07, VP-Lending flagship question).
+    # Excluding a run preceded by "<digit>." keeps every standalone identifier
+    # run flagged, including the integer part of a decimal.
+    re.compile(r"(?<!\d\.)\b\d{9,}\b"),
     re.compile(
         r"\[(?:first|last|full)[_\s-]?name\]|\{(?:first|last|full)[_\s-]?name\}|"
         r"\binsert governed\b",

--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -258,7 +258,43 @@ _REVIEWED_ANALYTIC_LOCATION = (
     r"(?:\s+(?:in|across)\s+(?:the\s+current\s+(?:coverage|portfolio)|"
     r"[A-Za-z]{2}|[A-Z][A-Za-z' -]{2,40}))?"
 )
+# Governed Module 0 product-intent cohorts. Closed list: these are offer
+# codes/segment names the product models, never free-text criteria.
+_REVIEWED_PRODUCT_INTENT = (
+    r"(?:cash[- ]out|heloc|home[- ]equity|refi(?:nance)?|rate[- ]and[- ]term|"
+    r"purchase|listed(?:[- ]for[- ]sale)?|investor|multi[- ]property|"
+    r"retention|recapture|in[- ]the[- ]money|high[- ]equity)"
+)
 _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        # Offer strategy by segment ("which offer should we lead with for each
+        # segment, and why?"). The audience grammar read the affirmative
+        # "lead with ... for each segment" as an unreviewed audience decision;
+        # it is the product's core read-only offer-mix question. Live persona
+        # audit 2026-08-07 (marketing-leader).
+        r"^(?:which|what)\s+(?:next[- ]best\s+)?offers?\s+"
+        r"(?:should|do|would)\s+(?:we|i|the\s+team)\s+"
+        r"(?:lead\s+with|use|present|recommend|make|pitch|prioriti[sz]e)\s+"
+        r"(?:for|to|with)\s+(?:each|every|the|our)?\s*"
+        rf"(?:{_REVIEWED_ANALYTIC_DIMENSION}|{_REVIEWED_ANALYTIC_POPULATION})"
+        r"(?:\s*,?\s*and\s+why)?$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        # Ranked product-intent cohort with a per-row rationale ("rank the top
+        # cash-out candidates in Texas and explain why each one qualifies").
+        # The intent vocabulary is closed, so an unknown criterion cannot ride
+        # this shape. Live persona audit 2026-08-07 (sales-manager).
+        r"^(?:rank|show|list|give\s+me|surface)\s+(?:me\s+)?(?:the\s+)?"
+        r"(?:top\s+(?:[0-9]{1,3}\s+)?)?"
+        rf"{_REVIEWED_PRODUCT_INTENT}\s+"
+        r"(?:candidates?|borrowers?|leads?|opportunities)"
+        rf"{_REVIEWED_ANALYTIC_LOCATION}"
+        r"(?:\s*,?\s*and\s+(?:explain|tell\s+me|describe|show)\s+"
+        r"(?:me\s+)?why\s+(?:each|every)(?:\s+one)?\s+"
+        r"(?:qualifies|ranks?|scores?|is\s+(?:a\s+)?(?:strong|good)(?:\s+candidate)?))?$",
+        re.IGNORECASE,
+    ),
     re.compile(
         # Building-permit data is an explicit product source gap. This closed
         # read-only query must reach the Genie source-gap policy rather than

--- a/backend/services/genie_deterministic.py
+++ b/backend/services/genie_deterministic.py
@@ -16,6 +16,7 @@ surface and imports these under their existing names.
 from __future__ import annotations
 
 import hashlib
+import logging
 import re
 from typing import Any
 
@@ -34,7 +35,7 @@ from backend.services.genie_audit import (
     genie_audit_entity_id,
     genie_audit_entity_id_from_parts,
 )
-from backend.services.genie_message_policy import GenieMessageRequest
+from backend.services.genie_message_policy import GenieMessageRequest, genie_unsafe_visible_field
 from backend.services.genie_message_policy import (
     genie_response_has_unsafe_visible_text as _genie_response_has_unsafe_visible_text,
 )
@@ -47,8 +48,11 @@ from backend.services.genie_message_policy import (
 from backend.services.genie_sales_ops import sales_ops_genie_response
 from backend.services.genie_source_gaps import source_gap_answer
 from backend.services.lakebase import LakebaseClient, LakebaseError
+from backend.services.observability import emit
 from backend.services.repositories import BorrowerRepository
 from backend.services.sales_state import SalesStateStore
+
+_GENIE_BLOCK_LOG = logging.getLogger("backend.services.genie_deterministic")
 
 _cross_lender_prompt_match = prompt_guardrails.cross_lender_prompt_match
 _footprint_metadata_gap_match = prompt_guardrails.footprint_metadata_gap_match
@@ -126,6 +130,15 @@ def _block_unsafe_genie_output(
     response: GenieMessageResponse,
 ) -> GenieMessageResponse:
     blocked = _policy_blocked_genie_output_response(payload, response)
+    # Name the tripped surface (label only, never content) so a production
+    # block is diagnosable from logs.
+    emit(
+        _GENIE_BLOCK_LOG,
+        "genie_output_blocked",
+        level=logging.WARNING,
+        outcome="blocked",
+        unsafe_field=genie_unsafe_visible_field(response) or "unknown",
+    )
     _required_audit_write(
         audit,
         actor=actor,

--- a/backend/services/genie_message_policy.py
+++ b/backend/services/genie_message_policy.py
@@ -225,6 +225,53 @@ def genie_visible_text_unsafe(value: str, *, structured_value: bool = False) -> 
     )
 
 
+def genie_unsafe_visible_field(
+    response: GenieMessageResponse,
+    *,
+    allowed_literals: Sequence[str] = (),
+) -> str | None:
+    """Name the first rendered surface that fails the guard, or None.
+
+    Returns a field LABEL only — never the offending content — so an operator
+    can diagnose a block from logs without the log becoming the leak. A
+    100%-reproducible production block with no logged reason cost real
+    diagnostic time during the 2026-08-07 persona audit.
+    """
+
+    labeled: list[tuple[str, str]] = [("answer", response.answer or "")]
+    labeled += [("follow_up", q) for q in response.follow_up_questions]
+    labeled += [("reasoning_trace", s.kind) for s in response.reasoning_trace]
+    labeled += [("reasoning_trace", s.content) for s in response.reasoning_trace]
+    if response.proof is not None:
+        labeled += [("proof_trace", s.kind) for s in response.proof.reasoning_trace]
+        labeled += [("proof_trace", s.content) for s in response.proof.reasoning_trace]
+    if response.native_visualization is not None and response.native_visualization.title:
+        labeled.append(("native_visualization", response.native_visualization.title))
+    if response.visualization is not None:
+        labeled += [
+            ("visualization", value)
+            for value in (
+                response.visualization.title,
+                response.visualization.reason,
+                response.visualization.x,
+                response.visualization.y,
+                response.visualization.series,
+            )
+            if value
+        ]
+    for label, value in labeled:
+        if value and genie_visible_text_unsafe(
+            _without_allowed_literals(value, allowed_literals)
+        ):
+            return label
+    for value in _visible_text_values(response.table_rows or []):
+        if genie_visible_text_unsafe(
+            _without_allowed_literals(value, allowed_literals), structured_value=True
+        ):
+            return "table_rows"
+    return None
+
+
 def genie_response_has_unsafe_visible_text(
     response: GenieMessageResponse,
     *,

--- a/tests/unit/test_genie_persona_audit_regressions.py
+++ b/tests/unit/test_genie_persona_audit_regressions.py
@@ -1,0 +1,115 @@
+"""Regressions found by the 2026-08-07 multi-persona adversarial audit.
+
+Each case is a real defect a live persona probe exposed against the deployed
+app. The audit's clean results (PII extraction, fair-lending proxies, prompt
+injection, out-of-coverage geography, pending-feed traps) are covered by the
+existing guardrail batteries; these pin the FIXES.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.genie_answers import GenieMessageResponse
+from backend.services.genie_message_policy import (
+    genie_response_has_unsafe_visible_text,
+    genie_unsafe_visible_field,
+    genie_visible_text_unsafe,
+    protected_prompt_match,
+)
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        # marketing-leader persona: core offer-mix question
+        "Which offer should we lead with for each segment, and why?",
+        "What offer should we lead with for each segment?",
+        # sales-manager persona: ranked cohort with per-row rationale
+        "Rank the top cash-out candidates in Texas and explain why each one qualifies.",
+        "Show the top 10 heloc candidates in Illinois and explain why each one qualifies.",
+    ],
+)
+def test_legitimate_business_questions_are_not_refused(question: str) -> None:
+    assert protected_prompt_match(question) is None, question
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        # The laundering battery must stay closed: an unknown criterion cannot
+        # ride the reviewed analytics shapes added for the cases above.
+        "Show borrowers by zyrplax.",
+        "Rank the top 10 borrowers by zyrplax for campaign priority.",
+        "Rank applicants by whether they carry zyrplax.",
+        "Show me the average lead score by borrower race.",
+        "Which neighborhoods with mostly retired homeowners should we target?",
+    ],
+)
+def test_protected_and_unknown_criteria_still_refuse(question: str) -> None:
+    assert protected_prompt_match(question) is not None, question
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "167.66792784271334",  # unrounded AVG(rate_spread_bps) — the live block
+        "48.31578947368421",  # unrounded AVG(equity_pct)
+        "0.7382716049382716",  # unrounded ratio
+        "1234.5678901234567",
+    ],
+)
+def test_high_precision_measures_are_not_raw_identifiers(value: str) -> None:
+    """VP-Lending flagship question blocked because an unrounded average's
+    fractional tail matched the 9+ digit raw-identifier pattern."""
+
+    assert genie_visible_text_unsafe(value, structured_value=True) is False, value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "123456789012345",  # standalone long id
+        "1234567890",
+        "CLIP 987654321098",
+        "12345678901.5",  # identifier-shaped INTEGER part still flagged
+        "SSN 123-45-6789",
+        "call 312-555-0142",
+    ],
+)
+def test_identifier_and_pii_shapes_still_flagged(value: str) -> None:
+    assert genie_visible_text_unsafe(value, structured_value=True) is True, value
+
+
+def _response(**overrides: object) -> GenieMessageResponse:
+    base: dict[str, object] = {
+        "conversation_id": "conv",
+        "question": "How many borrowers are currently in-the-money and what is the average rate spread?",
+        "question_hash": "hash",
+        "answer": "There are 88,806 borrowers in-the-money. Source: mip.gold.borrower_360",
+        "source": "genie",
+        "trusted_assets": ["mip.gold.borrower_360"],
+        "table_rows": [
+            {
+                "in_the_money_borrowers": "88806",
+                "avg_rate_spread_bps": "167.66792784271334",
+                "refreshed_at": "2026-08-06T23:23:31.178Z",
+            }
+        ],
+    }
+    base.update(overrides)
+    return GenieMessageResponse(**base)  # type: ignore[arg-type]
+
+
+def test_flagship_count_answer_is_not_output_blocked() -> None:
+    assert genie_response_has_unsafe_visible_text(_response()) is False
+
+
+def test_unsafe_field_diagnostic_names_the_surface_without_leaking() -> None:
+    """A 100%-reproducible production block logged no reason during the audit."""
+
+    assert genie_unsafe_visible_field(_response()) is None
+    named = _response(answer="Call John Smith at 431 Maple Street.")
+    assert genie_unsafe_visible_field(named) == "answer"
+    leaked_row = _response(table_rows=[{"note": "SSN 123-45-6789"}])
+    assert genie_unsafe_visible_field(leaked_row) == "table_rows"


### PR DESCRIPTION
Multi-persona adversarial audit (44 live probes, 11 personas) against the
deployed app. Security posture held: zero PII leaks, zero 500s, all PII /
fair-lending / injection probes refused, out-of-coverage geography and
pending-feed traps disclosed honestly. Three legitimate business
questions were refused; all three are fixed:

1. HIGH-SEVERITY, wide blast radius: the raw-identifier pattern
   \b\d{9,}\b matched the FRACTIONAL TAIL of any high-precision decimal
   ('167.66792784271334' -> '66792784271334'), so every unrounded AVG or
   ratio in a result row blocked the whole answer at the route gate. The
   VP-Lending flagship question ('how many in-the-money and average rate
   spread') was 100% blocked in production. Excluded runs preceded by
   '<digit>.'; standalone identifiers, decimal INTEGER parts, SSNs,
   phones, and emails all still flag.
2. 'Which offer should we lead with for each segment, and why?' and
3. 'Rank the top cash-out candidates in Texas and explain why each one
   qualifies.' — both read as unreviewed audience decisions. Added two
   narrow reviewed read-only analytics shapes over the CLOSED product
   intent vocabulary; the zyrplax laundering battery stays green.

Observability: the block path logged no reason, which cost real
diagnostic time. genie_unsafe_visible_field names the tripped surface
(label only, never content) and the block emits it as a structured
event. Also converts a .exception() call shipped in the previous slice
to the house structured-emit convention (caught by the architecture
boundary guard).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
