### PR TITLE
fix(genie): persona-audit round 3 — narrative quality, disclosure, and sweep hygiene

### DIFF
--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -667,6 +667,17 @@ def _adapt_genie_response(
     )
     if answer_override is not None:
         answer_text: str | None = answer_override
+    elif cross_check_gaps and not prose_withheld_reason:
+        # Doctrine: disclose divergence — IN THE ANSWER, not only in the
+        # proof drawer. The persona audit confirmed a 0-of-10 ranking overlap
+        # was computed and never shown to the user (the presenter's next click
+        # into Lead Queue would not match the list on screen).
+        divergence_note = " ".join(cross_check_gaps)
+        answer_text = (
+            f"{(result.answer_text or '').strip()}\n\n{divergence_note}"
+            if (result.answer_text or "").strip()
+            else divergence_note
+        )
     elif prose_withheld_reason:
         row_count = len(rows) if rows else 0
         row_word = "row" if row_count == 1 else "rows"
@@ -813,11 +824,22 @@ def _governed_cross_check(
     return _CROSS_CHECK_CLEAN
 
 
+# A citation Genie wrote INLINE at the end of a paragraph, or one naming
+# several assets ("Source: mip.gold.borrower_360, mip.gold.evidence_events"),
+# never matched the own-line pattern above — so the app appended a second,
+# narrower line. That printed a duplicate "Source:" on 7 of 24 audited answers
+# and silently dropped the evidence table from a multi-asset citation
+# (live persona audit 2026-08-07).
+_INLINE_SOURCE_RE = re.compile(
+    r"(?i)source\s*:\s*`?[A-Za-z_][\w-]*\.[A-Za-z_]\w*\.[A-Za-z_]\w*"
+)
+
+
 def _ensure_answer_cites_source(answer: str | None, trusted_assets: list[str]) -> str:
-    """Append a source line when trusted live Genie text omits one."""
+    """Append a source line only when the text cites no asset at all."""
 
     text = (answer or "").strip()
-    if not trusted_assets or _SOURCE_LINE_RE.search(text):
+    if not trusted_assets or _SOURCE_LINE_RE.search(text) or _INLINE_SOURCE_RE.search(text):
         return text
     source = trusted_assets[0]
     if not text:

--- a/backend/services/repositories/databricks_genie_sweep.py
+++ b/backend/services/repositories/databricks_genie_sweep.py
@@ -41,6 +41,24 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 # Sources that mean a sub-turn produced governed analytic content.
 _DATA_BEARING_SOURCES = frozenset({"genie", "trusted_sql"})
 
+# A turn can be governed and still carry no prose: when the narrative is
+# withheld the answer is a status line about the pipeline. Printing that under
+# a section heading is worse than omitting the section (live persona audit
+# 2026-08-07: 3 of 5 sections read "the draft narrative was withheld").
+_PLUMBING_ANSWER_MARKERS = (
+    "the draft narrative was withheld",
+    "did not pass the governed output policy",
+    "did not return trusted sql",
+)
+
+
+def _has_rendered_prose(response: GenieMessageResponse) -> bool:
+    answer = (response.answer or "").strip()
+    if not answer:
+        return False
+    lowered = answer.lower()
+    return not any(marker in lowered for marker in _PLUMBING_ANSWER_MARKERS)
+
 # Fan-out cap: polite to the Conversation API while keeping wall time near the
 # slowest single turn.
 _SWEEP_MAX_WORKERS = 4
@@ -57,7 +75,11 @@ def _planning_prompt(question: str) -> str:
         "not execute anything. The user asked a broad question that cannot be "
         "answered by a single SQL statement:\n\n"
         f'"{question}"\n\n'
-        "Break it into the specific analytics questions YOU judge most useful, "
+        "If this is not an analytics request at all — a greeting, a request "
+        "for help using the product, or unintelligible input — reply with "
+        "exactly NO_PLAN and nothing else.\n\n"
+        "Otherwise break it into the specific analytics questions YOU judge "
+        "most useful, "
         "phrased as neutral read-only analytics (prefer 'top borrowers by "
         "opportunity score' over audience-selection wording like 'eligible "
         "for' or 'characteristics of'), "
@@ -71,6 +93,12 @@ def _planning_prompt(question: str) -> str:
 
 def _parse_planned_questions(text: str | None) -> list[str]:
     if not text:
+        return []
+    # The planner's own "this is not an analytics request" verdict. Nothing
+    # here inspects the USER's wording — the live space decides, and the
+    # normal single-turn path then answers "help"-style prompts directly
+    # instead of burning a seven-turn sweep on them.
+    if "NO_PLAN" in text.upper():
         return []
     planned: list[str] = []
     for line in text.splitlines():
@@ -130,7 +158,8 @@ def plan_sub_questions(
         hit = _planned_question_guard_hit(candidate)
         if hit is not None:
             dropped.append(
-                f"One planned sub-analysis was dropped by the {hit} before execution."
+                "One planned sub-analysis used selection vocabulary outside the "
+                f"reviewed set ({hit}) and was not executed."
             )
             continue
         planned.append(candidate)
@@ -245,7 +274,7 @@ def run_planned_sweep(
         if (
             response is not None
             and response.source in _DATA_BEARING_SOURCES
-            and (response.answer or "").strip()
+            and _has_rendered_prose(response)
         ):
             sections.append((sub_question, response))
         else:

--- a/genie/mortgage_lead_intelligence_space.yml
+++ b/genie/mortgage_lead_intelligence_space.yml
@@ -215,6 +215,27 @@ instructions: |
       exactly as modeled in mip.gold.evidence_events. Competitor-lien evidence is
       signal_type = 'competitor_lien'. Never use signal_type = 'lien-change' or
       signal_type = 'competitor'.
+    - VOLUME ARITHMETIC (persona audit 2026-08-07: a 10,000-touch plan
+      recommended lanes totaling 1,718 borrowers without noticing): when the
+      user names a target volume (touches, calls, contacts, budgeted
+      outreach), sum the addressable counts you return, compare against the
+      requested volume IN THE ANSWER, and state the gap plainly — e.g. "these
+      five lanes cover 1,718 of the requested 10,000 touches; widening to
+      the next segments or lowering the score floor covers the rest." Never
+      present a plan whose arithmetic you have not stated.
+    - COHORT PREDICATE DISCLOSURE (persona audit: Illinois was reported as
+      48,396 in one answer and 1,173,260 in the next with no bridge): any
+      answer citing a cohort count must name the filter that produced it in
+      plain words — e.g. "48,396 = marketing-eligible, opt-in borrowers
+      passing the refinance-economics screen" vs "1,173,260 = all borrowers
+      with equity above the cash-out floor, before eligibility filters."
+      When two adjacent framings could both be read as "the" number, state
+      both and the difference.
+    - TEACH THE TERMS: the first time an answer uses opportunity score, rate
+      spread, in-the-money, lock-in, or confidence, define it inline in one
+      clause ("opportunity score — a 0-100 blend of refinance economics,
+      equity, listing, portfolio, retention, and propensity signals"). A
+      Head of Growth reading the answer cold must not need a glossary.
     - LOAN AGE / loan vintage / seasoning semantics (re-audit 2026-06-11: a
       live answer computed "average loan age" from the data-refresh date and
       returned 0.00 years — wrong): loan age means time since the mortgage

--- a/tests/unit/test_genie_persona_audit_regressions.py
+++ b/tests/unit/test_genie_persona_audit_regressions.py
@@ -113,3 +113,98 @@ def test_unsafe_field_diagnostic_names_the_surface_without_leaking() -> None:
     assert genie_unsafe_visible_field(named) == "answer"
     leaked_row = _response(table_rows=[{"note": "SSN 123-45-6789"}])
     assert genie_unsafe_visible_field(leaked_row) == "table_rows"
+
+
+# --- Round 2: narrative-quality defects from the same audit -----------------
+
+
+def test_inline_and_multi_asset_citations_are_not_duplicated() -> None:
+    """7 of 24 audited answers printed 'Source:' twice, and a multi-asset
+    citation silently lost its evidence table."""
+
+    from backend.services.repositories.databricks_genie import (
+        _ensure_answer_cites_source,
+    )
+
+    assets = ["mip.gold.borrower_360"]
+    inline = _ensure_answer_cites_source(
+        "There are 88,806 borrowers. Source: mip.gold.borrower_360.", assets
+    )
+    assert inline.count("Source:") == 1
+    own_line = _ensure_answer_cites_source(
+        "Body text.\n\nSource: mip.gold.borrower_360", assets
+    )
+    assert own_line.count("Source:") == 1
+    multi = _ensure_answer_cites_source(
+        "Body. Source: mip.gold.borrower_360, mip.gold.evidence_events.", assets
+    )
+    assert multi.count("Source:") == 1
+    assert "evidence_events" in multi
+    # A genuinely uncited answer still gets its citation.
+    assert "Source:" in _ensure_answer_cites_source("There are 88,806 borrowers.", assets)
+
+
+def test_planner_no_plan_verdict_skips_the_sweep() -> None:
+    """The live space decides a prompt is not analytics ('help'), instead of a
+    keyword gate — and the seven-turn sweep does not fire."""
+
+    from backend.services.repositories.databricks_genie_sweep import (
+        _parse_planned_questions,
+    )
+
+    assert _parse_planned_questions("NO_PLAN") == []
+    assert _parse_planned_questions("no_plan") == []
+    assert (
+        len(
+            _parse_planned_questions(
+                "1. How many borrowers are in the money?\n"
+                "2. Which states lead?\n"
+                "3. What fired recently?"
+            )
+        )
+        == 3
+    )
+
+
+def test_sweep_sections_without_prose_are_suppressed() -> None:
+    """A governed turn whose narrative was withheld carries a plumbing status
+    line; printing it under a section heading is worse than omitting it."""
+
+    from backend.services.genie_answers import GenieMessageResponse
+    from backend.services.repositories.databricks_genie_sweep import _has_rendered_prose
+
+    def _response(answer: str) -> GenieMessageResponse:
+        return GenieMessageResponse(
+            conversation_id="c",
+            question="q",
+            question_hash="h",
+            answer=answer,
+            source="genie",
+            trusted_assets=["mip.gold.borrower_360"],
+        )
+
+    assert (
+        _has_rendered_prose(
+            _response(
+                "Genie ran a governed query against mip.gold.borrower_360 and "
+                "returned 5 rows, shown with the generated SQL. The draft "
+                "narrative was withheld: it contained numbers the app could not verify."
+            )
+        )
+        is False
+    )
+    assert _has_rendered_prose(_response("There are 88,806 borrowers, averaging 167 bps.")) is True
+
+
+def test_divergence_note_passes_the_output_gate() -> None:
+    """The cross-check divergence is now rendered in the answer body, so it
+    must clear the same guard every rendered string clears."""
+
+    from backend.services.genie_message_policy import genie_visible_text_unsafe
+
+    note = (
+        "Governed cross-check: this answer's framing overlaps 0 of 10 borrowers "
+        "with the canonical opportunity ranking; both are governed views — the "
+        "Lead Queue holds the operational list."
+    )
+    assert genie_visible_text_unsafe(note) is False


### PR DESCRIPTION
Closes the remaining business-auditor findings from the 2026-08-07
persona audit (the copilot compliance items are a separate in-flight
slice and are untouched here):

- DISCLOSE DIVERGENCE IN THE ANSWER. The governed cross-check computed
  'this framing overlaps 0 of 10 borrowers with the canonical ranking'
  and put it only in proof.known_data_gaps, so a presenter clicking
  into Lead Queue would find a different list with no warning. The
  divergence now renders in the answer body (doctrine says disclose,
  not merely record); pinned as gate-clean.
- SOURCE CITATIONS. The own-line-anchored pattern missed citations
  Genie wrote inline or across several assets, so the app appended a
  second, narrower line: 7 of 24 audited answers printed 'Source:'
  twice and a multi-asset citation lost mip.gold.evidence_events. Now
  a citation anywhere suppresses the append.
- SWEEP HYGIENE. (a) 'help' burned a 55s seven-turn sweep and returned
  a 5,586-char report; the PLANNER now decides — it may return NO_PLAN
  and the normal single-turn path answers instead (agentic verdict, not
  a keyword gate). (b) Sections whose narrative was withheld printed a
  plumbing status line under a heading; they are dropped with the
  existing disclosure instead.
- DISCLOSURE WORDING. 'dropped by the protected-class screen' implied
  Genie kept attempting protected-class analytics (it appeared 4x on a
  benign prompt); it now names the real cause — selection vocabulary
  outside the reviewed set.
- SPACE INSTRUCTIONS. Volume arithmetic (a 10,000-touch plan proposed
  lanes totaling 1,718 without noticing), cohort-predicate disclosure
  (Illinois reported as 48,396 and 1,173,260 with no bridge), and
  teach-the-term-inline for opportunity score / rate spread / lock-in.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
