### PR TITLE
fix(genie): a withheld narrative renders the verified rows, not pipeline chatter

### DIFF
--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -679,12 +679,16 @@ def _adapt_genie_response(
             else divergence_note
         )
     elif prose_withheld_reason:
-        row_count = len(rows) if rows else 0
-        row_word = "row" if row_count == 1 else "rows"
-        answer_text = (
-            f"Genie ran a governed query against {trusted_assets[0]} and returned "
-            f"{row_count:,} {row_word}, shown with the generated SQL. The draft "
-            f"narrative was withheld: {prose_withheld_reason}"
+        # Withholding the model's prose must not leave the user reading
+        # pipeline chatter. The verified rows are already in hand, so render
+        # them factually — values straight from the result, no derivation and
+        # no claims — and disclose why the draft was withheld. (Live persona
+        # audit 2026-08-07: withheld turns rendered a status line and read as
+        # content-free answers.)
+        answer_text = _factual_row_summary(
+            rows,
+            trusted_assets,
+            withheld_reason=prose_withheld_reason,
         )
     else:
         answer_text = result.answer_text
@@ -833,6 +837,69 @@ def _governed_cross_check(
 _INLINE_SOURCE_RE = re.compile(
     r"(?i)source\s*:\s*`?[A-Za-z_][\w-]*\.[A-Za-z_]\w*\.[A-Za-z_]\w*"
 )
+
+
+def _format_cell(value: object) -> str:
+    """Render one governed cell for the factual fallback summary."""
+
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, int):
+        return f"{value:,}"
+    if isinstance(value, float):
+        return f"{value:,.2f}".rstrip("0").rstrip(".")
+    text = str(value).strip()
+    try:  # numeric strings arrive from the SQL layer as text
+        numeric = float(text)
+    except (TypeError, ValueError):
+        return text
+    if numeric.is_integer():
+        return f"{int(numeric):,}"
+    return f"{numeric:,.2f}"
+
+
+def _humanize_column(column: str) -> str:
+    return column.replace("_", " ").strip()
+
+
+def _factual_row_summary(
+    rows: list[dict[str, Any]] | None,
+    trusted_assets: list[str],
+    *,
+    withheld_reason: str,
+) -> str:
+    """Render the verified rows plainly when the model's prose is withheld."""
+
+    asset = trusted_assets[0] if trusted_assets else "the trusted assets"
+    disclosure = f"Genie's draft narrative was withheld: {withheld_reason}"
+    if not rows:
+        return (
+            f"The governed query against {asset} returned no rows. {disclosure}"
+        )
+    row_count = len(rows)
+    if row_count == 1:
+        pairs = [
+            f"{_humanize_column(column)}: {_format_cell(value)}"
+            for column, value in rows[0].items()
+            if value is not None
+        ]
+        body = "; ".join(pairs[:8])
+        return (
+            f"From {asset}, the governed query returned {body}. "
+            f"These figures come straight from the returned row. {disclosure}"
+        )
+    first = rows[0]
+    headline_pairs = [
+        f"{_humanize_column(column)}: {_format_cell(value)}"
+        for column, value in first.items()
+        if value is not None
+    ]
+    headline = "; ".join(headline_pairs[:5])
+    return (
+        f"The governed query against {asset} returned {row_count:,} rows, "
+        f"shown in full in the table. The first row reads {headline}. "
+        f"Every value comes straight from the returned rows. {disclosure}"
+    )
 
 
 def _ensure_answer_cites_source(answer: str | None, trusted_assets: list[str]) -> str:

--- a/tests/unit/test_genie_persona_audit_regressions.py
+++ b/tests/unit/test_genie_persona_audit_regressions.py
@@ -254,3 +254,42 @@ def test_narrative_prose_is_unaffected_by_the_measure_exemption() -> None:
 
     assert genie_visible_text_unsafe("Call 312-555-0142 today") is True
     assert genie_visible_text_unsafe("1250000000") is True
+
+
+def test_withheld_prose_renders_verified_rows_not_pipeline_chatter() -> None:
+    """When the model's prose is withheld the user must still get the verified
+    data, not a status line about the pipeline (live audit 2026-08-07:
+    withheld turns read as content-free answers)."""
+
+    from backend.services.genie_message_policy import genie_visible_text_unsafe
+    from backend.services.repositories.databricks_genie import _factual_row_summary
+
+    single = _factual_row_summary(
+        [
+            {
+                "in_the_money_borrowers": "88806",
+                "avg_rate_spread_bps": "167.66792784271334",
+            }
+        ],
+        ["mip.gold.borrower_360"],
+        withheld_reason="it carried numbers the returned rows could not verify.",
+    )
+    assert "88,806" in single
+    assert "167.67" in single
+    assert "in the money borrowers" in single
+    assert "withheld" in single  # the disclosure survives
+    assert genie_visible_text_unsafe(single) is False
+
+    multi = _factual_row_summary(
+        [{"state": "IL", "borrowers": 48396}, {"state": "TX", "borrowers": 10914}],
+        ["mip.gold.borrower_360"],
+        withheld_reason="the output safety guard flagged its wording.",
+    )
+    assert "2 rows" in multi
+    assert "48,396" in multi
+    assert genie_visible_text_unsafe(multi) is False
+
+    empty = _factual_row_summary(
+        [], ["mip.gold.borrower_360"], withheld_reason="test reason."
+    )
+    assert "no rows" in empty


### PR DESCRIPTION
Final open item from the persona audit. When the claims verifier or the
output guard withholds the model's prose, the answer body was a status
line ('Genie ran a governed query ... The draft narrative was
withheld'), which audited as a content-free answer — the single most
demo-damaging pattern the business auditor found, and the reason the
no-prose count plateaued at 3-4 of 44 across rounds.

Withholding model prose never justified withholding the DATA. The
verified rows are already in hand, so the answer now renders them
factually — values straight from the result, no derivation, no claims,
no model text — and keeps the disclosure about why the draft was
withheld. This is not a canned answer: it is the governed result of
Genie's own query, rendered plainly instead of hidden behind a status
message.

Withholds are inherently variance-driven (a live capture of the same
flagship question came back clean), so this converts the remaining
tail from 'content-free' to 'factual but plainer', with the disclosure
intact either way.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
