### PR TITLE
fix(frontend): 2026-08-07 rendering audit — signed bps, money units, ZIP-as-measure, topbar overlap

### DIFF
--- a/.claude/agent-memory/frontend-implementer/MEMORY.md
+++ b/.claude/agent-memory/frontend-implementer/MEMORY.md
@@ -8,3 +8,5 @@
 - [CSS cascade is source-order](project_css_cascade_order.md) — components.css is flat with no @layer; reusing a primitive declared later needs parent-scoped specificity.
 - [Lead-queue filter plumbing](project_lead_queue_filter_plumbing.md) — a new portfolio filter needs 4 parallel structures in lead-queue.filters.ts; API pass-through is generic.
 - [Component test context mock](project_component_test_context_mock.md) — mock ../AppContext useApp for setDrawer; run tests via npm --prefix frontend (not npx --root) or babel breaks.
+- [Worktree frontend validation](project_worktree_frontend_validation.md) — symlink node_modules to run tests; preview_start serves the MAIN checkout, so verify visuals off `frontend/dist`.
+- [Shared display formatters](project_shared_formatters.md) — lib/formatters.ts owns bps/currency/rate units; never hand-roll a unit in JSX.

--- a/.claude/agent-memory/frontend-implementer/project_shared_formatters.md
+++ b/.claude/agent-memory/frontend-implementer/project_shared_formatters.md
@@ -1,0 +1,27 @@
+---
+name: project-shared-formatters
+description: frontend/src/lib/formatters.ts is the single home for unit-bearing display formatting (bps, compact currency, rate percents) — import it instead of hand-rolling in JSX.
+metadata:
+  type: project
+---
+
+`frontend/src/lib/formatters.ts` owns every unit the product renders:
+`currency`, `compactCurrency` (K→M rollup), `signedBps` / `signedBpsLabel`,
+`ratePct` (input already 0-100) and `ratePctFromFraction` (input 0-1).
+
+**Why:** the 2026-08-07 rendering audit found the same class of bug at six
+independent call sites because each one formatted its own unit inline —
+`+{rate_spread_bps}` on a signed field produced `+-422 bps`,
+`$${v/1000}k` produced `$4410k`, and a raw `{current_rate}%` next to a
+`(market_rate*100).toFixed(3)` put two rate precisions on one screen. The
+formatter module (PR #166) plus `formatters.test.ts` pins each of those cases.
+
+**How to apply:** when rendering a number with a unit, import from
+`lib/formatters` — do not write a template literal with `$`, `%`, `bps`, or a
+`/1000` in JSX. If a new unit is needed, add it there with a doc comment naming
+the gold column's unit (SQL `COMMENT ON COLUMN` is authoritative: e.g.
+`current_rate` is percent form, `market_rate_fraction` is a fraction,
+`rate_spread_bps` is signed, `equity_pct`/`ltv` are integer percent 0-100).
+The Genie answer layer has its own column-semantics layer on top
+(`GenieAnswer.logic.ts`: `isIdentifierColumn` / `isMoneyColumn` /
+`coerceMeasure`) — a numeric ZIP must never be localized or used as a measure.

--- a/.claude/agent-memory/frontend-implementer/project_worktree_frontend_validation.md
+++ b/.claude/agent-memory/frontend-implementer/project_worktree_frontend_validation.md
@@ -1,0 +1,38 @@
+---
+name: project-worktree-frontend-validation
+description: How to run frontend tests and see the app in a browser from a .claude/worktrees checkout — node_modules symlink, and why preview_start serves the wrong checkout.
+metadata:
+  type: project
+---
+
+A `.claude/worktrees/<agent-id>` checkout has **no `frontend/node_modules`**, and the
+usual dev-server tooling silently serves the MAIN checkout instead of the worktree.
+
+**Why:** git worktrees only carry tracked files, and `node_modules` is ignored.
+`preview_start` (and `npm --prefix <abs-path> run dev`) resolves the dev server
+against the repo root the tool launched from, not the worktree — so the served
+bundle looks stale and your edits appear to do nothing. Confirmed 2026-08-07: the
+served sourcemap's `file:` field pointed at the main checkout while the edits sat
+in the worktree.
+
+**How to apply:**
+
+1. Tests / lint / build — symlink node_modules first (diff `package-lock.json`
+   against the main checkout; identical when you branched off `origin/main`):
+   `ln -s <main-repo>/frontend/node_modules <worktree>/frontend/node_modules`,
+   then `npm --prefix frontend run test|lint|build` behaves normally. Remove the
+   symlink before you finish — `.gitignore` has `frontend/node_modules/` **with a
+   trailing slash**, which does not match a symlink, so it shows as untracked.
+2. Visual / browser verification — don't fight the dev server. Run
+   `npm --prefix frontend run build` (a required validation anyway) and serve it:
+   `python3 -m http.server 5174 --directory <worktree>/frontend/dist`, then point
+   the browser pane at `localhost:5174`. API calls 404 without a backend, but the
+   AppShell, CSS, and layout render — enough to measure geometry via
+   `javascript_tool` + `getBoundingClientRect`.
+3. Running vite directly from the worktree dies on
+   `Cannot find package 'babel-plugin-react-compiler'`: the react-compiler babel
+   preset resolves from the process CWD, so it needs a node_modules beside it.
+   Same root cause as the `npx --root` trap in [[project-component-test-context-mock]].
+
+Measuring in a real browser is worth the setup: the 2026-08-07 topbar-overlap fix
+was sized from measured track widths (296/704/296 → 392/512/392), not guessed.

--- a/frontend/src/components/HealthProvider.test.tsx
+++ b/frontend/src/components/HealthProvider.test.tsx
@@ -8,6 +8,7 @@ import {
   HealthProvider,
   applyDownUpDebounce,
   computeDegraded,
+  shouldPollFast,
   useHealth,
   useOptionalHealth,
 } from './HealthProvider';
@@ -82,6 +83,56 @@ describe('computeDegraded', () => {
         circuit_breakers: { warehouse: 'closed', lakebase: 'closed', genie: 'closed' },
       }),
     ).toBe(false);
+  });
+});
+
+/**
+ * Cadence selection is deliberately narrower than `computeDegraded` — the
+ * 2026-08-07 audit measured `/api/v1/health` 3-4x per route load because the
+ * deployed build declares `status: "degraded"` for a deploy-shaped reason
+ * while every dependency is up and every breaker is closed. What the UI SAYS
+ * is unchanged; only how often it asks.
+ */
+describe('shouldPollFast', () => {
+  const allUp = {
+    dependencies: { warehouse: 'up' as const, lakebase: 'up' as const, genie: 'up' as const },
+    circuit_breakers: { warehouse: 'closed' as const, lakebase: 'closed' as const, genie: 'closed' as const },
+  };
+
+  it('does not fast-poll a backend-declared degrade with every dependency up', () => {
+    const payload = { status: 'degraded' as const, mode: 'live', ...allUp };
+    // Still degraded for display…
+    expect(computeDegraded(payload)).toBe(true);
+    // …but nothing here recovers on a 3-second timescale.
+    expect(shouldPollFast(payload)).toBe(false);
+  });
+
+  it('fast-polls a dependency that is actually down', () => {
+    for (const dep of ['warehouse', 'lakebase', 'genie']) {
+      expect(
+        shouldPollFast({
+          status: 'ok',
+          mode: 'live',
+          dependencies: { ...allUp.dependencies, [dep]: 'down' },
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it('fast-polls an open circuit breaker', () => {
+    expect(
+      shouldPollFast({
+        status: 'ok',
+        mode: 'live',
+        dependencies: allUp.dependencies,
+        circuit_breakers: { ...allUp.circuit_breakers, genie: 'open' },
+      }),
+    ).toBe(true);
+  });
+
+  it('stays on the slow cadence before the first probe resolves and when healthy', () => {
+    expect(shouldPollFast(null)).toBe(false);
+    expect(shouldPollFast({ status: 'ok', mode: 'live', ...allUp })).toBe(false);
   });
 });
 
@@ -225,6 +276,62 @@ describe('HealthProvider browser polling', () => {
       document.dispatchEvent(new Event('visibilitychange'));
     });
     expect(fetchHealth).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the slow cadence when the backend declares degraded but all deps are up', async () => {
+    const fetchHealth = vi.fn(async () => ({
+      status: 'degraded' as const,
+      mode: 'live',
+      dependencies: { warehouse: 'up', lakebase: 'up', genie: 'up' },
+      circuit_breakers: { warehouse: 'closed', lakebase: 'closed', genie: 'closed' },
+    }));
+
+    await act(async () => {
+      root.render(
+        <HealthProvider pollIntervalOkMs={8000} pollIntervalDegradedMs={3000} fetchHealth={fetchHealth}>
+          <span>ready</span>
+        </HealthProvider>,
+      );
+    });
+    expect(fetchHealth).toHaveBeenCalledTimes(1);
+
+    // A 9s route-load window used to cost three more probes at the fast
+    // cadence; on the slow cadence it costs one.
+    for (let i = 0; i < 3; i += 1) {
+      await act(async () => {
+        vi.advanceTimersByTime(3_000);
+      });
+    }
+    expect(fetchHealth).toHaveBeenCalledTimes(2);
+  });
+
+  it('still probes fast while a dependency is actually down', async () => {
+    const fetchHealth = vi.fn(async () => ({
+      status: 'degraded' as const,
+      mode: 'live',
+      dependencies: { warehouse: 'down', lakebase: 'up', genie: 'up' },
+    }));
+
+    await act(async () => {
+      root.render(
+        <HealthProvider
+          pollIntervalOkMs={8000}
+          pollIntervalDegradedMs={3000}
+          debounceUpMs={0}
+          fetchHealth={fetchHealth}
+        >
+          <span>ready</span>
+        </HealthProvider>,
+      );
+    });
+    expect(fetchHealth).toHaveBeenCalledTimes(1);
+
+    for (let i = 0; i < 3; i += 1) {
+      await act(async () => {
+        vi.advanceTimersByTime(3_000);
+      });
+    }
+    expect(fetchHealth).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/frontend/src/components/HealthProvider.tsx
+++ b/frontend/src/components/HealthProvider.tsx
@@ -56,6 +56,24 @@ export function computeDegraded(health: HealthPayload | null): boolean {
   return false;
 }
 
+/**
+ * Should the poll run at the fast cadence? Only when there is something
+ * TRANSIENT to watch recover — a dependency reported down, or a breaker
+ * open. A backend-declared `status: 'degraded'` with every dependency up and
+ * every breaker closed is a deployment-shaped condition (e.g. the treatment
+ * runtime not enabled on a baseline deploy), which does not clear on a
+ * three-second timescale; polling it four times per page view is pure
+ * round-trip cost. Deliberately NOT `computeDegraded`: the pill and the
+ * banner keep reading that, so what the UI SAYS about health is unchanged —
+ * only how often it asks (2026-08-07 audit M4).
+ */
+export function shouldPollFast(health: HealthPayload | null): boolean {
+  if (!health) return false;
+  const deps = health.dependencies ?? {};
+  if (deps.warehouse === 'down' || deps.lakebase === 'down' || deps.genie === 'down') return true;
+  return Object.values(health.circuit_breakers ?? {}).some((state) => state === 'open');
+}
+
 interface HealthProviderProps {
   pollIntervalOkMs?: number;
   pollIntervalDegradedMs?: number;
@@ -171,9 +189,9 @@ export function HealthProvider({
   const [health, setHealth] = useState<HealthPayload | null>(null);
   const [probeMs, setProbeMs] = useState<number | null>(null);
   const [fetchedAt, setFetchedAt] = useState<string | null>(null);
-  // Latest degraded flag in a ref so the polling loop reads the fresh
-  // cadence without being re-registered every time the state flips.
-  const degradedRef = useRef(false);
+  // Latest cadence decision in a ref so the polling loop reads the fresh
+  // value without being re-registered every time the state flips.
+  const pollFastRef = useRef(false);
   // Per-dependency debounce state. Lives in a ref so the tick closure
   // sees the latest pendingUpSince across re-renders without React
   // batching it out of order.
@@ -198,7 +216,7 @@ export function HealthProvider({
     const scheduleNext = () => {
       clearTimer();
       if (cancelled || isHidden()) return;
-      const delay = degradedRef.current ? pollIntervalDegradedMs : pollIntervalOkMs;
+      const delay = pollFastRef.current ? pollIntervalDegradedMs : pollIntervalOkMs;
       timer = setTimeout(() => {
         void tick();
       }, delay);
@@ -222,7 +240,7 @@ export function HealthProvider({
         setHealth(payload);
         setProbeMs(elapsed);
         setFetchedAt(new Date().toISOString());
-        degradedRef.current = computeDegraded(payload);
+        pollFastRef.current = shouldPollFast(payload);
       } catch (err) {
         if (isAbortError(err) || cancelled) return;
         // api.health() swallows network errors internally and returns
@@ -246,7 +264,7 @@ export function HealthProvider({
         setHealth(payload);
         setProbeMs(null);
         setFetchedAt(new Date().toISOString());
-        degradedRef.current = true;
+        pollFastRef.current = true;
       } finally {
         inFlight = false;
       }

--- a/frontend/src/components/layout/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar.tsx
@@ -345,7 +345,7 @@ export function Topbar() {
         aria-label={`Configured tenant: ${lender}`}
       >
         <Icon name="building" size={12} />
-        <span>{lender}</span>
+        <span className="topbar__pill-tenant">{lender}</span>
       </div>
       {/*
         Single "system status" pill consolidating environment + warehouse

--- a/frontend/src/components/mortgage/EvidenceDrawer.headline-evidence.test.tsx
+++ b/frontend/src/components/mortgage/EvidenceDrawer.headline-evidence.test.tsx
@@ -45,7 +45,7 @@ const apiMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../AppContext', () => ({
-  useApp: () => ({ drawer: appMocks.drawer, setDrawer: appMocks.setDrawer }),
+  useApp: () => ({ drawer: appMocks.drawer, setDrawer: appMocks.setDrawer, canAccessAdmin: true }),
 }));
 
 vi.mock('../../lib/api', () => ({

--- a/frontend/src/components/mortgage/EvidenceDrawer.lineage.test.tsx
+++ b/frontend/src/components/mortgage/EvidenceDrawer.lineage.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../AppContext', () => ({
   useApp: () => ({
     drawer: appMocks.drawer,
     setDrawer: appMocks.setDrawer,
+    canAccessAdmin: true,
   }),
 }));
 

--- a/frontend/src/components/mortgage/EvidenceDrawer.test.tsx
+++ b/frontend/src/components/mortgage/EvidenceDrawer.test.tsx
@@ -13,6 +13,7 @@ import type { DrawerSource } from '../AppContext';
 const appMocks = vi.hoisted(() => ({
   drawer: null as DrawerSource | null,
   setDrawer: vi.fn(),
+  canAccessAdmin: true,
 }));
 
 const apiMocks = vi.hoisted(() => ({
@@ -23,6 +24,7 @@ vi.mock('../AppContext', () => ({
   useApp: () => ({
     drawer: appMocks.drawer,
     setDrawer: appMocks.setDrawer,
+    canAccessAdmin: appMocks.canAccessAdmin,
   }),
 }));
 
@@ -152,4 +154,31 @@ describe('EvidenceDrawer accessibility', () => {
     });
     expect(appMocks.setDrawer).toHaveBeenCalledWith(null);
   }, 15_000);
+
+  /**
+   * 2026-08-07 audit H4: opening evidence as a non-admin fired the
+   * AdminDep-gated metadata read and logged a 403 in the console on a core
+   * product route. The drawer degraded fine, the console did not.
+   */
+  it('does not issue the admin-scoped metadata read for a non-admin actor', async () => {
+    appMocks.canAccessAdmin = false;
+
+    await render();
+
+    expect(apiMocks.assetMetadata).not.toHaveBeenCalled();
+    // Honest state, not a fake data problem: the chip says why.
+    expect(document.body.textContent).toContain('Admin-only freshness');
+    expect(document.body.textContent).not.toContain('Metadata not loaded');
+    // The evidence itself is unaffected.
+    expect(document.body.textContent).toContain(SOURCE.description);
+
+    appMocks.canAccessAdmin = true;
+  });
+
+  it('still reads governed metadata for an admin actor', async () => {
+    await render();
+
+    expect(apiMocks.assetMetadata).toHaveBeenCalledWith('lead_population', expect.anything());
+    expect(document.body.textContent).not.toContain('Admin-only freshness');
+  });
 });

--- a/frontend/src/components/mortgage/EvidenceDrawer.tsx
+++ b/frontend/src/components/mortgage/EvidenceDrawer.tsx
@@ -167,11 +167,12 @@ function formatNumber(value: number | null | undefined): string {
  * render as "Freshness Unavailable", which reads like a data problem
  * (observed 2026-06-11 during the admin-allowlist incident).
  */
-type FreshnessView = AssetFreshness | 'loading' | 'error' | undefined;
+type FreshnessView = AssetFreshness | 'loading' | 'error' | 'restricted' | undefined;
 
 function freshnessLabel(view: FreshnessView): string {
   if (view === 'loading') return 'Checking freshness…';
   if (view === 'error') return 'Metadata not loaded';
+  if (view === 'restricted') return 'Admin-only freshness';
   if (view === 'fresh') return 'Fresh';
   if (view === 'aging') return 'Aging';
   if (view === 'stale') return 'Stale';
@@ -182,6 +183,9 @@ function freshnessHelp(view: FreshnessView): string {
   if (view === 'loading') return 'Reading governed Unity Catalog metadata.';
   if (view === 'error') {
     return 'Governed freshness could not be read for this view — see the notice below. This does not mean the source is stale.';
+  }
+  if (view === 'restricted') {
+    return 'Governed table metadata is an administrator read. The evidence and lineage below are unaffected.';
   }
   if (view === 'fresh') return 'Updated within 7 days.';
   if (view === 'aging') return 'Updated 7-30 days ago.';
@@ -205,7 +209,7 @@ function metadataStatRows(metadata?: AssetMetadataResponse) {
 }
 
 export function EvidenceDrawer() {
-  const { drawer, setDrawer } = useApp();
+  const { drawer, setDrawer, canAccessAdmin } = useApp();
   const open = !!drawer;
   const d = drawer;
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -218,10 +222,14 @@ export function EvidenceDrawer() {
   useEffect(() => {
     setTab('overview');
   }, [d]);
+  // /api/admin/assets/:key/metadata is AdminDep-gated. A loan officer opening
+  // an evidence drawer used to fire it and eat a 403 on every open — invisible
+  // in the UI, loud in the browser console (2026-08-07 audit H4). Ask only
+  // when the server-authoritative session says this actor may.
   const metadataQuery = useQuery({
     queryKey: queryKeys.assetMetadata(d?.assetKey),
     queryFn: ({ signal }) => api.assetMetadata(d?.assetKey ?? '', signal),
-    enabled: open && !!d?.assetKey,
+    enabled: open && !!d?.assetKey && canAccessAdmin,
     retry: false,
   });
   // Both tabs use the same governed manifest. Overview presents its compact
@@ -245,11 +253,13 @@ export function EvidenceDrawer() {
   // View-state for the freshness chip: only mapped assets ever issue the
   // governed metadata read, so loading/error states are scoped to them.
   const freshnessView: FreshnessView = d?.assetKey
-    ? metadataQuery.isError
-      ? 'error'
-      : metadataQuery.isPending
-        ? 'loading'
-        : metadata?.freshness
+    ? !canAccessAdmin
+      ? 'restricted'
+      : metadataQuery.isError
+        ? 'error'
+        : metadataQuery.isPending
+          ? 'loading'
+          : metadata?.freshness
     : metadata?.freshness;
   const assetHref = d?.assetKey ? assetDetailHref(d.assetKey) : null;
   const selectTabFromKeyboard = (event: KeyboardEvent<HTMLButtonElement>) => {

--- a/frontend/src/components/mortgage/GenieAnswer.logic.ts
+++ b/frontend/src/components/mortgage/GenieAnswer.logic.ts
@@ -2,6 +2,7 @@ import type {
   GenieAnswer as GenieAnswerShape,
   GenieVisualization,
 } from '../../types';
+import { currency } from '../../lib/formatters';
 import { safeSegmentName } from '../../lib/segmentMetadata';
 
 export const MAX_TABLE_ROWS = 10;
@@ -29,9 +30,22 @@ export interface GenieVisualizationPlan {
   viz: GenieVisualization | null;
 }
 
+/**
+ * Columns that are LABELS, not measures: a numeric ZIP is a place, not a
+ * quantity, and thousands-separating it ("75,040") or charting it as the Y
+ * axis is a category error. Anything matching here is excluded from measure
+ * inference and rendered verbatim rather than localized.
+ *
+ * Widened 2026-08-07 after the rendering audit found real gold columns
+ * falling through: `zip5` (mip.gold.address_lookup.zip5), the
+ * `property_zip` / `situs_zip` variants, `apn`, `loan_number`, and every
+ * vintage-style `*_year` column (`year_built` was rendering as "2,019").
+ */
+const ZIP_COLUMN_PATTERN = /(^|_)zip(_?code)?(_?5)?$/i;
+
 const IDENTIFIER_COLUMN_PATTERNS = [
-  /^zip(code)?$/i,
-  /^zip_code$/i,
+  ZIP_COLUMN_PATTERN,
+  /^zipcode$/i,
   /^postal(_code)?$/i,
   /^fips(_\d+)?$/i,
   /^county_fips(_5)?$/i,
@@ -42,6 +56,26 @@ const IDENTIFIER_COLUMN_PATTERNS = [
   /(^|_)id$/i,
   /^id$/i,
   /^clip$/i,
+  /^apn$/i,
+  /(^|_)loan_number$/i,
+  /(^|_)year$/i,
+  /^year_built$/i,
+];
+
+/**
+ * Columns whose numbers are dollars. Rendered as currency so a lien balance
+ * can't be mistaken for a borrower count in the same Genie table (the audit's
+ * H3: `equity_estimate` landed as a bare "412,350"). Percent/score siblings
+ * are deliberately excluded — `equity_pct` ends in `_pct`, not `equity`.
+ */
+const MONEY_COLUMN_PATTERNS = [
+  /(^|_)usd$/i,
+  /(^|_)amount$/i,
+  /(^|_)balance$/i,
+  /(^|_)price$/i,
+  /(^|_)upb$/i,
+  /(^|_)equity(_estimate)?$/i,
+  /(^|_)avm_value$/i,
 ];
 
 const VALUE_COLUMN_PRIORITY = [
@@ -73,6 +107,11 @@ export function isIdentifierColumn(column: string): boolean {
   return IDENTIFIER_COLUMN_PATTERNS.some((pattern) => pattern.test(column));
 }
 
+export function isMoneyColumn(column: string): boolean {
+  if (isIdentifierColumn(column)) return false;
+  return MONEY_COLUMN_PATTERNS.some((pattern) => pattern.test(column));
+}
+
 export function coerceNumber(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (typeof value === 'string') {
@@ -84,15 +123,27 @@ export function coerceNumber(value: unknown): number | null {
   return null;
 }
 
-function coerceMeasure(value: unknown, column: string): number | null {
+/**
+ * Coerce a value ONLY when its column can honestly carry a measure. Every
+ * "what is the metric here" path must use this, never bare `coerceNumber` —
+ * a digit string like "75040" parses fine, which is how a ZIP became a
+ * strategy-board headline number.
+ */
+export function coerceMeasure(value: unknown, column: string): number | null {
   if (isIdentifierColumn(column)) return null;
   return coerceNumber(value);
+}
+
+/** First column in `row` that can honestly serve as a measure, else null. */
+export function findMeasureColumn(row: Record<string, unknown> | undefined): string | null {
+  if (!row) return null;
+  return Object.keys(row).find((column) => coerceMeasure(row[column], column) !== null) ?? null;
 }
 
 export function formatIdentifier(column: string, value: unknown): string {
   if (value === null || value === undefined) return '—';
   const raw = String(value).trim();
-  if (/^zip(code)?$|^zip_code$|^postal(_code)?$/i.test(column)) {
+  if (ZIP_COLUMN_PATTERN.test(column) || /^zipcode$|^postal(_code)?$/i.test(column)) {
     const digits = raw.replace(/\D/g, '');
     if (digits.length > 0 && digits.length <= 5) return digits.padStart(5, '0');
   }
@@ -265,6 +316,9 @@ export function formatCell(column: string, v: unknown): string {
   if (/^segment_codes$/i.test(column)) return formatSegmentValue(v, true);
   if (/^(segment|segment_code|top_segment)$/i.test(column)) return formatSegmentValue(v, false);
   if (isIdentifierColumn(column)) return formatIdentifier(column, v);
-  if (typeof v === 'number') return Number.isInteger(v) ? v.toLocaleString() : v.toFixed(2);
+  if (typeof v === 'number') {
+    if (isMoneyColumn(column)) return currency(v);
+    return Number.isInteger(v) ? v.toLocaleString() : v.toFixed(2);
+  }
   return String(v);
 }

--- a/frontend/src/components/mortgage/GenieAnswer.test.tsx
+++ b/frontend/src/components/mortgage/GenieAnswer.test.tsx
@@ -5,7 +5,15 @@ import { readFileSync } from 'node:fs';
 import { stripQuestionRestatement } from './GenieAnswer';
 import { strategySegmentLabel } from './GenieAnswerCharts';
 import { normalizeGenieAnswerLanguage } from '../../lib/genieAnswerLanguage';
-import { formatCell, humanizeKey, inferChartFromRows } from './GenieAnswer.logic';
+import {
+  coerceMeasure,
+  findMeasureColumn,
+  formatCell,
+  humanizeKey,
+  inferChartFromRows,
+  isIdentifierColumn,
+  isMoneyColumn,
+} from './GenieAnswer.logic';
 import {
   shouldPersistConversation,
   shouldRenderGenieSourceAssets,
@@ -184,6 +192,68 @@ describe('Genie table display labels', () => {
     expect(strategySegmentLabel('permit')).toBe('HELOC Intent');
     expect(strategySegmentLabel('retention-risk')).toBe('Unknown segment');
     expect(strategySegmentLabel('made_up')).toBe('Unknown segment');
+  });
+});
+
+/**
+ * 2026-08-07 audit H2: real gold columns were falling through the identifier
+ * list into `toLocaleString()`, so `zip5` rendered "75,040" and `year_built`
+ * rendered "2,019".
+ */
+describe('identifier columns are labels, not measures', () => {
+  it.each([
+    ['zip5', 75040, '75040'],
+    ['zip_code_5', 7504, '07504'],
+    ['property_zip', 7504, '07504'],
+    ['situs_zip', 75040, '75040'],
+    ['apn', 12345678, '12345678'],
+    ['loan_number', 90210, '90210'],
+    ['year_built', 2019, '2019'],
+    ['origination_year', 2019, '2019'],
+  ])('renders %s verbatim, never thousands-separated', (column, value, expected) => {
+    expect(isIdentifierColumn(column)).toBe(true);
+    expect(formatCell(column, value)).toBe(expected);
+    expect(coerceMeasure(value, column)).toBeNull();
+  });
+
+  it('keeps genuine measures out of the identifier list', () => {
+    for (const column of ['borrowers', 'avg_score', 'equity_estimate', 'rate_spread_bps']) {
+      expect(isIdentifierColumn(column)).toBe(false);
+    }
+  });
+
+  it('picks the first honest measure column, skipping identifiers', () => {
+    // The C2 shape: no numeric measure at all, only a ZIP. The board must
+    // find nothing rather than promote the ZIP to a headline metric.
+    expect(findMeasureColumn({ zip: '75040', city: 'Garland' })).toBeNull();
+    expect(findMeasureColumn({ zip5: 75040, borrowers: 1503 })).toBe('borrowers');
+    expect(findMeasureColumn(undefined)).toBeNull();
+  });
+});
+
+/**
+ * 2026-08-07 audit H3: money columns rendered as bare numbers, visually
+ * indistinguishable from a borrower count in the same table.
+ */
+describe('money columns render as currency', () => {
+  it.each([
+    ['equity_estimate', 412350, '$412,350'],
+    ['current_lien_balance', 289000, '$289,000'],
+    ['listing_price', 1795000, '$1,795,000'],
+    ['second_pos_amount', 45000, '$45,000'],
+    ['total_equity_usd', 4201993, '$4,201,993'],
+    ['avg_loan_amount', 320450, '$320,450'],
+  ])('renders %s with a dollar sign and separators', (column, value, expected) => {
+    expect(isMoneyColumn(column)).toBe(true);
+    expect(formatCell(column, value)).toBe(expected);
+  });
+
+  it('does not treat percent, score, or bps siblings as money', () => {
+    for (const column of ['equity_pct', 'avg_score', 'rate_spread_bps', 'borrowers']) {
+      expect(isMoneyColumn(column)).toBe(false);
+    }
+    expect(formatCell('equity_pct', 45)).toBe('45');
+    expect(formatCell('borrowers', 412350)).toBe('412,350');
   });
 });
 

--- a/frontend/src/components/mortgage/GenieAnswerCharts.test.tsx
+++ b/frontend/src/components/mortgage/GenieAnswerCharts.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Strategy-board rendering contract (2026-08-07 audit C2). The board's
+ * headline number is the most quotable thing on an Ask Genie answer, so the
+ * column it comes from has to be a real measure — a ZIP is a place.
+ */
+
+import { createRoot, type Root } from 'react-dom/client';
+import { act, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GenieStrategyBoard } from './GenieAnswerCharts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-router', () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
+}));
+
+describe('GenieStrategyBoard measure selection', () => {
+  let root: Root;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="root"></div>';
+    root = createRoot(document.getElementById('root') as HTMLElement);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  const render = (node: ReactNode) => act(() => root.render(node));
+
+  it('never promotes a ZIP to the headline metric when no measure exists', () => {
+    render(
+      <GenieStrategyBoard
+        rows={[
+          { city: 'Garland', zip: '75040' },
+          { city: 'Bridgeport', zip: '06614' },
+        ]}
+      />,
+    );
+
+    expect(document.body.textContent).toContain('Garland');
+    expect(document.body.textContent).not.toContain('75,040');
+    expect(document.querySelector('.genie-board__value')).toBeNull();
+  });
+
+  it('ignores an identifier handed in as the explicit y column', () => {
+    render(
+      <GenieStrategyBoard
+        rows={[
+          { city: 'Garland', zip5: 75040, borrowers: 1503 },
+          { city: 'Bridgeport', zip5: 6614, borrowers: 1482 },
+        ]}
+        x="city"
+        y="zip5"
+      />,
+    );
+
+    expect(document.body.textContent).not.toContain('75,040');
+    // Falls back to the honest measure in the same row.
+    expect(document.querySelector('.genie-board__value')?.textContent).toBe('1,503');
+  });
+
+  it('renders a real measure, formatted for its unit', () => {
+    render(
+      <GenieStrategyBoard
+        rows={[
+          { city: 'Garland', equity_estimate: 412350 },
+          { city: 'Bridgeport', equity_estimate: 289000 },
+        ]}
+        x="city"
+        y="equity_estimate"
+      />,
+    );
+
+    expect(document.querySelector('.genie-board__value')?.textContent).toBe('$412,350');
+  });
+});

--- a/frontend/src/components/mortgage/GenieAnswerCharts.tsx
+++ b/frontend/src/components/mortgage/GenieAnswerCharts.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import {
+  coerceMeasure,
   coerceNumber,
+  findMeasureColumn,
   formatCell,
   humanizeKey,
+  isIdentifierColumn,
   level,
   normalizeState,
   type ChartRow,
@@ -178,7 +181,8 @@ export function GenieMapChart({
   const values = new Map<string, number>();
   for (const row of rows) {
     const state = normalizeState(row[x]);
-    const value = coerceNumber(row[y]);
+    // Shading is a measure axis too — an identifier column must never drive it.
+    const value = coerceMeasure(row[y], y);
     if (!state || value === null) continue;
     values.set(state, value);
   }
@@ -267,24 +271,35 @@ export function GenieStrategyBoard({
   y?: string | null;
 }) {
   const label = x ?? Object.keys(rows[0] ?? {}).find((c) => typeof rows[0]?.[c] === 'string');
-  const value = y ?? Object.keys(rows[0] ?? {}).find((c) => coerceNumber(rows[0]?.[c]) !== null);
-  if (!label || !value || rows.length === 0) return null;
+  // The measure must come from a column that can honestly BE a measure. The
+  // old fallback took the first coercible column, and `coerceNumber` happily
+  // parses a digit string — so a result set with no numeric column rendered
+  // the ZIP ("75,040") as the board's headline metric (2026-08-07 audit C2).
+  // An explicit viz.y gets the same guard: the backend's own _value_column
+  // filters identifiers, so an identifier arriving here is already wrong.
+  const explicitValue = y && !isIdentifierColumn(y) ? y : null;
+  const value = explicitValue ?? findMeasureColumn(rows[0]);
+  if (!label || rows.length === 0) return null;
   return (
     <div className="genie-board">
       <div className="eyebrow genie-chart__title">Strategy board</div>
       <div className="genie-board__grid">
         {rows.slice(0, 6).map((row, i) => {
           const title = formatCell(label, row[label]);
-          const metric = coerceNumber(row[value]);
+          // No measure column → the card carries its label and context only.
+          // Better an unnumbered card than a confident wrong number.
+          const metric = value ? coerceMeasure(row[value], value) : null;
           const offer = strategyOfferLabel(row);
           const segment = strategySegmentLabel(row.segment ?? row.segment_code ?? row.top_segment);
+          const meta = [segment, offer].filter(Boolean).map(String).join(' · ')
+            || (value ? humanizeKey(value) : '');
           return (
             <div key={`${title}-${i}`} className="genie-board__card">
               <div className="genie-board__title">{title}</div>
-              <div className="genie-board__meta">
-                {[segment, offer].filter(Boolean).map(String).join(' · ') || humanizeKey(value)}
-              </div>
-              {metric !== null && <div className="genie-board__value">{metric.toLocaleString()}</div>}
+              {meta && <div className="genie-board__meta">{meta}</div>}
+              {metric !== null && value && (
+                <div className="genie-board__value">{formatCell(value, metric)}</div>
+              )}
             </div>
           );
         })}

--- a/frontend/src/components/mortgage/LeadRowPreview.tsx
+++ b/frontend/src/components/mortgage/LeadRowPreview.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties } from 'react';
 import { Link } from 'react-router';
 import type { LeadSummary } from '../../types';
 import { DRAWER_SOURCES } from '../../lib/drawerSources';
+import { compactCurrency, signedBpsLabel } from '../../lib/formatters';
 import { offerDisplayLabel, offerRationale, offerShortDescription } from '../../lib/offerLanguage';
 import { safeSegmentName, segmentColor } from '../../lib/segmentMetadata';
 import { useApp } from '../AppContext';
@@ -44,8 +45,8 @@ export function RowPreview({ lead, approval }: { lead: LeadSummary; approval?: s
         <div className="preview-grid">
           <Cell k="Property ref"  v={propertyRef} mono />
           <Cell k="Location"      v={`${lead.city}, ${lead.state} · ${lead.zip}`} />
-          <Cell k="Equity"        v={`$${(lead.equity_estimate / 1000).toFixed(0)}k`} mono />
-          <Cell k="Rate spread"   v={`+${lead.rate_spread_bps} bps`} mono />
+          <Cell k="Equity"        v={compactCurrency(lead.equity_estimate)} mono />
+          <Cell k="Rate spread"   v={signedBpsLabel(lead.rate_spread_bps)} mono />
           <Cell k="Score"         v={`${lead.opportunity_score}`} mono />
           <Cell k="Signal"        v={`${lead.confidence}%`} mono />
           <Cell k="Approval"      v={approval ?? lead.approval_status ?? 'pending'} />

--- a/frontend/src/components/mortgage/LeadTableRow.render.test.tsx
+++ b/frontend/src/components/mortgage/LeadTableRow.render.test.tsx
@@ -256,3 +256,83 @@ describe('LeadTableRow display fallbacks', () => {
     expect(document.body.textContent).not.toContain('made_up');
   });
 });
+
+/**
+ * Unit rendering (2026-08-07 audit C1 + H1). `rate_spread_bps` is signed and
+ * `equity_estimate` runs past $1M on real rows, so the row and its expanded
+ * preview must both route through the shared formatters.
+ */
+describe('LeadTableRow numeric rendering', () => {
+  let root: Root;
+
+  const renderRow = (overrides: Partial<LeadSummary>, isOpen = false) => {
+    act(() => {
+      root.render(
+        <LeadTableRow
+          lead={{ ...lead, ...overrides }}
+          virtualIndex={0}
+          isOpen={isOpen}
+          approval={undefined}
+          isSelected={false}
+          isSelectable
+          isApprovalEligible
+          bulkApproving={false}
+          salesBusy={false}
+          salesTeamCount={1}
+          pendingApproval={false}
+          onToggleRow={noop}
+          onToggleSelect={noop}
+          onApprove={noop}
+          onReject={noop}
+          onOpenDisposition={noop}
+          onAssignmentUpdate={noop}
+        />,
+      );
+    });
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = '<table><tbody id="root"></tbody></table>';
+    root = createRoot(document.getElementById('root') as HTMLElement);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  it('renders a below-market spread as -422, never +-422', () => {
+    renderRow({ rate_spread_bps: -422 }, true);
+
+    expect(document.body.textContent).toContain('-422');
+    expect(document.body.textContent).not.toContain('+-422');
+    expect(document.body.textContent).toContain('-422 bps');
+  });
+
+  it('renders an at-market spread without a sign', () => {
+    renderRow({ rate_spread_bps: 0 }, true);
+
+    expect(document.body.textContent).toContain('0 bps');
+    expect(document.body.textContent).not.toContain('+0 bps');
+  });
+
+  it('keeps the plus on an above-market spread', () => {
+    renderRow({ rate_spread_bps: 180 }, true);
+
+    expect(document.body.textContent).toContain('+180 bps');
+  });
+
+  it('rolls seven-figure equity up to millions instead of $4410K', () => {
+    renderRow({ equity_estimate: 4_410_000 }, true);
+
+    expect(document.body.textContent).toContain('$4.4M');
+    expect(document.body.textContent).not.toContain('4410');
+  });
+
+  it('keeps the thousands form under $1M', () => {
+    renderRow({ equity_estimate: 806_500 }, true);
+
+    expect(document.body.textContent).toContain('$807K');
+  });
+});

--- a/frontend/src/components/mortgage/LeadTableRow.tsx
+++ b/frontend/src/components/mortgage/LeadTableRow.tsx
@@ -1,6 +1,7 @@
 import { Fragment, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
 import type { LeadSummary } from '../../types';
 import { DRAWER_SOURCES } from '../../lib/drawerSources';
+import { compactCurrency, signedBps } from '../../lib/formatters';
 import { offerDisplayLabel } from '../../lib/offerLanguage';
 import { safeSegmentName, segmentColor } from '../../lib/segmentMetadata';
 import { Icon } from '../Icon';
@@ -222,11 +223,11 @@ export function LeadTableRow({
             )}
           </div>
         </td>
-        <td className="num tbl-cell--right">${(lead.equity_estimate / 1000).toFixed(0)}k</td>
+        <td className="num tbl-cell--right">{compactCurrency(lead.equity_estimate)}</td>
         <td
           className={`num tbl-cell--right ${lead.rate_spread_bps >= 75 ? 'lead-table__rate--positive' : 'lead-table__rate--neutral'}`}
         >
-          +{lead.rate_spread_bps}
+          {signedBps(lead.rate_spread_bps)}
         </td>
         <td>
           <span className="mono fs-12 text-1">

--- a/frontend/src/design-system/components.css
+++ b/frontend/src/design-system/components.css
@@ -110,7 +110,14 @@
   grid-area: topbar;
   min-width: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(30rem, 44rem) minmax(0, 1fr);
+  /* Symmetric side tracks keep the search on the topbar's centre line. The
+     centre track is capped at 32rem (not 44rem) because the actions cluster
+     — tenant pill + status pill + three icon buttons — measures ~376px at
+     max-content: a 44rem search left only 296px per side track, so the
+     end-justified actions box overflowed its track LEFTWARD and the opaque
+     tenant pill covered the ⌘K badge by 26px at 1440x900 (2026-08-07 audit
+     M1, reproduced on all ten routes). 32rem leaves 392px per side. */
+  grid-template-columns: minmax(0, 1fr) minmax(0, 32rem) minmax(0, 1fr);
   align-items: center;
   gap: var(--sp-4);
   padding: 0 var(--sp-5);
@@ -157,8 +164,8 @@
   display: flex;
   align-items: center;
   gap: var(--sp-2);
-  inline-size: min(44rem, 100%);
-  min-inline-size: min(30rem, 100%);
+  inline-size: min(32rem, 100%);
+  min-inline-size: 0;
   padding: var(--sp-1) var(--sp-2);
   border: 1px solid var(--line-1);
   border-radius: var(--r-md);
@@ -214,6 +221,10 @@
   justify-content: flex-end;
   gap: var(--sp-3);
   min-inline-size: 0;
+  /* Cap the end-justified item at its grid track. Without this a grid item
+     sizes to content and overflows the track, sliding under the centered
+     search — the same failure the crumbs rule above fixes on the left. */
+  max-inline-size: 100%;
 }
 .topbar__search-results {
   position: absolute;
@@ -251,6 +262,18 @@
   padding: 5px 10px; border-radius: var(--r-pill);
   background: var(--bg-3); border: 1px solid var(--line-1);
   font-size: var(--fs-12); color: var(--text-2);
+  /* A pill is one line high. Under flex pressure the tenant label used to
+     wrap to two lines inside a 109px pill instead of truncating. */
+  min-inline-size: 0;
+  white-space: nowrap;
+}
+/* Tenant label: the only elastic item in the actions cluster, so an unusually
+   long lender name ellipsizes here rather than pushing the row into the
+   search box. */
+.topbar__pill-tenant {
+  min-inline-size: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .topbar__pill .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--signal-success); box-shadow: 0 0 8px var(--signal-success); }
 .topbar__pill .dot.amber { background: var(--signal-warning); box-shadow: 0 0 8px var(--signal-warning); }
@@ -259,7 +282,12 @@
   font-family: var(--font-mono);
   font-size: var(--fs-12);
 }
-@media (max-width: 1180px) {
+/* Below 88rem (1408px) the two side tracks can no longer both hold the
+   actions cluster at max-content, so the third track sizes to its content
+   instead: the search gives up exact centering rather than being overlapped.
+   Above it (the contracted 1440x900 demo viewport included) the symmetric,
+   perfectly centered layout above applies. */
+@media (max-width: 88rem) {
   .topbar {
     grid-template-columns: minmax(0, 0.9fr) minmax(22rem, 1.1fr) auto;
   }

--- a/frontend/src/design-system/components.test.ts
+++ b/frontend/src/design-system/components.test.ts
@@ -24,14 +24,36 @@ describe('layout containment contracts', () => {
 
     expect(css).toMatch(/\.topbar\s*\{[^}]*display:\s*grid;/s);
     expect(css).toMatch(
-      /\.topbar\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\) minmax\(30rem,\s*44rem\) minmax\(0,\s*1fr\);/s,
+      /\.topbar\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\) minmax\(0,\s*32rem\) minmax\(0,\s*1fr\);/s,
     );
     expect(css).toMatch(/\.topbar__search\s*\{[^}]*grid-column:\s*2;/s);
-    expect(css).toMatch(/\.topbar__search\s*\{[^}]*inline-size:\s*min\(44rem,\s*100%\);/s);
+    expect(css).toMatch(/\.topbar__search\s*\{[^}]*inline-size:\s*min\(32rem,\s*100%\);/s);
     expect(css).toContain('.topbar__actions');
     expect(css).toContain('.topbar__search-results');
     expect(css).toContain('.topbar__search-status');
     expect(css).toMatch(/\.topbar__search-results\s*\{[^}]*z-index:\s*60;/s);
+  });
+
+  /**
+   * 2026-08-07 audit M1: the end-justified actions cluster (~375px at
+   * max-content) overflowed its 296px grid track and the opaque tenant pill
+   * covered the search box's ⌘K badge by 26px at 1440x900, on every route.
+   * Measured after the fix: tracks 392/512/392, search centred with 0px
+   * overlap, tenant pill back to one line.
+   */
+  it('keeps the topbar actions cluster inside its own grid track', () => {
+    const css = designCss();
+
+    expect(css).toMatch(/\.topbar__actions\s*\{[^}]*justify-self:\s*end;/s);
+    expect(css).toMatch(/\.topbar__actions\s*\{[^}]*max-inline-size:\s*100%;/s);
+    // A pill is one line high; a long tenant name ellipsizes, never wraps.
+    expect(css).toMatch(/\.topbar__pill\s*\{[^}]*white-space:\s*nowrap;/s);
+    expect(css).toMatch(/\.topbar__pill-tenant\s*\{[^}]*text-overflow:\s*ellipsis;/s);
+    // Below the breakpoint the third track is content-sized instead, so the
+    // cluster still can't be overlapped when the side tracks get tight.
+    expect(css).toMatch(
+      /@media \(max-width:\s*88rem\)\s*\{[\s\S]*?\.topbar\s*\{[^}]*grid-template-columns:[^;]*auto;/s,
+    );
   });
 
   it('prevents lead-table chips from compressing into neighboring cells', () => {

--- a/frontend/src/lib/borrowerStory.ts
+++ b/frontend/src/lib/borrowerStory.ts
@@ -1,4 +1,5 @@
 import type { Borrower360 } from '../types';
+import { compactCurrency } from './formatters';
 import { offerDisplayLabel } from './offerLanguage';
 
 /**
@@ -30,12 +31,6 @@ export interface BorrowerStory {
   allVerified: boolean;
   /** Numbers found in the prose that map to no verified claim (should be []). */
   unverifiedTokens: string[];
-}
-
-function fmtCurrencyK(n: number): string {
-  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `$${Math.round(n / 1_000)}K`;
-  return `$${Math.round(n)}`;
 }
 
 /** Available equity % from display LTV; underwater LTV clamps the story to 0% equity. */
@@ -108,7 +103,7 @@ export function buildBorrowerStory(b: Borrower360): BorrowerStory {
   if (parts.length > 0) {
     const lienStr =
       typeof b.current_lien_balance === 'number' && b.current_lien_balance > 0
-        ? ` on a ${register(fmtCurrencyK(b.current_lien_balance), 'Lien balance', 'current_lien_balance', b.current_lien_balance)} lien`
+        ? ` on a ${register(compactCurrency(b.current_lien_balance), 'Lien balance', 'current_lien_balance', b.current_lien_balance)} lien`
         : '';
     // Capitalize the first part.
     const joined = parts.join(', ').replace(/^./, (c) => c.toUpperCase());

--- a/frontend/src/lib/formatters.test.ts
+++ b/frontend/src/lib/formatters.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit contract for the shared display formatters. Each case here is a
+ * defect the 2026-08-07 rendering audit found live, pinned so the fix can't
+ * regress back into a per-call-site template.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  compactCurrency,
+  currency,
+  ratePct,
+  ratePctFromFraction,
+  signedBps,
+  signedBpsLabel,
+} from './formatters';
+
+describe('signedBps', () => {
+  it('prefixes a positive spread and never double-signs a negative one', () => {
+    expect(signedBps(180)).toBe('+180');
+    // The C1 defect: `+{value}` on a signed field rendered "+-422".
+    expect(signedBps(-422)).toBe('-422');
+  });
+
+  it('renders an at-market spread without a sign', () => {
+    expect(signedBps(0)).toBe('0');
+    // Math.round(-0.4) is -0 — must not surface as "-0".
+    expect(signedBps(-0.4)).toBe('0');
+  });
+
+  it('rounds to whole basis points', () => {
+    expect(signedBps(167.4)).toBe('+167');
+    expect(signedBps(-167.6)).toBe('-168');
+  });
+
+  it('renders an em dash for a non-finite value rather than NaN', () => {
+    expect(signedBps(Number.NaN)).toBe('—');
+    expect(signedBps(Number.POSITIVE_INFINITY)).toBe('—');
+  });
+});
+
+describe('signedBpsLabel', () => {
+  it('carries the unit on every branch', () => {
+    expect(signedBpsLabel(180)).toBe('+180 bps');
+    expect(signedBpsLabel(-422)).toBe('-422 bps');
+    expect(signedBpsLabel(0)).toBe('0 bps');
+  });
+
+  it('does not render "— bps" for an unknown value', () => {
+    expect(signedBpsLabel(Number.NaN)).toBe('—');
+  });
+});
+
+describe('compactCurrency', () => {
+  it('rolls up to millions instead of rendering $4410K', () => {
+    expect(compactCurrency(4_410_000)).toBe('$4.4M');
+    expect(compactCurrency(1_389_000)).toBe('$1.4M');
+  });
+
+  it('keeps the thousands form under $1M', () => {
+    expect(compactCurrency(806_500)).toBe('$807K');
+    expect(compactCurrency(520_000)).toBe('$520K');
+    expect(compactCurrency(37_400)).toBe('$37K');
+  });
+
+  it('applies the K→M boundary after rounding', () => {
+    // Rounds to 1000K — must promote rather than render "$1000K".
+    expect(compactCurrency(999_600)).toBe('$1.0M');
+    expect(compactCurrency(999_000)).toBe('$999K');
+  });
+
+  it('renders sub-thousand and negative values honestly', () => {
+    expect(compactCurrency(950)).toBe('$950');
+    expect(compactCurrency(0)).toBe('$0');
+    expect(compactCurrency(-12_000)).toBe('-$12K');
+  });
+
+  it('renders an em dash for a non-finite value', () => {
+    expect(compactCurrency(Number.NaN)).toBe('—');
+  });
+});
+
+describe('rate percent conventions', () => {
+  it('pins percent-form rates to two decimals', () => {
+    expect(ratePct(2.27)).toBe('2.27%');
+    // 0.07 * 100 in SQL reaches the UI as 7.000000000000001.
+    expect(ratePct(7.000000000000001)).toBe('7.00%');
+  });
+
+  it('scales fraction-form rates exactly once, at the same precision', () => {
+    expect(ratePctFromFraction(0.0649)).toBe('6.49%');
+    expect(ratePctFromFraction(0.06125)).toBe('6.13%');
+  });
+
+  it('renders an em dash for a non-finite rate', () => {
+    expect(ratePct(Number.NaN)).toBe('—');
+    expect(ratePctFromFraction(Number.NaN)).toBe('—');
+  });
+});
+
+describe('currency', () => {
+  it('renders whole dollars with thousands separators', () => {
+    expect(currency(806_500)).toBe('$806,500');
+  });
+});

--- a/frontend/src/lib/formatters.ts
+++ b/frontend/src/lib/formatters.ts
@@ -1,2 +1,87 @@
+/**
+ * Shared display formatters for the unit-bearing numbers Module 0 renders.
+ *
+ * Every one of these units was, at some point, hand-rolled per call site —
+ * which is exactly how the 2026-08-07 rendering audit found `+-422 bps`
+ * (a hardcoded "+" in front of a signed value), `$4410k` (a thousands
+ * formatter with no millions branch), and two different rate precisions on
+ * one screen. Formatting a unit is a product decision, not a template
+ * detail: put it here and import it, don't re-derive it in JSX.
+ */
+
 export const currency = (value: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value);
 export const pct = (value: number) => `${value.toFixed(1)}%`;
+
+/** Rendered when a value is missing or non-finite — never a fabricated 0. */
+const UNKNOWN = '—';
+
+/**
+ * Signed basis-point value, WITHOUT the unit suffix (for a column already
+ * headed "Rate Δ (bps)").
+ *
+ * `rate_spread_bps` is signed by construction (`fn_rate_spread` =
+ * `BROUND((current_rate - market_rate) * 10000)`, unclamped): positive is
+ * above market (a refi opportunity), negative is below market, zero is at
+ * market. So the sign belongs to the VALUE, never to the template:
+ *   180  → "+180"   (above market)
+ *   -422 → "-422"   (below market — the "+-422" defect)
+ *   0    → "0"      (at market: neither "+0" nor "-0" is true)
+ */
+export function signedBps(value: number): string {
+  if (!Number.isFinite(value)) return UNKNOWN;
+  // Math.round(-0.4) is -0; comparing to 0 catches it so we never emit "-0".
+  const rounded = Math.round(value);
+  if (rounded === 0) return '0';
+  return rounded > 0 ? `+${rounded}` : `${rounded}`;
+}
+
+/** `signedBps` with the unit: "+180 bps" / "-422 bps" / "0 bps". */
+export function signedBpsLabel(value: number): string {
+  const magnitude = signedBps(value);
+  return magnitude === UNKNOWN ? UNKNOWN : `${magnitude} bps`;
+}
+
+/**
+ * Compact USD for dense surfaces (table cells, preview grids, narrative
+ * prose): rolls up through K *and* M so a $4.41M equity position reads as
+ * "$4.4M" instead of "$4410K".
+ *
+ *   4_410_000 → "$4.4M"      806_500 → "$807K"      950 → "$950"
+ *
+ * The K→M boundary is applied AFTER rounding so 999_600 renders "$1.0M",
+ * not "$1000K". Use `currency()` instead where the exact dollar figure is
+ * the point (dossier facts, governed thresholds).
+ */
+export function compactCurrency(value: number): string {
+  if (!Number.isFinite(value)) return UNKNOWN;
+  const sign = value < 0 ? '-' : '';
+  const abs = Math.abs(value);
+  if (abs >= 1_000) {
+    const thousands = Math.round(abs / 1_000);
+    if (thousands >= 1_000) return `${sign}$${(abs / 1_000_000).toFixed(1)}M`;
+    return `${sign}$${thousands}K`;
+  }
+  return `${sign}$${Math.round(abs)}`;
+}
+
+/**
+ * A rate already in PERCENT form (0-100), at the product's one rate
+ * precision. `mip.gold.borrower_360.current_rate` is `first_pos_rate * 100`
+ * with no ROUND in SQL, so `0.07 * 100` reaches the UI as
+ * 7.000000000000001 — rendering it raw is an IEEE754 leak.
+ */
+export function ratePct(percentValue: number): string {
+  if (!Number.isFinite(percentValue)) return UNKNOWN;
+  return `${percentValue.toFixed(2)}%`;
+}
+
+/**
+ * A rate in FRACTION form (0-1) — e.g. `market_rate_fraction`, which the
+ * borrower router maps to `WhyPanel.market_rate`. Scales once, then renders
+ * at the same precision as `ratePct` so a borrower's own rate and the par
+ * rate beside it can't disagree about how many decimals a rate has.
+ */
+export function ratePctFromFraction(fraction: number): string {
+  if (!Number.isFinite(fraction)) return UNKNOWN;
+  return ratePct(fraction * 100);
+}

--- a/frontend/src/lib/portfolioStory.test.ts
+++ b/frontend/src/lib/portfolioStory.test.ts
@@ -24,6 +24,10 @@ describe('buildPortfolioStory', () => {
     const s = buildPortfolioStory(preview());
     expect(s.available).toBe(true);
     const prose = s.sentences.join(' ');
+    // The predicate behind this count is `marketing_eligibility: 'Any'`, so
+    // the prose must not claim the governed "marketable" subset.
+    expect(prose).toContain('Your addressable book stands at');
+    expect(prose).not.toContain('marketable');
     // Locale-grouped counts and the derived refinance-economics share all appear.
     expect(prose).toContain('5,156,184');
     expect(prose).toContain('111,726');
@@ -39,7 +43,7 @@ describe('buildPortfolioStory', () => {
   it('grounds each figure to the right gold-table source drawer', () => {
     const s = buildPortfolioStory(preview());
     const byLabel = Object.fromEntries(s.claims.map((c) => [c.label, c.sourceKey]));
-    expect(byLabel['Marketable population']).toBe('population');
+    expect(byLabel['Addressable population']).toBe('population');
     expect(byLabel['Refi-economics screen']).toBe('itm');
     expect(byLabel['Refi-economics share']).toBe('itm');
     expect(byLabel['Opportunity score 75+ count']).toBe('leadScore');

--- a/frontend/src/lib/portfolioStory.ts
+++ b/frontend/src/lib/portfolioStory.ts
@@ -90,9 +90,15 @@ export function buildPortfolioStory(preview: PortfolioPreview | null | undefined
   const pct = (highIntent / marketable) * 100;
   const pctToken = `${pct.toFixed(pct < 10 ? 1 : 0)}%`;
 
-  const s1 = `Your marketable book stands at ${register(
+  // "Addressable", not "marketable": Home loads the preview with
+  // `marketing_eligibility: 'Any'` (routes/home.tsx), so this count is the
+  // whole book the lender could reach, NOT the governed marketable subset —
+  // which is ~76K against ~5.16M addressable. The number is right; the word
+  // was wrong (2026-08-07 data audit). `marketable_population` stays as the
+  // API field name; only the sentence changed.
+  const s1 = `Your addressable book stands at ${register(
     intToken(marketable),
-    'Marketable population',
+    'Addressable population',
     'population',
     marketable,
   )} borrowers.`;

--- a/frontend/src/routes/borrower-360.tsx
+++ b/frontend/src/routes/borrower-360.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type CSSProperties, type ReactElement, type ReactN
 import { Link, Navigate, useParams } from 'react-router';
 import { api, ApiError } from '../lib/api';
 import type { Borrower360 as Borrower360Type } from '../types';
-import { currency } from '../lib/formatters';
+import { currency, ratePct, ratePctFromFraction, signedBpsLabel } from '../lib/formatters';
 import { PageShell } from '../components/layout/PageShell';
 import { TriggerTimeline } from '../components/mortgage/TriggerTimeline';
 import { BorrowerStoryCard } from '../components/mortgage/BorrowerStoryCard';
@@ -347,7 +347,12 @@ export default function Borrower360() {
                 v=""
                 childEl={
                   <div>
-                    <div className="field__value mono num">{`${currency(b.current_lien_balance)} · ${b.current_rate}%`}</div>
+                    {/* `current_rate` is already percent form in gold
+                        (`first_pos_rate * 100`, unrounded) — render it through
+                        the shared 2-dp rate convention so it can't disagree
+                        with the par rate in the refi-economics panel, and so
+                        an IEEE754 tail (7.000000000000001) never ships. */}
+                    <div className="field__value mono num">{`${currency(b.current_lien_balance)} · ${ratePct(b.current_rate)}`}</div>
                     <div className="field__sub">
                       <div className="chip-row chip-row--baseline">
                         <Chip variant="warning" className="chip--compact" icon="info">
@@ -474,10 +479,13 @@ export default function Borrower360() {
                   {b.why_panel.in_the_money ? <GlossaryTerm term="inTheMoney">Passes refi screen</GlossaryTerm> : 'Below refi screen'}
                 </Chip>
                 <span className="mono num text-1">
-                  +{b.why_panel.rate_spread_bps} bps
+                  {signedBpsLabel(b.why_panel.rate_spread_bps)}
                 </span>
+                {/* `why_panel.market_rate` is FRACTION form
+                    (`market_rate_fraction`), so it scales once here — same
+                    precision as the borrower's own rate above. */}
                 <span className="muted fs-12">
-                  vs. par {(b.why_panel.market_rate * 100).toFixed(3)}%
+                  vs. par {ratePctFromFraction(b.why_panel.market_rate)}
                 </span>
               </div>
               <div className="rationale-box">

--- a/frontend/src/routes/home.kpi-drawer.test.tsx
+++ b/frontend/src/routes/home.kpi-drawer.test.tsx
@@ -86,7 +86,10 @@ describe('Home KPI evidence drawers cite the headline metric view', () => {
   });
 
   const KPI_CHIPS: Array<{ label: string; chipText: string; family: string }> = [
-    { label: 'Marketable population', chipText: 'Marketable population', family: 'marketable_population' },
+    // Card label reads "Addressable" (the Home preview asks for
+    // `marketing_eligibility: 'Any'`); the evidence chip keeps the governed
+    // asset's own name, which the backend lineage manifest also uses.
+    { label: 'Addressable population', chipText: 'Marketable population', family: 'marketable_population' },
     { label: 'Refi economics screen', chipText: 'Rate + equity screen', family: 'in_the_money' },
     { label: 'Opportunity score 75+', chipText: 'Opportunity score', family: 'opportunity_score' },
     { label: 'Primary offer paths', chipText: 'How the offer path was selected', family: 'next_best_offer' },

--- a/frontend/src/routes/home.tsx
+++ b/frontend/src/routes/home.tsx
@@ -216,8 +216,13 @@ export default function Home() {
       )}
       {!isDayZero && !previewWarming && (
         <div className="kpi-row">
+          {/* "Addressable", not "marketable": HOME_PORTFOLIO_PREVIEW_CRITERIA
+              asks for `marketing_eligibility: 'Any'`, so this KPI counts the
+              whole reachable book, not the governed marketable subset
+              (~76K of ~5.16M). 2026-08-07 data audit — the number is right,
+              the label was claiming a narrower predicate than it applied. */}
           <KpiCard
-            label="Marketable population"
+            label="Addressable population"
             valueAnimated={preview?.marketable_population ?? null}
             trend={preview?.trends?.marketable_population?.series}
             delta={formatDelta(preview?.trends?.marketable_population)}

--- a/frontend/src/routes/lead-queue.test.tsx
+++ b/frontend/src/routes/lead-queue.test.tsx
@@ -38,6 +38,12 @@ const apiMocks = vi.hoisted(() => ({
   adminRules: vi.fn(),
 }));
 
+const appMocks = vi.hoisted(() => ({ canAccessAdmin: true }));
+
+vi.mock('../components/AppContext', () => ({
+  useApp: () => ({ canAccessAdmin: appMocks.canAccessAdmin }),
+}));
+
 vi.mock('../lib/useWarmingUpRetry', () => ({
   useWarmingUpRetry: () => retryMocks.state,
 }));
@@ -244,6 +250,45 @@ describe('LeadQueue filter state', () => {
     queryClient.clear();
     document.body.innerHTML = '';
     vi.clearAllMocks();
+  });
+
+  /**
+   * 2026-08-07 audit H4: the export's rules-version stamp comes from the
+   * AdminDep-gated /api/admin/rules, and this route fired it for every actor.
+   * A loan officer's console filled with 403s on a core product route.
+   */
+  it('does not call the admin-scoped rules endpoint for a non-admin actor', async () => {
+    appMocks.canAccessAdmin = false;
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/lead-queue']}>
+            <LeadQueue />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+    await settle();
+
+    expect(apiMocks.adminRules).not.toHaveBeenCalled();
+    // The rest of the route still loads its own data.
+    expect(apiMocks.portfolioPreview).toHaveBeenCalled();
+    appMocks.canAccessAdmin = true;
+  });
+
+  it('reads the rules version for an admin actor', async () => {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/lead-queue']}>
+            <LeadQueue />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+    await settle();
+
+    expect(apiMocks.adminRules).toHaveBeenCalled();
   });
 
   it('shows Genie cohort multi-value route filters in dropdown controls', async () => {

--- a/frontend/src/routes/lead-queue.tsx
+++ b/frontend/src/routes/lead-queue.tsx
@@ -12,6 +12,7 @@ import { Chip } from '../components/Primitives';
 import { WarmingUpBlock } from '../components/ui/WarmingUpBlock';
 import { FilterSelect } from '../components/ui/FilterSelect';
 import { useFootprint } from '../components/FootprintProvider';
+import { useApp } from '../components/AppContext';
 import { queryKeys } from '../lib/queryKeys';
 import { LENDER_RELATIONSHIP_OPTIONS } from '../lib/lenderFilters';
 import { LeadQueueTableSkeleton } from './lead-queue.skeleton';
@@ -76,6 +77,7 @@ export default function LeadQueue() {
   const [searchParams, setSearchParams] = useSearchParams();
   const filtersActive = searchParams.toString().length > 0;
   const footprint = useFootprint();
+  const { canAccessAdmin } = useApp();
   const segment = parseSegmentCodes(searchParams.get('segment'))[0];
   const segmentCodes = useMemo(
     () => parseSegmentCodes(searchParams.get('segment_codes')),
@@ -330,12 +332,20 @@ export default function LeadQueue() {
       .portfolioPreview({}, ctrl.signal)
       .then((payload: PortfolioPreview) => setExportRefreshedAt(payload.data_refreshed_at ?? null))
       .catch(() => setExportRefreshedAt(null));
+    // The offer-rules version stamped on an export comes from an admin-scoped
+    // endpoint. A loan officer's visit to this route used to fire it anyway
+    // and eat a 403, which the UI swallowed but the browser console did not
+    // (2026-08-07 audit H4). Ask only when the session says we may.
+    if (!canAccessAdmin) {
+      setRulesVersion(null);
+      return () => ctrl.abort();
+    }
     api
       .adminRules<AdminRulesSummary>(ctrl.signal)
       .then((payload) => setRulesVersion(payload.offer_rules_version ?? null))
       .catch(() => setRulesVersion(null));
     return () => ctrl.abort();
-  }, []);
+  }, [canAccessAdmin]);
 
   const visibleLeads = useMemo(() => {
     return leadsData?.leads ?? [];

--- a/frontend/tests/e2e/lineage_explorer.spec.ts
+++ b/frontend/tests/e2e/lineage_explorer.spec.ts
@@ -255,7 +255,7 @@ test.describe('Lineage explorer — KPI to Catalog Explorer deep link', () => {
     // manifest response. The drawer must surface drift instead of borrowing
     // nodes from a different KPI family.
     const kpiCard = page
-      .locator('.kpi', { has: page.getByText('Marketable population', { exact: true }) })
+      .locator('.kpi', { has: page.getByText('Addressable population', { exact: true }) })
       .first();
     await expect(kpiCard).toBeVisible({ timeout: 10_000 });
     await kpiCard.locator('.evidence-chip').first().click();


### PR DESCRIPTION
Frontend-only fixes for the defects found by the 2026-08-07 platform audit (`e2e_report.md`). No `backend/` or `sql/` files touched.

## What changed

| Audit | Fix |
|---|---|
| **C1** `+-422 bps` | `rate_spread_bps` is signed; three sites hardcoded a `+`. Now `signedBps` / `signedBpsLabel` — `+180` / `-422` / `0` (never `-0`). |
| **H1** `$4410k` | `compactCurrency` rolls K→M — `$4.4M`, `$807K`, `$950`; the K→M boundary is applied after rounding so 999,600 is `$1.0M`. `borrowerStory`'s private `fmtCurrencyK` is deleted in favour of the shared one. |
| **M2 / M5** two rate conventions on one screen | `ratePct` (percent-form fields) and `ratePctFromFraction` (fraction-form fields) at one 2-dp precision. The units were already right; the raw `{current_rate}%` was leaking the `first_pos_rate * 100` IEEE754 tail. |
| **C2** ZIP as a strategy-board metric | Measure selection runs through the identifier-guarded `coerceMeasure` (via `findMeasureColumn`); an explicit `viz.y` gets the same guard; a board with no honest measure renders unnumbered cards instead of inventing a number. Same guard on the choropleth shading axis. |
| **H2** identifier gaps | `zip5`, `property_zip`, `situs_zip`, `zip_code_5`, `apn`, `loan_number`, `*_year` — and the zip family is now one pattern shared with the zero-padding path, so the two lists cannot drift. |
| **H3** Genie money cells | `*_usd`, `*_amount`, `*_balance`, `*_price`, `*_upb`, `*_equity`, `avm_value` render through the app's `currency()`. `equity_pct` and its siblings are excluded by construction. |
| **M1** tenant pill over the search box | Centre track 44rem → 32rem (the actions cluster measures ~375px; side tracks were 296px), `max-inline-size: 100%` on `.topbar__actions`, and a `.topbar__pill-tenant` element that ellipsizes instead of wrapping. The narrow-viewport branch moves 1180px → 88rem. |
| **M4** health polled 3-4×/route | No duplicate caller exists — it was the cadence. Fast polling now requires a dependency down or a breaker open; a deploy-shaped `status: "degraded"` with everything up stays on the slow cadence. Display semantics unchanged. |
| **H4** 403s on non-admin routes | `/lead-queue`'s rules-version read and the evidence drawer's asset-metadata read gate on `can_access_admin`. The drawer gains an honest `restricted` freshness state instead of reusing `error`. |
| **data audit** "marketable" copy | Home's preview asks for `marketing_eligibility: 'Any'`, so the KPI label and the "your book today" sentence now say **addressable**. Which number is fetched is unchanged. |

## Verification

- `npm --prefix frontend run lint` — clean (`--max-warnings 0`)
- `npm --prefix frontend run test` — 128 files / 987 tests pass (new cases: sign formatter, M-rollup, identifier guard, money columns, strategy-board render, health cadence, RBAC gating)
- `npm --prefix frontend run build` passes; `tools/check_frontend_budgets.mjs` passed (initial CSS 146.97 KiB / gzip 24.87 KiB)
- Topbar measured in a real browser against this build at 1440×900: tracks 392/512/392, **0px overlap** (was 26px), ⌘K badge visible, tenant pill back to one line. Also 0px at 1408, 1280, and with a 37-character tenant name.

## Deliberately not changed

- `DRAWER_SOURCES.population` still reads "Marketable population" — that string is the lineage family the **backend** manifest publishes, so a frontend-only rename would put two names on one asset a click apart. Needs the backend/lineage workstream.
- **C3** (`$1795000`) and the `$1389K` evidence chip live in `sql/transformations/gold_evidence_events.sql` — out of scope.
- **M3** (`admin-config` USD threshold renders `806500`) and L1–L5 — not on the assigned fix list.
- `tests/e2e/module0.spec.ts` KPI assertions were already stale before this branch (it pins "High-intent leads" / "Top-tier opportunities", labels the product does not use); left alone rather than half-fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
