### PR TITLE
fix(ci): green main — type the Genie protocol, split the gate offenders, patch nanoid

### DIFF
--- a/backend/api/growth_agent.py
+++ b/backend/api/growth_agent.py
@@ -8,7 +8,6 @@ for human review. It never sends outreach or activates a connector.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 from collections.abc import Sequence
@@ -30,12 +29,9 @@ from backend.schemas.growth_agent import (
     GrowthAgentMonitor,
     GrowthAgentMonitorDraftRequest,
     GrowthAgentNotificationDraft,
-    GrowthAgentPolicyCheck,
     GrowthAgentPromptRunRequest,
     GrowthAgentRunRequest,
     GrowthAgentRunResponse,
-    GrowthAgentToolStep,
-    GrowthAgentWorkflow,
     GrowthAgentWorkflowId,
 )
 from backend.services.audit_lakebase_store import write_audit_event_in_transaction
@@ -74,6 +70,9 @@ from backend.services.growth_agent_ledger_sql import (
 )
 from backend.services.growth_agent_ledger_sql import (
     RUN_SELECT_BY_REQUEST_ID_SQL as _RUN_SELECT_BY_REQUEST_ID_SQL,
+)
+from backend.services.growth_agent_live_analysis import (
+    live_analysis_fallback as _live_analysis_fallback,
 )
 from backend.services.growth_agent_metrics import load_growth_agent_metrics
 from backend.services.growth_agent_monitors import (
@@ -132,7 +131,6 @@ from backend.services.rbac import require_admin
 from backend.services.repositories.databricks_lead_cohorts import (
     normalise_growth_agent_handoff_filters,
 )
-from backend.services.repositories.factory import get_genie_answer_repository
 
 router = APIRouter(prefix="/growth-agent", tags=["growth-agent"])
 
@@ -490,126 +488,6 @@ def run_custom_growth_agent_workflow(
 
 
 _LIVE_ANALYSIS_LOG = logging.getLogger("backend.api.growth_agent.live_analysis")
-
-
-def _live_analysis_fallback(
-    payload: GrowthAgentPromptRunRequest,
-    request: Request,
-    lakebase: LakebaseClient,
-) -> GrowthAgentRunResponse | None:
-    """Read-only live-analysis fallback when no reviewed workflow matches.
-
-    The objective runs through the full Genie policy pipeline (which can plan
-    its own multi-part decomposition), exactly like an Ask Genie turn: prompt
-    guard battery first, live SQL trust, claims verification, PII redaction.
-    Nothing here writes campaign/monitor state — the response is analysis with
-    proof, and the audit trail records that a read-only analysis ran.
-    """
-
-    from backend.services.repositories.databricks_genie_sweep import (
-        _planned_question_guard_hit,
-    )
-
-    if _planned_question_guard_hit(payload.prompt) is not None:
-        return None
-    repo = get_genie_answer_repository()
-    try:
-        analysis = repo.respond(payload.prompt)
-    except Exception:  # noqa: BLE001 - fall back to the honest 422
-        return None
-    if analysis.source not in ("genie", "trusted_sql") or not (analysis.answer or "").strip():
-        return None
-    actor = resolve_actor(request)
-    run_id = payload.request_id or str(uuid4())
-    result_hash = hashlib.sha256(
-        f"{analysis.question_hash}|{analysis.sql_query or ''}".encode()
-    ).hexdigest()[:32]
-    try:
-        with lakebase.transaction() as conn:
-            write_audit_event_in_transaction(
-                conn,
-                actor=actor,
-                action="growth_agent.live_analysis",
-                entity_type="growth_agent_run",
-                entity_id=run_id,
-                # Keys come from the reviewed audit-metadata allowlist
-                # (backend/services/audit_store.py::_ALLOWED_METADATA_KEYS).
-                payload_json={
-                    "question_hash": analysis.question_hash,
-                    "source_assets": analysis.trusted_assets,
-                    "conversation_id": analysis.conversation_id or None,
-                    "message_id": analysis.message_id,
-                },
-            )
-    except (LakebaseError, psycopg.Error) as exc:
-        raise HTTPException(status_code=503, detail=safe_dependency_detail("lakebase")) from exc
-    workflow = GrowthAgentWorkflow(
-        id="live_analysis",
-        title="Live analysis",
-        objective=payload.prompt[:280],
-        trigger_label="No reviewed workflow matched; the live space analyzed the objective itself.",
-        action_label="Review the governed analysis; no state was written.",
-        source_assets=list(analysis.trusted_assets),
-        proof_points=[
-            "Every figure comes from Genie's own governed SQL over trusted assets.",
-            "The full answer, generated SQL, and process trace are in Ask Genie.",
-        ],
-        tool_detail="Genie Conversation API (read-only)",
-        specialist_agent="structured_data_agent",
-        default_route="/ask-genie",
-    )
-    tool_steps = [
-        GrowthAgentToolStep(
-            label=step.kind,
-            status="completed",
-            detail=step.content,
-        )
-        for step in (analysis.reasoning_trace or [])[:8]
-    ] or [
-        GrowthAgentToolStep(
-            label="live",
-            status="completed",
-            detail="The objective ran as a governed live Genie analysis.",
-        )
-    ]
-    return GrowthAgentRunResponse(
-        workflow=workflow,
-        run_id=run_id,
-        specialist_agent="structured_data_agent",
-        execution_mode="genie_conversation",
-        trace_kind="genie_conversation",
-        planner_label="Live Genie analysis (read-only fallback)",
-        trace_id=f"agent-trace-{uuid4()}",
-        tool_result_hash=result_hash,
-        broad_total=analysis.row_count or 0,
-        actionable_total=0,
-        route="/ask-genie",
-        criteria={"prompt": payload.prompt[:280]},
-        source_assets=list(analysis.trusted_assets),
-        tool_steps=tool_steps,
-        policy_checks=[
-            GrowthAgentPolicyCheck(
-                label="Prompt guard battery",
-                status="passed",
-                detail="Fair-lending, PII, scope, and injection screens cleared.",
-            ),
-            GrowthAgentPolicyCheck(
-                label="Governed answer pipeline",
-                status="passed",
-                detail="SQL trust policy, claims verification, and PII redaction applied.",
-            ),
-            GrowthAgentPolicyCheck(
-                label="No state written",
-                status="passed",
-                detail="Read-only analysis; campaigns, monitors, and Lead Queue were not modified.",
-            ),
-        ],
-        interpreted_intent="Read-only live analysis (no reviewed workflow matched).",
-        agent_reasoning=analysis.answer,
-        genie_conversation_id=analysis.conversation_id or None,
-        genie_message_id=analysis.message_id,
-        genie_question_hash=analysis.question_hash,
-    )
 
 
 @router.post("/agent/run", response_model=GrowthAgentRunResponse, responses=JSON_CONTENT_TYPE_RESPONSE)

--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -8,6 +8,9 @@ from backend.schemas.growth_agent_segment_intent import (
     is_closed_reviewed_segment_signal_criterion,
 )
 from backend.schemas.marketing_audience_admission import audience_admission_criterion
+from backend.schemas.marketing_selection_reviewed_analytics import (
+    _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS,
+)
 
 REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT = (
     r"(?:(?:high|strong|substantial|sufficient|available|usable)\s+(?:home[- ]?)?equity|"
@@ -238,132 +241,6 @@ _AUDIENCE_CRITERION_SUFFIX_RE = re.compile(
 _REVIEWED_SEGMENT_SIGNAL_BINDING_RE = re.compile(
     r"^\s+with\s+(?P<criterion>.+)$",
     re.IGNORECASE,
-)
-_REVIEWED_ANALYTIC_POPULATION = (
-    r"(?:(?:(?:in[- ]the[- ]money|listed|refinance[- ]ready|retention[- ]risk|"
-    r"marketing[- ]eligible|investor|equity[- ]rich|highest[- ]scoring)\s+)?"
-    r"(?:borrowers?|leads?|applicants?|homeowners?|customers?|cohorts?|populations?))"
-)
-_REVIEWED_ANALYTIC_DIMENSION = (
-    r"(?:(?:current\s+coverage|covered)\s+)?(?:states?|count(?:y|ies)|"
-    r"zip(?:\s+codes?)?|postal\s+codes?|markets?|metros?|"
-    r"segments?|lead\s+scores?|opportunity\s+scores?|equity|ltv|loan[- ]to[- ]value|"
-    r"rate[- ]spreads?|listing\s+time(?:\s+on\s+market)?)"
-)
-_REVIEWED_ANALYTIC_MEASURE = (
-    r"(?:listing\s+time\s+on\s+market|lead\s+score|opportunity\s+score|"
-    r"borrower\s+count|equity(?:\s+percentage)?|ltv|loan[- ]to[- ]value|rate[- ]spread)"
-)
-_REVIEWED_ANALYTIC_LOCATION = (
-    r"(?:\s+(?:in|across)\s+(?:the\s+current\s+(?:coverage|portfolio)|"
-    r"[A-Za-z]{2}|[A-Z][A-Za-z' -]{2,40}))?"
-)
-# Governed Module 0 product-intent cohorts. Closed list: these are offer
-# codes/segment names the product models, never free-text criteria.
-_REVIEWED_PRODUCT_INTENT = (
-    r"(?:cash[- ]out|heloc|home[- ]equity|refi(?:nance)?|rate[- ]and[- ]term|"
-    r"purchase|listed(?:[- ]for[- ]sale)?|investor|multi[- ]property|"
-    r"retention|recapture|in[- ]the[- ]money|high[- ]equity)"
-)
-_REVIEWED_READ_ONLY_ANALYTIC_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(
-        # Offer strategy by segment ("which offer should we lead with for each
-        # segment, and why?"). The audience grammar read the affirmative
-        # "lead with ... for each segment" as an unreviewed audience decision;
-        # it is the product's core read-only offer-mix question. Live persona
-        # audit 2026-08-07 (marketing-leader).
-        r"^(?:which|what)\s+(?:next[- ]best\s+)?offers?\s+"
-        r"(?:should|do|would)\s+(?:we|i|the\s+team)\s+"
-        r"(?:lead\s+with|use|present|recommend|make|pitch|prioriti[sz]e)\s+"
-        r"(?:for|to|with)\s+(?:each|every|the|our)?\s*"
-        rf"(?:{_REVIEWED_ANALYTIC_DIMENSION}|{_REVIEWED_ANALYTIC_POPULATION})"
-        r"(?:\s*,?\s*and\s+why)?$",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        # Ranked product-intent cohort with a per-row rationale ("rank the top
-        # cash-out candidates in Texas and explain why each one qualifies").
-        # The intent vocabulary is closed, so an unknown criterion cannot ride
-        # this shape. Live persona audit 2026-08-07 (sales-manager).
-        r"^(?:rank|show|list|give\s+me|surface|prioriti[sz]e)\s+(?:me\s+)?(?:the\s+)?"
-        r"(?:top\s+(?:[0-9]{1,3}\s+)?)?"
-        # One or two stacked intent tokens ("in-the-money refi", "purchase
-        # mortgage") — still drawn from the same closed vocabulary, so an
-        # unknown criterion cannot ride the second slot. Live persona audit
-        # 2026-08-07 (co-pilot flagship objective).
-        rf"{_REVIEWED_PRODUCT_INTENT}(?:[\s-]+(?:{_REVIEWED_PRODUCT_INTENT}|mortgage|loan))?\s+"
-        r"(?:candidates?|borrowers?|leads?|opportunities)"
-        rf"{_REVIEWED_ANALYTIC_LOCATION}"
-        r"(?:\s*,?\s*and\s+(?:explain|tell\s+me|describe|show)\s+"
-        r"(?:me\s+)?why\s+(?:each|every)(?:\s+one)?\s+"
-        r"(?:qualifies|ranks?|scores?|is\s+(?:a\s+)?(?:strong|good)(?:\s+candidate)?))?$",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        # Reviewed-population cohort carrying a closed product-intent
-        # with-clause ("show customers with an in-the-money refi", "show
-        # investor borrowers with multiple properties" — the Owner Link
-        # domain rule). The with-clause alternatives are a closed set; a
-        # free-text criterion ("with zyrplax", "with eczema") does not match
-        # and falls through to the strict criterion machine. Live persona
-        # audit 2026-08-07 (co-pilot).
-        r"^(?:show|find|list|rank|surface|give\s+me)\s+(?:me\s+)?(?:the\s+)?"
-        rf"(?:{_REVIEWED_PRODUCT_INTENT}\s+)?"
-        r"(?:customers?|borrowers?|leads?|candidates?|prospects?|homeowners?|owners?)\s+"
-        r"with\s+(?:"
-        rf"(?:(?:a|an|the)\s+)?{_REVIEWED_PRODUCT_INTENT}"
-        rf"(?:[\s-]+(?:{_REVIEWED_PRODUCT_INTENT}|mortgage|loan|refi|refinance|position|offer|opportunity))?"
-        r"|multiple\s+properties"
-        r")"
-        rf"{_REVIEWED_ANALYTIC_LOCATION}$",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        # Building-permit data is an explicit product source gap. This closed
-        # read-only query must reach the Genie source-gap policy rather than
-        # being mislabeled as protected-class targeting merely because it
-        # uses the product noun ``candidates``.
-        r"^(?:show|list|find|identify)\s+(?:me\s+)?(?:the\s+)?"
-        r"(?:heloc|home[- ]equity)\s+candidates?\s+with\s+"
-        r"(?:recent|filed)\s+(?:building\s+)?permits?\s+and\s+"
-        r"(?:strong|high)\s+equity$",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        r"^(?:show|list|count)\s+(?:me\s+)?(?:the\s+)?"
-        r"(?:approved|assigned|queued)\s+leads?\s+"
-        r"(?:that|who)\s+(?:have|has)\s+not\s+been\s+"
-        r"(?:touched|contacted|called)\s+in\s+[0-9]{1,3}\s+days?$",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        r"^(?:chart|plot|graph|visualize|display|show|list|count|rank|order|group|compare|"
-        r"break\s+down)\s+(?:me\s+)?(?:the\s+)?"
-        r"(?:(?:top|bottom)\s+(?:[0-9]{1,3}|ten|twenty(?:[- ]five)?)\s+)?"
-        rf"{_REVIEWED_ANALYTIC_POPULATION}\s+"
-        r"(?:(?:by|grouped\s+by|ordered\s+by|ranked\s+by)\s+)"
-        rf"{_REVIEWED_ANALYTIC_DIMENSION}{_REVIEWED_ANALYTIC_LOCATION}$",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        r"^(?:what\s+is|calculate|show|display|report|compare)\s+(?:me\s+)?(?:the\s+)?"
-        r"(?:average|median|mean|total|minimum|maximum|distribution\s+of)\s+"
-        rf"{_REVIEWED_ANALYTIC_MEASURE}\s+(?:for|across)\s+(?:the\s+)?"
-        rf"{_REVIEWED_ANALYTIC_POPULATION}\s+by\s+"
-        rf"{_REVIEWED_ANALYTIC_DIMENSION}{_REVIEWED_ANALYTIC_LOCATION}$",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        rf"^(?:which|what)\s+{_REVIEWED_ANALYTIC_DIMENSION}\s+"
-        r"(?:leads?|ranks?\s+(?:highest|lowest)|has\s+(?:the\s+)?"
-        r"(?:highest|lowest|most|fewest)\s+(?:count|score|borrowers?|leads?))$",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        rf"^how\s+(?:has|have)\s+(?:the\s+)?{_REVIEWED_ANALYTIC_POPULATION}\s+"
-        r"(?:moved|changed|shifted|trended)(?:\s+(?:recently|over\s+time|this\s+week))?$",
-        re.IGNORECASE,
-    ),
 )
 _REVIEWED_NON_POPULATION_STRATEGY_RE = re.compile(
     # This grammar allocates aggregate outreach capacity; it does not select

--- a/backend/schemas/marketing_selection_reviewed_analytics.py
+++ b/backend/schemas/marketing_selection_reviewed_analytics.py
@@ -1,0 +1,139 @@
+"""Reviewed read-only analytics question shapes.
+
+Closed-vocabulary grammars for analytics questions the product itself asks
+(offer mix by segment, ranked product-intent cohorts, permit source-gap
+probes). Split from the criterion machine when it crossed the size gate
+(2026-08-08); the vocabulary and shapes are unchanged. Every fragment stays
+closed so an unknown criterion can never ride an approved shape.
+"""
+
+from __future__ import annotations
+
+import re
+
+_REVIEWED_ANALYTIC_POPULATION = (
+    r"(?:(?:(?:in[- ]the[- ]money|listed|refinance[- ]ready|retention[- ]risk|"
+    r"marketing[- ]eligible|investor|equity[- ]rich|highest[- ]scoring)\s+)?"
+    r"(?:borrowers?|leads?|applicants?|homeowners?|customers?|cohorts?|populations?))"
+)
+_REVIEWED_ANALYTIC_DIMENSION = (
+    r"(?:(?:current\s+coverage|covered)\s+)?(?:states?|count(?:y|ies)|"
+    r"zip(?:\s+codes?)?|postal\s+codes?|markets?|metros?|"
+    r"segments?|lead\s+scores?|opportunity\s+scores?|equity|ltv|loan[- ]to[- ]value|"
+    r"rate[- ]spreads?|listing\s+time(?:\s+on\s+market)?)"
+)
+_REVIEWED_ANALYTIC_MEASURE = (
+    r"(?:listing\s+time\s+on\s+market|lead\s+score|opportunity\s+score|"
+    r"borrower\s+count|equity(?:\s+percentage)?|ltv|loan[- ]to[- ]value|rate[- ]spread)"
+)
+_REVIEWED_ANALYTIC_LOCATION = (
+    r"(?:\s+(?:in|across)\s+(?:the\s+current\s+(?:coverage|portfolio)|"
+    r"[A-Za-z]{2}|[A-Z][A-Za-z' -]{2,40}))?"
+)
+# Governed Module 0 product-intent cohorts. Closed list: these are offer
+# codes/segment names the product models, never free-text criteria.
+_REVIEWED_PRODUCT_INTENT = (
+    r"(?:cash[- ]out|heloc|home[- ]equity|refi(?:nance)?|rate[- ]and[- ]term|"
+    r"purchase|listed(?:[- ]for[- ]sale)?|investor|multi[- ]property|"
+    r"retention|recapture|in[- ]the[- ]money|high[- ]equity)"
+)
+_REVIEWED_READ_ONLY_ANALYTIC_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        # Offer strategy by segment ("which offer should we lead with for each
+        # segment, and why?"). The audience grammar read the affirmative
+        # "lead with ... for each segment" as an unreviewed audience decision;
+        # it is the product's core read-only offer-mix question. Live persona
+        # audit 2026-08-07 (marketing-leader).
+        r"^(?:which|what)\s+(?:next[- ]best\s+)?offers?\s+"
+        r"(?:should|do|would)\s+(?:we|i|the\s+team)\s+"
+        r"(?:lead\s+with|use|present|recommend|make|pitch|prioriti[sz]e)\s+"
+        r"(?:for|to|with)\s+(?:each|every|the|our)?\s*"
+        rf"(?:{_REVIEWED_ANALYTIC_DIMENSION}|{_REVIEWED_ANALYTIC_POPULATION})"
+        r"(?:\s*,?\s*and\s+why)?$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        # Ranked product-intent cohort with a per-row rationale ("rank the top
+        # cash-out candidates in Texas and explain why each one qualifies").
+        # The intent vocabulary is closed, so an unknown criterion cannot ride
+        # this shape. Live persona audit 2026-08-07 (sales-manager).
+        r"^(?:rank|show|list|give\s+me|surface|prioriti[sz]e)\s+(?:me\s+)?(?:the\s+)?"
+        r"(?:top\s+(?:[0-9]{1,3}\s+)?)?"
+        # One or two stacked intent tokens ("in-the-money refi", "purchase
+        # mortgage") — still drawn from the same closed vocabulary, so an
+        # unknown criterion cannot ride the second slot. Live persona audit
+        # 2026-08-07 (co-pilot flagship objective).
+        rf"{_REVIEWED_PRODUCT_INTENT}(?:[\s-]+(?:{_REVIEWED_PRODUCT_INTENT}|mortgage|loan))?\s+"
+        r"(?:candidates?|borrowers?|leads?|opportunities)"
+        rf"{_REVIEWED_ANALYTIC_LOCATION}"
+        r"(?:\s*,?\s*and\s+(?:explain|tell\s+me|describe|show)\s+"
+        r"(?:me\s+)?why\s+(?:each|every)(?:\s+one)?\s+"
+        r"(?:qualifies|ranks?|scores?|is\s+(?:a\s+)?(?:strong|good)(?:\s+candidate)?))?$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        # Reviewed-population cohort carrying a closed product-intent
+        # with-clause ("show customers with an in-the-money refi", "show
+        # investor borrowers with multiple properties" — the Owner Link
+        # domain rule). The with-clause alternatives are a closed set; a
+        # free-text criterion ("with zyrplax", "with eczema") does not match
+        # and falls through to the strict criterion machine. Live persona
+        # audit 2026-08-07 (co-pilot).
+        r"^(?:show|find|list|rank|surface|give\s+me)\s+(?:me\s+)?(?:the\s+)?"
+        rf"(?:{_REVIEWED_PRODUCT_INTENT}\s+)?"
+        r"(?:customers?|borrowers?|leads?|candidates?|prospects?|homeowners?|owners?)\s+"
+        r"with\s+(?:"
+        rf"(?:(?:a|an|the)\s+)?{_REVIEWED_PRODUCT_INTENT}"
+        rf"(?:[\s-]+(?:{_REVIEWED_PRODUCT_INTENT}|mortgage|loan|refi|refinance|position|offer|opportunity))?"
+        r"|multiple\s+properties"
+        r")"
+        rf"{_REVIEWED_ANALYTIC_LOCATION}$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        # Building-permit data is an explicit product source gap. This closed
+        # read-only query must reach the Genie source-gap policy rather than
+        # being mislabeled as protected-class targeting merely because it
+        # uses the product noun ``candidates``.
+        r"^(?:show|list|find|identify)\s+(?:me\s+)?(?:the\s+)?"
+        r"(?:heloc|home[- ]equity)\s+candidates?\s+with\s+"
+        r"(?:recent|filed)\s+(?:building\s+)?permits?\s+and\s+"
+        r"(?:strong|high)\s+equity$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^(?:show|list|count)\s+(?:me\s+)?(?:the\s+)?"
+        r"(?:approved|assigned|queued)\s+leads?\s+"
+        r"(?:that|who)\s+(?:have|has)\s+not\s+been\s+"
+        r"(?:touched|contacted|called)\s+in\s+[0-9]{1,3}\s+days?$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^(?:chart|plot|graph|visualize|display|show|list|count|rank|order|group|compare|"
+        r"break\s+down)\s+(?:me\s+)?(?:the\s+)?"
+        r"(?:(?:top|bottom)\s+(?:[0-9]{1,3}|ten|twenty(?:[- ]five)?)\s+)?"
+        rf"{_REVIEWED_ANALYTIC_POPULATION}\s+"
+        r"(?:(?:by|grouped\s+by|ordered\s+by|ranked\s+by)\s+)"
+        rf"{_REVIEWED_ANALYTIC_DIMENSION}{_REVIEWED_ANALYTIC_LOCATION}$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^(?:what\s+is|calculate|show|display|report|compare)\s+(?:me\s+)?(?:the\s+)?"
+        r"(?:average|median|mean|total|minimum|maximum|distribution\s+of)\s+"
+        rf"{_REVIEWED_ANALYTIC_MEASURE}\s+(?:for|across)\s+(?:the\s+)?"
+        rf"{_REVIEWED_ANALYTIC_POPULATION}\s+by\s+"
+        rf"{_REVIEWED_ANALYTIC_DIMENSION}{_REVIEWED_ANALYTIC_LOCATION}$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"^(?:which|what)\s+{_REVIEWED_ANALYTIC_DIMENSION}\s+"
+        r"(?:leads?|ranks?\s+(?:highest|lowest)|has\s+(?:the\s+)?"
+        r"(?:highest|lowest|most|fewest)\s+(?:count|score|borrowers?|leads?))$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"^how\s+(?:has|have)\s+(?:the\s+)?{_REVIEWED_ANALYTIC_POPULATION}\s+"
+        r"(?:moved|changed|shifted|trended)(?:\s+(?:recently|over\s+time|this\s+week))?$",
+        re.IGNORECASE,
+    ),
+)

--- a/backend/services/growth_agent_live_analysis.py
+++ b/backend/services/growth_agent_live_analysis.py
@@ -1,0 +1,149 @@
+"""Read-only live-analysis fallback for the Growth Agent co-pilot.
+
+When no reviewed workflow matches the operator's objective, the objective can
+still run as a governed Ask Genie turn: prompt guard battery, live SQL trust,
+claims verification, PII redaction — analysis with proof, never state. Moved
+out of the router module when it crossed the size gate (2026-08-08); behavior
+unchanged. Routers stay thin; this is service logic.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from uuid import uuid4
+
+import psycopg
+from fastapi import HTTPException, Request
+
+from backend.schemas.growth_agent import (
+    GrowthAgentPolicyCheck,
+    GrowthAgentPromptRunRequest,
+    GrowthAgentRunResponse,
+    GrowthAgentToolStep,
+    GrowthAgentWorkflow,
+)
+from backend.services.audit_lakebase_store import write_audit_event_in_transaction
+from backend.services.audit_store import resolve_actor
+from backend.services.error_sanitizer import safe_dependency_detail
+from backend.services.lakebase import LakebaseClient, LakebaseError
+from backend.services.repositories.factory import get_genie_answer_repository
+
+
+def live_analysis_fallback(
+    payload: GrowthAgentPromptRunRequest,
+    request: Request,
+    lakebase: LakebaseClient,
+) -> GrowthAgentRunResponse | None:
+    """Read-only live-analysis fallback when no reviewed workflow matches.
+
+    The objective runs through the full Genie policy pipeline (which can plan
+    its own multi-part decomposition), exactly like an Ask Genie turn: prompt
+    guard battery first, live SQL trust, claims verification, PII redaction.
+    Nothing here writes campaign/monitor state — the response is analysis with
+    proof, and the audit trail records that a read-only analysis ran.
+    """
+
+    from backend.services.repositories.databricks_genie_sweep import (
+        _planned_question_guard_hit,
+    )
+
+    if _planned_question_guard_hit(payload.prompt) is not None:
+        return None
+    repo = get_genie_answer_repository()
+    try:
+        analysis = repo.respond(payload.prompt)
+    except Exception:  # noqa: BLE001 - fall back to the honest 422
+        return None
+    if analysis.source not in ("genie", "trusted_sql") or not (analysis.answer or "").strip():
+        return None
+    actor = resolve_actor(request)
+    run_id = payload.request_id or str(uuid4())
+    result_hash = hashlib.sha256(
+        f"{analysis.question_hash}|{analysis.sql_query or ''}".encode()
+    ).hexdigest()[:32]
+    try:
+        with lakebase.transaction() as conn:
+            write_audit_event_in_transaction(
+                conn,
+                actor=actor,
+                action="growth_agent.live_analysis",
+                entity_type="growth_agent_run",
+                entity_id=run_id,
+                # Keys come from the reviewed audit-metadata allowlist
+                # (backend/services/audit_store.py::_ALLOWED_METADATA_KEYS).
+                payload_json={
+                    "question_hash": analysis.question_hash,
+                    "source_assets": analysis.trusted_assets,
+                    "conversation_id": analysis.conversation_id or None,
+                    "message_id": analysis.message_id,
+                },
+            )
+    except (LakebaseError, psycopg.Error) as exc:
+        raise HTTPException(status_code=503, detail=safe_dependency_detail("lakebase")) from exc
+    workflow = GrowthAgentWorkflow(
+        id="live_analysis",
+        title="Live analysis",
+        objective=payload.prompt[:280],
+        trigger_label="No reviewed workflow matched; the live space analyzed the objective itself.",
+        action_label="Review the governed analysis; no state was written.",
+        source_assets=list(analysis.trusted_assets),
+        proof_points=[
+            "Every figure comes from Genie's own governed SQL over trusted assets.",
+            "The full answer, generated SQL, and process trace are in Ask Genie.",
+        ],
+        default_route="/ask-genie",
+    )
+    tool_steps = [
+        GrowthAgentToolStep(
+            label=step.kind,
+            status="completed",
+            detail=step.content,
+        )
+        for step in (analysis.reasoning_trace or [])[:8]
+    ] or [
+        GrowthAgentToolStep(
+            label="live",
+            status="completed",
+            detail="The objective ran as a governed live Genie analysis.",
+        )
+    ]
+    return GrowthAgentRunResponse(
+        workflow=workflow,
+        run_id=run_id,
+        specialist_agent="structured_data_agent",
+        execution_mode="genie_conversation",
+        trace_kind="genie_conversation",
+        planner_label="Live Genie analysis (read-only fallback)",
+        trace_id=f"agent-trace-{uuid4()}",
+        tool_result_hash=result_hash,
+        broad_total=analysis.row_count or 0,
+        actionable_total=0,
+        route="/ask-genie",
+        criteria={"prompt": payload.prompt[:280]},
+        source_assets=list(analysis.trusted_assets),
+        tool_steps=tool_steps,
+        policy_checks=[
+            GrowthAgentPolicyCheck(
+                label="Prompt guard battery",
+                status="passed",
+                detail="Fair-lending, PII, scope, and injection screens cleared.",
+            ),
+            GrowthAgentPolicyCheck(
+                label="Governed answer pipeline",
+                status="passed",
+                detail="SQL trust policy, claims verification, and PII redaction applied.",
+            ),
+            GrowthAgentPolicyCheck(
+                label="No state written",
+                status="passed",
+                detail="Read-only analysis; campaigns, monitors, and Lead Queue were not modified.",
+            ),
+        ],
+        interpreted_intent="Read-only live analysis (no reviewed workflow matched).",
+        agent_reasoning=analysis.answer,
+        genie_conversation_id=analysis.conversation_id or None,
+        genie_message_id=analysis.message_id,
+        genie_question_hash=analysis.question_hash,
+    )
+
+

--- a/backend/services/repositories/protocols.py
+++ b/backend/services/repositories/protocols.py
@@ -19,7 +19,10 @@ duck-typed compliance can do so cheaply.
 """
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:  # cycle-free: genie_answers imports only pydantic/stdlib
+    from backend.services.genie_answers import GenieMessageResponse
 
 from backend.schemas.analytics import (
     AnalyticsFilters,
@@ -380,10 +383,8 @@ class GenieAnswerRepository(Protocol):
         self,
         question: str,
         conversation_id: str | None = None,
-    ) -> object:
-        """Return a ``GenieMessageResponse``. Typed as ``object`` here
-        to avoid a forward-import cycle with ``backend.services
-        .genie_answers``; routers re-annotate to the concrete model."""
+    ) -> GenieMessageResponse:
+        """Return the governed answer for one live Genie turn."""
         ...
 
     def respond_existing(
@@ -392,7 +393,7 @@ class GenieAnswerRepository(Protocol):
         *,
         conversation_id: str,
         message_id: str,
-    ) -> object:
+    ) -> GenieMessageResponse:
         """Complete an already-submitted live Genie message into a governed
         answer (async lifecycle). Same return contract as :meth:`respond`."""
         ...

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2643,9 +2643,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/tests/unit/test_growth_agent_live_analysis_fallback.py
+++ b/tests/unit/test_growth_agent_live_analysis_fallback.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from fastapi.testclient import TestClient
 
-import backend.api.growth_agent as growth_api
+import backend.services.growth_agent_live_analysis as live_analysis_service
 from backend.main import app
 from backend.services.databricks_sql import get_sql_client
 from backend.services.genie_answers import GenieMessageResponse, GenieReasoningStep
@@ -75,9 +75,9 @@ def _clear_overrides() -> None:
 def test_unmapped_objective_runs_read_only_live_analysis(monkeypatch) -> None:
     stub_repo = _StubGenieRepo()
     audits: list[dict[str, Any]] = []
-    monkeypatch.setattr(growth_api, "get_genie_answer_repository", lambda: stub_repo)
+    monkeypatch.setattr(live_analysis_service, "get_genie_answer_repository", lambda: stub_repo)
     monkeypatch.setattr(
-        growth_api,
+        live_analysis_service,
         "write_audit_event_in_transaction",
         lambda conn, **kw: audits.append(kw),
     )
@@ -108,7 +108,7 @@ def test_unmapped_objective_runs_read_only_live_analysis(monkeypatch) -> None:
 
 def test_guard_hit_objective_still_refuses(monkeypatch) -> None:
     monkeypatch.setattr(
-        growth_api,
+        live_analysis_service,
         "get_genie_answer_repository",
         lambda: (_ for _ in ()).throw(AssertionError("must not run genie for guarded prompts")),
     )


### PR DESCRIPTION
Main's ci had been red across three jobs since before the audit sprint:

- backend: GenieAnswerRepository.respond was typed '-> object' (a stale
  forward-cycle workaround — genie_answers imports only pydantic/stdlib,
  so no cycle exists). Typing it properly collapsed 16 mypy errors; the
  other two were dead kwargs the schema silently discarded.
- file-size gate: backend/api/growth_agent.py (982) and
  backend/schemas/marketing_selection_criteria.py (955) split along
  real seams, not allowlisted: the read-only live-analysis fallback is
  now backend/services/growth_agent_live_analysis.py (routers stay
  thin), and the reviewed-analytics closed-vocabulary shapes are
  backend/schemas/marketing_selection_reviewed_analytics.py. Behavior
  unchanged; tests repointed at the service seam.
- security: npm audit fix bumps nanoid past GHSA-2v37-7h3g-55p8.

mypy backend: clean (240 files). file-size gate: 0 failures.
npm audit --audit-level=high: 0 vulnerabilities. Full unit suite green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
