### PR TITLE
fix(integration): truthful geo caption, formatted evidence dollars, aligned KPI lineage naming

### DIFF
--- a/frontend/src/components/mortgage/EvidenceDrawer.headline-evidence.test.tsx
+++ b/frontend/src/components/mortgage/EvidenceDrawer.headline-evidence.test.tsx
@@ -109,7 +109,7 @@ const MANIFEST: LineageManifestResponse = {
  * `.drawer__subtitle` the live spec asserts.
  */
 const HOME_KPI_SOURCES: Array<[string, DrawerSource]> = [
-  ['Marketable population', DRAWER_SOURCES.population],
+  ['Addressable population', DRAWER_SOURCES.population],
   ['Rate + equity screen', DRAWER_SOURCES.itm],
   ['Opportunity score', DRAWER_SOURCES.leadScore],
   ['How the offer path was selected', DRAWER_SOURCES.nbo],

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -333,6 +333,8 @@ export interface DispositionResponse {
 export interface LeadsPageResult {
   leads: LeadSummary[];
   totalMatching: number | null;
+  /** Ranked subset (score >= 50) of totalMatching on geo-filtered queries. */
+  rankedMatching: number | null;
   returnedRows: number | null;
   truncatedAt: number | null;
   growthAgentVerification: GrowthAgentCohortVerification | null;
@@ -1258,6 +1260,7 @@ export const api = {
     ).then(async ({ data, headers }) => ({
       leads: data,
       totalMatching: headers.get('X-Total-Matching') ? Number(headers.get('X-Total-Matching')) : null,
+      rankedMatching: headers.get('X-Ranked-Matching') ? Number(headers.get('X-Ranked-Matching')) : null,
       returnedRows: headers.get('X-Returned-Rows') ? Number(headers.get('X-Returned-Rows')) : null,
       truncatedAt: headers.get('X-Truncated-At') ? Number(headers.get('X-Truncated-At')) : null,
       growthAgentVerification: growthAgentProof

--- a/frontend/src/lib/drawerSourceRegistry.ts
+++ b/frontend/src/lib/drawerSourceRegistry.ts
@@ -12,9 +12,9 @@ function defineDrawerSources<T extends Record<string, DrawerSource>>(
  */
 export const DRAWER_SOURCES = defineDrawerSources({
   population: {
-    title: 'Marketable population',
+    title: 'Addressable population',
     lineageFamily: 'marketable_population',
-    short: 'Marketable population',
+    short: 'Addressable population',
     // Governed anchor (2026-06-11): the marketable-population KPI is
     // COUNT(*) over mip.gold.borrower_360, so this drawer reads that
     // asset's governed metadata. Without an anchor the hero KPI's drawer
@@ -307,7 +307,7 @@ export const DRAWER_SOURCES = defineDrawerSources({
     description:
       'Borrower-grain semantic view defining every home headline KPI: marketable population, refi economics screen, high opportunity, offers available, and primary offer paths.',
     signals: [
-      { label: 'Marketable population', source: 'portfolio_headline_metric_view', value: 'COUNT(*)' },
+      { label: 'Addressable population', source: 'portfolio_headline_metric_view', value: 'COUNT(*)' },
       { label: 'Refi economics screen', source: 'in_the_money', value: 'SUM' },
       { label: 'High opportunity', source: 'is_high_opportunity', value: 'fn_high_opportunity' },
       { label: 'Offers available', source: 'offer_available', value: 'non-null offer' },

--- a/frontend/src/routes/admin-config.tsx
+++ b/frontend/src/routes/admin-config.tsx
@@ -91,6 +91,9 @@ function formatThresholdValue(t: ThresholdRow): string {
   if (unit === 'rate_fraction') {
     return `${(t.value * 100).toFixed(3)}%`;
   }
+  if (unit === 'usd') {
+    return `$${Math.round(t.value).toLocaleString('en-US')}`;
+  }
   return `${t.value}`;
 }
 

--- a/frontend/src/routes/home.kpi-drawer.test.tsx
+++ b/frontend/src/routes/home.kpi-drawer.test.tsx
@@ -89,7 +89,7 @@ describe('Home KPI evidence drawers cite the headline metric view', () => {
     // Card label reads "Addressable" (the Home preview asks for
     // `marketing_eligibility: 'Any'`); the evidence chip keeps the governed
     // asset's own name, which the backend lineage manifest also uses.
-    { label: 'Addressable population', chipText: 'Marketable population', family: 'marketable_population' },
+    { label: 'Addressable population', chipText: 'Addressable population', family: 'marketable_population' },
     { label: 'Refi economics screen', chipText: 'Rate + equity screen', family: 'in_the_money' },
     { label: 'Opportunity score 75+', chipText: 'Opportunity score', family: 'opportunity_score' },
     { label: 'Primary offer paths', chipText: 'How the offer path was selected', family: 'next_best_offer' },

--- a/frontend/src/routes/lead-queue.tsx
+++ b/frontend/src/routes/lead-queue.tsx
@@ -495,14 +495,17 @@ export default function LeadQueue() {
               {stateFilters.length > 0 && <span className="lead-queue-scope__pill">States: {stateFilters.join(', ')}</span>}
               {zipFilters.length > 0 && <span className="lead-queue-scope__pill">ZIPs: {zipFilters.join(', ')}</span>}
               {borrowerIdFilters.length > 0 && <span className="lead-queue-scope__pill">Borrowers: {borrowerIdFilters.length}</span>}
-              {/* Re-audit #3 P3 (2026-06-12): the map tile counts MARKETABLE
-                  borrowers; this queue ranks the scored, contactable subset.
-                  Without the caption the handoff reads as a numbers jump
-                  (e.g. 30,833 on the ZIP tile → 1,379 ranked rows). */}
+              {/* 2026-08-07 audit C4: geo drill-ins show EVERY borrower the
+                  map counted (no score floor — the map-tile promise), so the
+                  old caption claiming a "scored, marketing-eligible subset"
+                  described the inverse of the query. State both real numbers
+                  from the same identity row instead. */}
               <span className="lead-queue-scope__note muted fs-11">
-                Ranked leads are the scored, marketing-eligible subset of this
-                geography&apos;s marketable borrowers — intentionally smaller than
-                the map tile&apos;s population count.
+                {leadsData?.rankedMatching != null
+                  && leadsData?.totalMatching != null
+                  && leadsData.rankedMatching < leadsData.totalMatching
+                  ? `Showing every borrower the map counted for this geography, ranked by opportunity score; ${leadsData.rankedMatching.toLocaleString('en-US')} of ${leadsData.totalMatching.toLocaleString('en-US')} also clear the national queue's score floor.`
+                  : 'Showing every borrower the map counted for this geography, ranked by opportunity score.'}
               </span>
               </>
             ) : null}

--- a/sql/transformations/gold_evidence_events.sql
+++ b/sql/transformations/gold_evidence_events.sql
@@ -167,10 +167,17 @@ equity_rows AS (
     'AVM'                                            AS source_product,
     'mip.silver.lien_current'                   AS source_table,
     'equity'                                         AS signal_type,
-    CONCAT('$',
-           CAST(ROUND(
+    -- Roll to millions above $1M so evidence chips read "$4.4M", not "$4410K"
+    -- (2026-08-07 audit, e2e rendering sweep).
+    CASE
+      WHEN GREATEST(0, COALESCE(lc.avm_value, 0) - COALESCE(lc.estimated_current_lien_balance, 0)) >= 1000000
+      THEN CONCAT('$', format_number(
+             GREATEST(0, COALESCE(lc.avm_value, 0) - COALESCE(lc.estimated_current_lien_balance, 0)) / 1000000.0,
+             1), 'M')
+      ELSE CONCAT('$', CAST(ROUND(
              GREATEST(0, COALESCE(lc.avm_value, 0) - COALESCE(lc.estimated_current_lien_balance, 0)) / 1000.0
-           ) AS STRING), 'K')                        AS signal_value,
+           ) AS STRING), 'K')
+    END                                              AS signal_value,
     'AVM-backed equity estimate using amortized UPB.' AS display_text,
     LEAST(1.0, GREATEST(0.0,
       CASE
@@ -220,7 +227,7 @@ listing_rows AS (
       COALESCE(la.listing_status_description, la.listing_status_category, 'active'),
       CASE
         WHEN la.plausible_listing_price IS NOT NULL
-          THEN CONCAT(' at $', CAST(la.plausible_listing_price AS STRING), ' list price')
+          THEN CONCAT(' at $', format_number(la.plausible_listing_price, 0), ' list price')
         ELSE ''
       END,
       CASE


### PR DESCRIPTION
Cross-boundary leftovers from the audit fix batches, landed after both
sides merged:

- Lead Queue geo caption (audit C4): the old caption asserted the
  drill-in was 'the scored, marketing-eligible subset … intentionally
  smaller' — the inverse of the query. It now states both numbers from
  the identity row: every borrower the map counted, plus how many clear
  the national queue's score floor (X-Ranked-Matching).
- gold_evidence_events.sql: '$1795000 list price' gets thousands
  separators; equity chips roll to millions ('$4.4M', not '$4410K').
- Admin-config threshold table renders USD units with '$' and
  separators (was bare 806500).
- Evidence-drawer lineage registry renamed to 'Addressable population',
  matching the KPI label change — the last two surfaces carrying the
  misnomer a click apart (tests repinned).

vitest 987 pass, build clean, backend suite green, SQL re-rendered.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
