### PR TITLE
fix(handoffs): actioned-stage parity in all three surfaces + real map citation

### DIFF
--- a/backend/services/repositories/databricks_lead_cohort_support.py
+++ b/backend/services/repositories/databricks_lead_cohort_support.py
@@ -130,7 +130,13 @@ class LeadCohortQuerySupport:
         if stage == "approved":
             return "AND COALESCE(ls.approval_status, 'pending') = 'approved'"
         if stage == "actioned":
-            return "AND COALESCE(ls.outreach_status, 'none') = 'actioned'"
+            # Actioned is a subset of approved (2026-08-07 audit F5): outreach
+            # recorded against a rejected borrower must never present as a
+            # funnel stage below the decision that rejected it.
+            return (
+                "AND COALESCE(ls.approval_status, 'pending') = 'approved' "
+                "AND COALESCE(ls.outreach_status, 'none') = 'actioned'"
+            )
         raise ValueError(f"unsupported funnel_stage: {funnel_stage}")
 
     @staticmethod

--- a/frontend/src/components/mortgage/USChoroplethMap.tsx
+++ b/frontend/src/components/mortgage/USChoroplethMap.tsx
@@ -769,7 +769,7 @@ export function USChoroplethMap({
                 avgScore: facts ? facts.avgScore : null,
                 topSegment: facts?.topSegment || undefined,
                 sourceHint: inFootprint
-                  ? 'mip.gold.state_rollup'
+                  ? 'mip.gold.funnel_snapshot_daily + mip.gold.state_top_segment'
                   : 'Outside Cotality evaluation scope',
                 overlay: overlayUnit
                   ? {

--- a/sql/transformations/gold_funnel_snapshot_daily.sql
+++ b/sql/transformations/gold_funnel_snapshot_daily.sql
@@ -87,7 +87,8 @@ USING (
                      AND recommended_offer_code <> 'nurture' THEN 1 ELSE 0 END) AS INT)
                                                                                   AS offer_recommended_borrowers,
       CAST(SUM(CASE WHEN approval_status = 'approved' THEN 1 ELSE 0 END) AS INT)  AS approved_borrowers,
-      CAST(SUM(CASE WHEN outreach_status = 'actioned' THEN 1 ELSE 0 END) AS INT)  AS actioned_borrowers,
+      CAST(SUM(CASE WHEN approval_status = 'approved'
+                     AND outreach_status = 'actioned' THEN 1 ELSE 0 END) AS INT)  AS actioned_borrowers,
       CAST(ROUND(AVG(opportunity_score)) AS INT)                                  AS avg_opportunity_score,
       CURRENT_TIMESTAMP()                                                         AS snapshot_at
     FROM unioned
@@ -105,7 +106,8 @@ USING (
                      AND recommended_offer_code <> 'nurture' THEN 1 ELSE 0 END) AS INT)
                                                                                   AS offer_recommended_borrowers,
       CAST(SUM(CASE WHEN approval_status = 'approved' THEN 1 ELSE 0 END) AS INT)  AS approved_borrowers,
-      CAST(SUM(CASE WHEN outreach_status = 'actioned' THEN 1 ELSE 0 END) AS INT)  AS actioned_borrowers,
+      CAST(SUM(CASE WHEN approval_status = 'approved'
+                     AND outreach_status = 'actioned' THEN 1 ELSE 0 END) AS INT)  AS actioned_borrowers,
       CAST(ROUND(AVG(opportunity_score)) AS INT)                                  AS avg_opportunity_score,
       CURRENT_TIMESTAMP()                                                         AS snapshot_at
     FROM unioned

--- a/tests/unit/test_leads_limit.py
+++ b/tests/unit/test_leads_limit.py
@@ -43,7 +43,10 @@ FUNNEL_STAGE_PREDICATES = {
         "AND b.recommended_offer_code <> 'nurture'"
     ),
     "approved": "COALESCE(ls.approval_status, 'pending') = 'approved'",
-    "actioned": "COALESCE(ls.outreach_status, 'none') = 'actioned'",
+    "actioned": (
+        "COALESCE(ls.approval_status, 'pending') = 'approved' "
+        "AND COALESCE(ls.outreach_status, 'none') = 'actioned'"
+    ),
 }
 
 FUNNEL_SNAPSHOT_EXPRESSIONS = {
@@ -61,7 +64,10 @@ FUNNEL_SNAPSHOT_EXPRESSIONS = {
         "                     AND recommended_offer_code <> 'nurture'"
     ),
     "approved": "CAST(SUM(CASE WHEN approval_status = 'approved' THEN 1 ELSE 0 END) AS INT)",
-    "actioned": "CAST(SUM(CASE WHEN outreach_status = 'actioned' THEN 1 ELSE 0 END) AS INT)",
+    "actioned": (
+        "CAST(SUM(CASE WHEN approval_status = 'approved'\n"
+        "                     AND outreach_status = 'actioned' THEN 1 ELSE 0 END) AS INT)"
+    ),
 }
 
 


### PR DESCRIPTION
Closes the two cross-workstream handoffs from the audit fix batches:

- The 'actioned' funnel stage is gated on approval in the persisted
  snapshot (gold_funnel_snapshot_daily.sql), the lead-queue stage
  filter, and — from PR #170 — the live executive funnel: three
  surfaces, one predicate, pinned by the existing parity test.
- The choropleth cited mip.gold.state_rollup, a table that does not
  exist; the tooltip now cites the assets /geo/state-rollups actually
  reads (funnel_snapshot_daily + state_top_segment).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
