### PR TITLE
fix(guards): a governed phrase's greedy head pair is not a person name

### DIFF
--- a/backend/schemas/_validators_person_names.py
+++ b/backend/schemas/_validators_person_names.py
@@ -193,6 +193,27 @@ _CONTEXTUAL_HUMAN_NAME_RE = re.compile(
 )
 
 
+def _pair_is_boundary_artifact(text: str, match: re.Match[str]) -> bool:
+    """True when a flagged pair is the greedy head of a governed phrase.
+
+    "Strong Home Equity fit" — the non-overlapping pair scan consumes
+    "Strong Home" before it can see the exempt "Home Equity" pair (live
+    approve-rationale refusal, 2026-08-08). If the flagged pair's last word
+    begins a governed non-person pair with the next capitalized word, the
+    flag is a tokenization artifact — unless the pair leads with a known
+    first name, which is never exempt this way ("John Smith Equity" stays
+    caught by the lexicon scan regardless).
+    """
+
+    tokens = [token for token in re.split(r"\s+|\|", match.group(0).strip()) if token]
+    if not tokens or tokens[0].casefold() in _COMMON_FIRST_NAMES:
+        return False
+    following = re.match(r"\s+([A-Z][a-z]{1,30})\b", text[match.end() :])
+    if following is None:
+        return False
+    return titlecase_pair_is_non_person(f"{tokens[-1]} {following.group(1)}")
+
+
 def contains_human_name_shape(
     value: str,
     *,
@@ -210,6 +231,7 @@ def contains_human_name_shape(
     text = _LEADING_ANALYTICS_COMMAND_RE.sub(" ", text)
     if include_titlecase and any(
         not titlecase_pair_is_non_person(match.group(0))
+        and not _pair_is_boundary_artifact(text, match)
         for match in _TITLECASE_HUMAN_NAME_RE.finditer(text)
     ):
         return True

--- a/tests/unit/test_guard_cross_surface_audit.py
+++ b/tests/unit/test_guard_cross_surface_audit.py
@@ -251,3 +251,23 @@ def test_cross_lender_vocabulary_is_unified(prompt: str) -> None:
 def test_genie_prose_inherits_the_city_fix() -> None:
     assert genie_visible_text_unsafe("Top metro this week is Fort Worth with 4,821 candidates") is False
     assert genie_visible_text_unsafe("Call John Smith about the refi") is True
+
+
+@pytest.mark.parametrize(
+    "rationale",
+    [
+        # Live approve-rationale refusal 2026-08-08: the greedy pair scan
+        # consumed "Strong Home" before seeing the exempt "Home Equity".
+        "AUDIT-verify: Strong Home Equity fit in the ranked queue.",
+        "High Home Equity potential; Prime Purchase Mortgage timing.",
+    ],
+)
+def test_boundary_artifact_pairs_are_not_names(rationale: str) -> None:
+    assert validate_no_human_name_shape(rationale, field_name="rationale")
+
+
+def test_lexicon_names_never_ride_the_boundary_exemption() -> None:
+    with pytest.raises(ValueError):
+        validate_no_human_name_shape(
+            "Reviewed with John Smith Equity yesterday.", field_name="rationale"
+        )


### PR DESCRIPTION
Live approve-rationale refusal caught during the final verification
pass: 'Strong Home Equity fit' — the non-overlapping title-case pair
scan consumed 'Strong Home' before it could see the exempt 'Home
Equity' pair. A flagged pair whose last word begins a governed
non-person pair with the next capitalized word is a tokenization
artifact, exempt unless the pair leads with a lexicon first name —
'John Smith Equity' stays refused.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
