### PR TITLE
fix(frontend): UX-walk defects — population labels, loading zeros, dossier codes

### DIFF
--- a/frontend/src/components/mortgage/LeadTableRow.render.test.tsx
+++ b/frontend/src/components/mortgage/LeadTableRow.render.test.tsx
@@ -335,4 +335,22 @@ describe('LeadTableRow numeric rendering', () => {
 
     expect(document.body.textContent).toContain('$807K');
   });
+
+  it('carries the full property ref on the cell it truncates', () => {
+    renderRow({ clip: 'clip_ref_d8b9f5890b66' });
+
+    const cell = document.querySelector('.lead-table__clip');
+    // Ellipsis truncation is CSS; the title is what keeps the ref readable
+    // once it no longer wraps onto a second line.
+    expect(cell?.getAttribute('title')).toBe('clip_ref_d8b9f5890b66');
+    expect(cell?.textContent).toBe('clip_ref_d8b9f5890b66');
+  });
+
+  it('does not put an unavailable-ref placeholder in the title', () => {
+    renderRow({ clip: '' });
+
+    const cell = document.querySelector('.lead-table__clip');
+    expect(cell?.getAttribute('title')).toBeNull();
+    expect(cell?.textContent).toBe('Property ref unavailable');
+  });
 });

--- a/frontend/src/components/mortgage/LeadTableRow.tsx
+++ b/frontend/src/components/mortgage/LeadTableRow.tsx
@@ -102,7 +102,12 @@ export function LeadTableRow({
             }}
           >
             <span className="mono lead-table__borrower">{lead.borrower_id}</span>
-            <span className="mono muted lead-table__clip">
+            {/* One opaque token — it truncates with an ellipsis rather than
+                wrapping mid-identifier, so the full ref rides on `title`. */}
+            <span
+              className="mono muted lead-table__clip"
+              title={lead.clip && lead.clip.length > 0 ? lead.clip : undefined}
+            >
               {lead.clip && lead.clip.length > 0 ? lead.clip : 'Property ref unavailable'}
             </span>
           </button>

--- a/frontend/src/design-system/components.css
+++ b/frontend/src/design-system/components.css
@@ -1310,9 +1310,18 @@ kbd {
   background: var(--bg-2);
 }
 .lead-table__borrower,
-.lead-table__clip,
 .lead-table__zip {
   overflow-wrap: anywhere;
+}
+/* The masked property ref is ONE opaque token: `overflow-wrap: anywhere`
+   guillotined it mid-identifier ("clip_ref_d8b9f5890b" / "66"), which reads
+   as two different refs. Truncate with an ellipsis instead; the row carries
+   the full ref in its title attribute. */
+.lead-table__clip {
+  max-inline-size: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .lead-table__segments {
   display: grid;
@@ -1364,6 +1373,7 @@ kbd {
   display: inline-flex;
   flex-direction: column;
   align-items: flex-start;
+  max-inline-size: 100%;
   gap: var(--sp-1);
   padding: 0;
   border: 0;

--- a/frontend/src/lib/approvalFunnelDrawerSource.ts
+++ b/frontend/src/lib/approvalFunnelDrawerSource.ts
@@ -1,5 +1,19 @@
 import type { DrawerSource } from '../components/AppContext';
 import { DRAWER_SOURCES, enrichAsset } from './drawerSources';
+import { HIGH_OPPORTUNITY_KPI_LABEL } from './opportunityScore';
+import { ADDRESSABLE_POPULATION_KPI_LABEL } from './populationLabels';
+
+/**
+ * Display copy for a funnel stage. The two UC stages carry pinned frontend
+ * KPI copy so the tab reads the same words as Home / Portfolio Builder; the
+ * Lakebase workflow stages use the server label as-is. Shared with the KPI
+ * cards so a stage's headline and its evidence drawer can never disagree.
+ */
+export function funnelStageDisplayLabel(stage: { stage: string; label: string }): string {
+  if (stage.stage === 'high_opportunity') return HIGH_OPPORTUNITY_KPI_LABEL;
+  if (stage.stage === 'population') return ADDRESSABLE_POPULATION_KPI_LABEL;
+  return stage.label;
+}
 
 /** Evidence for a live approval-funnel stage count. */
 export function approvalFunnelStageDrawer(stage: {
@@ -8,8 +22,9 @@ export function approvalFunnelStageDrawer(stage: {
   borrower_count: number;
   source: string;
 }): DrawerSource {
+  const displayLabel = funnelStageDisplayLabel(stage);
   const liveCount = {
-    label: `${stage.label} (live)`,
+    label: `${displayLabel} (live)`,
     source: stage.source,
     value: stage.borrower_count.toLocaleString(),
   };
@@ -17,10 +32,10 @@ export function approvalFunnelStageDrawer(stage: {
     const base = DRAWER_SOURCES.portfolioHeadlineView;
     return enrichAsset({
       ...base,
-      title: `${stage.label} — funnel stage`,
+      title: `${displayLabel} — funnel stage`,
       description:
         stage.stage === 'population'
-          ? 'COUNT(*) over the S1 headline metric view — the marketable borrower population every funnel stage narrows from.'
+          ? 'COUNT(*) over the S1 headline metric view with no contactability gate — the addressable borrower book every funnel stage narrows from. The contact-eligible marketable subset is smaller.'
           : 'SUM(is_high_opportunity) over the S1 headline metric view. The predicate is mip.gold.fn_high_opportunity — the canonical governed threshold, never a hardcoded literal.',
       signals: [liveCount, ...(base.signals ?? [])],
     });

--- a/frontend/src/lib/dossierCodes.test.ts
+++ b/frontend/src/lib/dossierCodes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { loanTypeLabel, metroLabel, metroLoanTypeLabel } from './dossierCodes';
+
+describe('loanTypeLabel', () => {
+  it('expands the Cotality loan type codes gold actually carries', () => {
+    // Live 2026-08-08 dossier value.
+    expect(loanTypeLabel('CNV')).toBe('Conventional');
+    // The spelling the UC functions test for.
+    expect(loanTypeLabel('CONV')).toBe('Conventional');
+    expect(loanTypeLabel('fha')).toBe('FHA');
+    expect(loanTypeLabel(' va ')).toBe('VA');
+  });
+
+  it('passes an unknown code through instead of guessing a bucket', () => {
+    expect(loanTypeLabel('ZZZ')).toBe('ZZZ');
+    expect(loanTypeLabel('')).toBeNull();
+    expect(loanTypeLabel(null)).toBeNull();
+  });
+});
+
+describe('metroLabel', () => {
+  it('labels the bare CBSA code', () => {
+    expect(metroLabel('42660')).toBe('CBSA 42660');
+    // Never double-prefixes if a labelled value ever arrives.
+    expect(metroLabel('CBSA 42660')).toBe('CBSA 42660');
+    expect(metroLabel(null)).toBeNull();
+  });
+});
+
+describe('metroLoanTypeLabel', () => {
+  it('renders the dossier line without raw codes', () => {
+    expect(metroLoanTypeLabel('42660', 'CNV')).toBe('CBSA 42660 · Conventional');
+  });
+
+  it('marks each half honestly when it is missing', () => {
+    expect(metroLoanTypeLabel(null, 'FHA')).toBe('CBSA unavailable · FHA');
+    expect(metroLoanTypeLabel('42660', null)).toBe('CBSA 42660 · Loan type unavailable');
+  });
+});

--- a/frontend/src/lib/dossierCodes.ts
+++ b/frontend/src/lib/dossierCodes.ts
@@ -1,0 +1,66 @@
+/**
+ * Plain-English rendering for the RAW SOURCE CODES the Borrower 360 dossier
+ * shows. These are Cotality/Census identifiers, not product vocabulary: the
+ * dossier's "Metro / loan type" field rendered them straight through, so the
+ * screen read "42660 · CNV" — two opaque tokens where a loan officer expects
+ * a place and a loan program.
+ *
+ * Rule: expand what is known, pass through what is not. An unrecognized code
+ * is real signal and must stay visible verbatim; it must never be guessed
+ * into a bucket. Same fail-closed posture as `mip.gold.fn_loan_product_type`,
+ * which returns NULL rather than a guess for an unknown code.
+ */
+
+/**
+ * Cotality `first_position_mortgage_loan_type_code`
+ * (`silver.lien_current.first_pos_loan_type`). Only codes whose meaning is
+ * unambiguous belong here.
+ *
+ * NOTE: live gold data carries `CNV` for conventional, while
+ * `sql/uc_functions/fn_loan_product_type.sql` and the fit sub-score branch in
+ * `gold_borrower_360.sql` test for `CONV`. Both spellings map to Conventional
+ * here so the dossier reads correctly either way — but the SQL-side mismatch
+ * is a separate, real defect, not something this map fixes.
+ */
+const LOAN_TYPE_LABELS: Record<string, string> = {
+  CNV: 'Conventional',
+  CONV: 'Conventional',
+  CONVENTIONAL: 'Conventional',
+  FHA: 'FHA',
+  VA: 'VA',
+  USDA: 'USDA',
+  USD: 'USDA',
+  FMHA: 'USDA (FmHA)',
+};
+
+/** "CNV" -> "Conventional"; unknown codes pass through unchanged. */
+export function loanTypeLabel(code: string | null | undefined): string | null {
+  const raw = (code ?? '').trim();
+  if (!raw) return null;
+  return LOAN_TYPE_LABELS[raw.toUpperCase()] ?? raw;
+}
+
+/**
+ * "42660" -> "CBSA 42660". The gold layer carries the CBSA CODE only
+ * (`borrower_360.situs_cbsa_code`) — there is no metro NAME column anywhere
+ * in the dossier payload, so labelling the code is as far as this can
+ * honestly go. If a metro-name reference lands in gold, prefer it here.
+ */
+export function metroLabel(cbsaCode: string | null | undefined): string | null {
+  const raw = (cbsaCode ?? '').trim();
+  if (!raw) return null;
+  return /^cbsa\b/i.test(raw) ? raw : `CBSA ${raw}`;
+}
+
+/**
+ * The dossier's "Metro / loan type" line, with an honest gap marker for
+ * whichever half is missing.
+ */
+export function metroLoanTypeLabel(
+  cbsaCode: string | null | undefined,
+  loanTypeCode: string | null | undefined,
+): string {
+  const metro = metroLabel(cbsaCode) ?? 'CBSA unavailable';
+  const loanType = loanTypeLabel(loanTypeCode) ?? 'Loan type unavailable';
+  return `${metro} · ${loanType}`;
+}

--- a/frontend/src/lib/drawerSourceRegistry.ts
+++ b/frontend/src/lib/drawerSourceRegistry.ts
@@ -1,4 +1,8 @@
 import type { DrawerSource } from '../components/AppContext';
+import {
+  ADDRESSABLE_POPULATION_KPI_LABEL,
+  MARKETABLE_POPULATION_KPI_LABEL,
+} from './populationLabels';
 
 function defineDrawerSources<T extends Record<string, DrawerSource>>(
   sources: T,
@@ -12,9 +16,9 @@ function defineDrawerSources<T extends Record<string, DrawerSource>>(
  */
 export const DRAWER_SOURCES = defineDrawerSources({
   population: {
-    title: 'Addressable population',
+    title: ADDRESSABLE_POPULATION_KPI_LABEL,
     lineageFamily: 'marketable_population',
-    short: 'Addressable population',
+    short: ADDRESSABLE_POPULATION_KPI_LABEL,
     // Governed anchor (2026-06-11): the marketable-population KPI is
     // COUNT(*) over mip.gold.borrower_360, so this drawer reads that
     // asset's governed metadata. Without an anchor the hero KPI's drawer
@@ -27,6 +31,28 @@ export const DRAWER_SOURCES = defineDrawerSources({
       { label: 'Underlying rows', source: 'mip.gold.borrower_360', value: 'borrower grain' },
       { label: 'Ownership graph', source: 'entity.owner_link', value: 'CLIP-grain' },
       { label: 'Tenant lens', source: 'mip.ref.lender_dictionary', value: 'gold refresh' },
+    ],
+  },
+
+  // Sibling of `population` for surfaces whose count HAS the contactability
+  // gate pushed down (Portfolio Builder's default CONTACTABILITY = "Eligible
+  // only"). Same asset, different predicate — and a materially different
+  // number, so the chip must name the predicate it applied rather than
+  // borrowing the addressable chip's copy.
+  populationMarketable: {
+    title: MARKETABLE_POPULATION_KPI_LABEL,
+    lineageFamily: 'marketable_population',
+    short: `${MARKETABLE_POPULATION_KPI_LABEL} — contact-eligible subset`,
+    assetKey: 'borrower_360',
+    assetPath: 'mip.gold.borrower_360',
+    description:
+      'COUNT(*) over the headline metric view with the build criteria AND the governed contactability gate pushed down: opt-in consent, no suppression reason, not DNC, past the recontact date, and outside the frequency cap. That gate is what separates this count from the addressable population.',
+    signals: [
+      { label: 'KPI measure', source: 'portfolio_headline_metric_view', value: 'COUNT(*)' },
+      { label: 'Eligibility gate', source: 'borrower_360.marketing_eligible', value: 'TRUE' },
+      { label: 'Consent', source: 'borrower_360.consent_status', value: 'opt_in' },
+      { label: 'Suppression', source: 'borrower_360.suppression_reason', value: 'IS NULL' },
+      { label: 'Do-not-contact', source: 'borrower_360.dnc', value: 'FALSE' },
     ],
   },
 

--- a/frontend/src/lib/drawerSources.ts
+++ b/frontend/src/lib/drawerSources.ts
@@ -292,6 +292,7 @@ type DrawerSourceKey = keyof typeof DRAWER_SOURCES;
 
 const DESTINATION_BY_SOURCE = {
   population: UNITY_CATALOG_DESTINATION,
+  populationMarketable: UNITY_CATALOG_DESTINATION,
   equitySpreadPoints: UNITY_CATALOG_DESTINATION,
   leadPopulation: UNITY_CATALOG_DESTINATION,
   segmentPopulation: UNITY_CATALOG_DESTINATION,

--- a/frontend/src/lib/formatters.test.ts
+++ b/frontend/src/lib/formatters.test.ts
@@ -104,6 +104,20 @@ describe('currency', () => {
   });
 });
 
+describe('signedBpsLabel spacing', () => {
+  it('separates magnitude and unit with exactly one space', () => {
+    // A 2026-08-08 UX walk read the Borrower 360 refi panel as "+330  bps".
+    // Every bps string in the product comes from this one formatter, and it
+    // emits a single space -- pinned here so a future call site cannot
+    // reintroduce a hand-rolled `{value} + ' bps'` template with two.
+    expect(signedBpsLabel(330)).toBe('+330 bps');
+    for (const value of [330, -422, 0, 1_250]) {
+      expect(signedBpsLabel(value)).not.toMatch(/ {2}/);
+      expect(signedBpsLabel(value).split(' ')).toHaveLength(2);
+    }
+  });
+});
+
 describe('rangeLabel', () => {
   it('collapses a degenerate band to its single value', () => {
     // Live 2026-08-08: the estimated-UPB chip read "$100,000-$100,000".

--- a/frontend/src/lib/formatters.test.ts
+++ b/frontend/src/lib/formatters.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import {
   compactCurrency,
   currency,
+  rangeLabel,
   ratePct,
   ratePctFromFraction,
   signedBps,
@@ -100,5 +101,24 @@ describe('rate percent conventions', () => {
 describe('currency', () => {
   it('renders whole dollars with thousands separators', () => {
     expect(currency(806_500)).toBe('$806,500');
+  });
+});
+
+describe('rangeLabel', () => {
+  it('collapses a degenerate band to its single value', () => {
+    // Live 2026-08-08: the estimated-UPB chip read "$100,000-$100,000".
+    expect(rangeLabel(100_000, 100_000, currency)).toBe('$100,000');
+  });
+
+  it('keeps a real band as a range', () => {
+    expect(rangeLabel(95_000, 105_000, currency)).toBe('$95,000-$105,000');
+  });
+
+  it('collapses ends that round to the same displayed value', () => {
+    expect(rangeLabel(100_000.2, 100_000.4, currency)).toBe('$100,000');
+  });
+
+  it('works with any formatter, not just currency', () => {
+    expect(rangeLabel(4_410_000, 4_410_000, compactCurrency)).toBe('$4.4M');
   });
 });

--- a/frontend/src/lib/formatters.ts
+++ b/frontend/src/lib/formatters.ts
@@ -42,6 +42,27 @@ export function signedBpsLabel(value: number): string {
 }
 
 /**
+ * A low-high estimate range, collapsed to a single value when the two ends
+ * render identically. A confidence band whose ends are equal is a POINT
+ * estimate, and "$100,000-$100,000" reads as a formatting bug rather than as
+ * the confident number it is — the shape every row takes when the band
+ * columns are absent and both ends fall back to the point value.
+ *
+ * The comparison is on the FORMATTED ends, so two inputs that round to the
+ * same displayed value (100_000.2 / 100_000.4 under `currency`) also collapse
+ * instead of printing a range between two identical strings.
+ */
+export function rangeLabel(
+  low: number,
+  high: number,
+  format: (value: number) => string,
+): string {
+  const lowLabel = format(low);
+  const highLabel = format(high);
+  return lowLabel === highLabel ? lowLabel : `${lowLabel}-${highLabel}`;
+}
+
+/**
  * Compact USD for dense surfaces (table cells, preview grids, narrative
  * prose): rolls up through K *and* M so a $4.41M equity position reads as
  * "$4.4M" instead of "$4410K".

--- a/frontend/src/lib/populationLabels.test.ts
+++ b/frontend/src/lib/populationLabels.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { DRAWER_SOURCES } from './drawerSources';
+import {
+  ADDRESSABLE_POPULATION_KPI_LABEL,
+  MARKETABLE_POPULATION_KPI_LABEL,
+  populationKpiLabel,
+} from './populationLabels';
+
+describe('populationKpiLabel', () => {
+  it('only calls a count marketable when the contactability gate was applied', () => {
+    expect(populationKpiLabel('Eligible only')).toBe(MARKETABLE_POPULATION_KPI_LABEL);
+    // "Any" leaves suppressed + DNC borrowers in the count (Home's predicate),
+    // and "Suppressed only" is the complement — neither is marketable.
+    expect(populationKpiLabel('Any')).toBe(ADDRESSABLE_POPULATION_KPI_LABEL);
+    expect(populationKpiLabel('Suppressed only')).toBe(ADDRESSABLE_POPULATION_KPI_LABEL);
+    expect(populationKpiLabel(undefined)).toBe(ADDRESSABLE_POPULATION_KPI_LABEL);
+  });
+});
+
+describe('population evidence chips', () => {
+  it('gives the two population cuts distinct chip copy', () => {
+    expect(DRAWER_SOURCES.population.short).toBe(ADDRESSABLE_POPULATION_KPI_LABEL);
+    expect(DRAWER_SOURCES.populationMarketable.short).toBe(
+      `${MARKETABLE_POPULATION_KPI_LABEL} — contact-eligible subset`,
+    );
+    expect(DRAWER_SOURCES.populationMarketable.short).not.toBe(DRAWER_SOURCES.population.short);
+    // Same governed asset and lineage family — only the predicate differs.
+    expect(DRAWER_SOURCES.populationMarketable.assetPath).toBe(DRAWER_SOURCES.population.assetPath);
+    expect(DRAWER_SOURCES.populationMarketable.lineageFamily).toBe(
+      DRAWER_SOURCES.population.lineageFamily,
+    );
+  });
+});

--- a/frontend/src/lib/populationLabels.ts
+++ b/frontend/src/lib/populationLabels.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical copy for the two borrower-population cuts Module 0 counts.
+ *
+ * They are NOT synonyms and the difference is ~5.16M vs ~76K:
+ *
+ *   ADDRESSABLE  — the whole reachable book. `COUNT(*)` over the headline
+ *                  metric view with `marketing_eligibility: 'Any'` (Home's
+ *                  `HOME_PORTFOLIO_PREVIEW_CRITERIA`), i.e. NO contactability
+ *                  gate. Suppressed and DNC borrowers are still counted.
+ *   MARKETABLE   — the contact-eligible subset: the same count with
+ *                  `marketing_eligibility: 'Eligible only'` pushed down
+ *                  (Portfolio Builder's default), so DNC / suppressed
+ *                  borrowers are excluded.
+ *
+ * The 2026-08-07 data audit renamed the Home + Portfolio surfaces after the
+ * addressable count shipped under the marketable word; the Analytics
+ * approval-funnel tab was missed and kept headlining 5,156,184 as
+ * "Marketable population". Pin the strings HERE and import them so the next
+ * surface can't drift on its own — the API field is still
+ * `marketable_population` in both cases, so the field name is no guide.
+ */
+
+/** No contactability gate — the whole reachable book. */
+export const ADDRESSABLE_POPULATION_KPI_LABEL = 'Addressable population';
+
+/** Contactability gate applied — the contact-eligible subset. */
+export const MARKETABLE_POPULATION_KPI_LABEL = 'Marketable population';
+
+/**
+ * Which population a count represents, given the CONTACTABILITY criterion
+ * that produced it. Anything other than "Eligible only" (Any / Suppressed
+ * only) leaves ineligible borrowers in the count, so it is addressable.
+ */
+export function populationKpiLabel(marketingEligibility: string | undefined): string {
+  return marketingEligibility === 'Eligible only'
+    ? MARKETABLE_POPULATION_KPI_LABEL
+    : ADDRESSABLE_POPULATION_KPI_LABEL;
+}

--- a/frontend/src/routes/analytics.approval-funnel.test.tsx
+++ b/frontend/src/routes/analytics.approval-funnel.test.tsx
@@ -223,6 +223,20 @@ describe('ApprovalFunnelSection', () => {
     expect(totals.filter((value) => value === '0').length).toBeGreaterThan(0);
   });
 
+  it('headlines the first stage as the addressable population, not the marketable subset', async () => {
+    await act(async () => renderSection());
+    await settle();
+
+    // The server labels this stage "Marketable population" (see the fixture),
+    // but it is COUNT(*) with NO contactability gate — the addressable book.
+    // The pinned frontend copy wins so the tab matches Home / Portfolio
+    // Builder. The count itself is untouched.
+    const kpiLabels = [...document.querySelectorAll('.kpi__label')].map((el) => el.textContent);
+    expect(kpiLabels).toContain('Addressable population');
+    expect(kpiLabels).not.toContain('Marketable population');
+    expect(document.body.textContent).toContain('5,200');
+  });
+
   it('every funnel stage number opens the EvidenceDrawer with its own source', async () => {
     await act(async () => renderSection());
     await settle();

--- a/frontend/src/routes/analytics.approval-funnel.tsx
+++ b/frontend/src/routes/analytics.approval-funnel.tsx
@@ -14,8 +14,12 @@ import {
   assignmentStatusLabel,
   assignmentStatusVariant,
 } from '../components/mortgage/LeadTable.logic';
-import { approvalFunnelStageDrawer } from '../lib/approvalFunnelDrawerSource';
+import {
+  approvalFunnelStageDrawer,
+  funnelStageDisplayLabel,
+} from '../lib/approvalFunnelDrawerSource';
 import { HIGH_OPPORTUNITY_KPI_LABEL } from '../lib/opportunityScore';
+import { ADDRESSABLE_POPULATION_KPI_LABEL } from '../lib/populationLabels';
 import { formatTimestamp } from '../lib/time';
 import { offerDisplayLabel } from '../lib/offerLanguage';
 import type {
@@ -35,10 +39,16 @@ import { DataTable, LoadState } from './analytics.charts';
  * the exact objects the count was computed from.
  */
 
+/**
+ * Stage headline copy. Shared with the stage's evidence drawer so the card
+ * and the drawer can never disagree: the S1 KPI stages use the pinned
+ * frontend copy (high-opportunity threshold text, and "Addressable
+ * population" — the first stage is COUNT(*) with NO contactability gate,
+ * the ~5.16M addressable book, not the ~76K contact-eligible marketable
+ * subset the server label claimed). The NUMBER is unchanged.
+ */
 function stageDisplayLabel(stage: ApprovalFunnelStage): string {
-  // Keep the S1 canonical high-opportunity KPI copy (threshold text comes
-  // from the pinned frontend constant, never restated here).
-  return stage.stage === 'high_opportunity' ? HIGH_OPPORTUNITY_KPI_LABEL : stage.label;
+  return funnelStageDisplayLabel(stage);
 }
 
 function FunnelStages({ stages }: { stages: ApprovalFunnelStage[] }) {
@@ -279,8 +289,9 @@ export function ApprovalFunnelSection() {
               <div>
                 <h2 className="h-3">Approval funnel — live</h2>
                 <p className="analytics-panel-note">
-                  Population and {HIGH_OPPORTUNITY_KPI_LABEL.toLowerCase()} aggregate over the
-                  governed headline metric view; approved, actioned, and outcome recorded read
+                  {ADDRESSABLE_POPULATION_KPI_LABEL} (the whole reachable book, before the
+                  contactability gate) and {HIGH_OPPORTUNITY_KPI_LABEL.toLowerCase()} aggregate over
+                  the governed headline metric view; approved, actioned, and outcome recorded read
                   live Lakebase workflow state. Open any number&apos;s source chip for its evidence.
                 </p>
               </div>

--- a/frontend/src/routes/analytics.sales-ops.test.tsx
+++ b/frontend/src/routes/analytics.sales-ops.test.tsx
@@ -147,6 +147,35 @@ describe('Analytics Sales ops tab', () => {
     expect(document.querySelector('[aria-label="Analytics filters"]')).toBeNull();
   });
 
+  it('renders skeletons, never zeros, while the snapshot queries are in flight', async () => {
+    // Hold every sales-ops request open: this is the window in which the
+    // page used to claim "STALE APPROVED 0" from its `?? []` fallback.
+    const never = new Promise<never>(() => {});
+    apiMocks.salesAging.mockReturnValue(never);
+    apiMocks.salesStandup.mockReturnValue(never);
+    apiMocks.salesConversion.mockReturnValue(never);
+    apiMocks.salesOutcomeSummary.mockReturnValue(never);
+    apiMocks.salesTeam.mockReturnValue(never);
+
+    await act(async () => {
+      renderAt('/analytics?view=sales-ops');
+    });
+    await settle();
+
+    const cards = [...document.querySelectorAll('.sales-ops-card')];
+    expect(cards.length).toBe(4);
+    for (const card of cards) {
+      expect(card.getAttribute('aria-busy')).toBe('true');
+      expect(card.querySelector('.skeleton')).toBeTruthy();
+      // No headline number at all while loading — not even a zero.
+      expect(card.querySelector('.kpi__value')).toBeNull();
+    }
+    // Claims about the window stay unrendered until the window is read.
+    expect(document.body.textContent).not.toContain('No LO dispositions logged this week');
+    expect(document.body.textContent).not.toContain('outcome feeds are not configured yet');
+    expect(document.body.textContent).toContain('Loading roster…');
+  });
+
   it('renders the filter row on analytical tabs and hides it after clicking Sales ops', async () => {
     await act(async () => {
       renderAt('/analytics');

--- a/frontend/src/routes/analytics.sales-ops.test.tsx
+++ b/frontend/src/routes/analytics.sales-ops.test.tsx
@@ -147,6 +147,41 @@ describe('Analytics Sales ops tab', () => {
     expect(document.querySelector('[aria-label="Analytics filters"]')).toBeNull();
   });
 
+  it('shows LO display names in week-to-date conversion, falling back to the raw key', async () => {
+    apiMocks.salesTeam.mockResolvedValue([
+      {
+        email: 'lo02@summit.example',
+        display_label: 'Summit LO 02',
+        role: 'loan_officer',
+        capacity_per_day: 25,
+        active: true,
+      },
+    ]);
+    apiMocks.salesConversion.mockResolvedValue({
+      rows: [
+        { group_key: 'lo02@summit.example', application_start_rate: 0.4 },
+        { group_key: 'manager@summit.example', application_start_rate: 0.1 },
+      ],
+    });
+
+    await act(async () => {
+      renderAt('/analytics?view=sales-ops');
+    });
+    await settle();
+
+    const card = [...document.querySelectorAll('.sales-ops-card')].find((node) =>
+      node.textContent?.includes('Week-to-date conversion'),
+    );
+    expect(card?.textContent).toContain('Summit LO 02');
+    expect(card?.textContent).not.toContain('lo02@summit.example');
+    // The raw key stays reachable as the title so the row is still traceable.
+    expect(
+      [...(card?.querySelectorAll('[title]') ?? [])].map((node) => node.getAttribute('title')),
+    ).toContain('lo02@summit.example');
+    // No roster entry -> render the key, never an invented name.
+    expect(card?.textContent).toContain('manager@summit.example');
+  });
+
   it('headlines the outcome window total so the card cannot contradict its subline', async () => {
     // Live shape observed 2026-08-08: 8 submitted, nothing funded yet. The
     // card used to headline `closed_funded` — a bold 0 above "8 submitted".

--- a/frontend/src/routes/analytics.sales-ops.test.tsx
+++ b/frontend/src/routes/analytics.sales-ops.test.tsx
@@ -147,6 +147,37 @@ describe('Analytics Sales ops tab', () => {
     expect(document.querySelector('[aria-label="Analytics filters"]')).toBeNull();
   });
 
+  it('headlines the outcome window total so the card cannot contradict its subline', async () => {
+    // Live shape observed 2026-08-08: 8 submitted, nothing funded yet. The
+    // card used to headline `closed_funded` — a bold 0 above "8 submitted".
+    apiMocks.salesOutcomeSummary.mockResolvedValue({
+      total_outcomes: 8,
+      applications_submitted: 8,
+      closed_funded: 0,
+      lost_to_competitor: 0,
+      withdrawn: 0,
+      not_qualified: 0,
+      by_source_system: [],
+      source_statuses: [],
+      by_lo: [],
+      top_competitors: [],
+    });
+
+    await act(async () => {
+      renderAt('/analytics?view=sales-ops');
+    });
+    await settle();
+
+    const card = [...document.querySelectorAll('.sales-ops-card')].find((node) =>
+      node.textContent?.includes('Closed-loop outcomes'),
+    );
+    expect(card?.querySelector('.kpi__value')?.textContent).toBe('8');
+    // Funded is stated explicitly in the breakdown, never implied by the
+    // headline.
+    expect(card?.textContent).toContain('0 funded');
+    expect(card?.textContent).toContain('8 submitted');
+  });
+
   it('renders skeletons, never zeros, while the snapshot queries are in flight', async () => {
     // Hold every sales-ops request open: this is the window in which the
     // page used to claim "STALE APPROVED 0" from its `?? []` fallback.

--- a/frontend/src/routes/analytics.sales-ops.tsx
+++ b/frontend/src/routes/analytics.sales-ops.tsx
@@ -2,6 +2,7 @@
 // budget; the analytics route family opts out. Keep this section explicit.
 'use no memo';
 
+import type { ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router';
 import { api } from '../lib/api';
@@ -39,6 +40,26 @@ function weekStartIsoDate(): string {
   const diff = day === 0 ? -6 : 1 - day;
   date.setDate(date.getDate() + diff);
   return isoDate(date);
+}
+
+/**
+ * A snapshot headline number. Reuses the KpiCard skeleton slots
+ * (`.skeleton.kpi__value-skeleton`) rather than declaring new CSS, so a
+ * loading sales-ops card reads exactly like a loading KPI card elsewhere.
+ * `loading` renders the shimmer; `error` renders an em-dash. Neither may
+ * render a zero — a zero here is a factual claim about the book.
+ */
+function CardValue({
+  state,
+  children,
+}: {
+  state: 'loading' | 'error' | 'ready';
+  children: ReactNode;
+}) {
+  if (state === 'loading') {
+    return <span className="skeleton kpi__value-skeleton" aria-hidden="true" />;
+  }
+  return <div className="kpi__value">{state === 'error' ? '—' : children}</div>;
 }
 
 export function SalesOpsSection() {
@@ -101,6 +122,17 @@ export function SalesOpsSection() {
   const hasDryRunOutcomeRows = dryRunOutcomeCount > 0;
   const salesTeamError = salesTeamQuery.error instanceof Error ? salesTeamQuery.error.message : null;
   const salesOpsError = salesOpsQuery.error instanceof Error ? salesOpsQuery.error.message : null;
+  // Every card on this page reads one combined query. Until it resolves the
+  // `?? []` / `?? 0` fallbacks are indistinguishable from real counts, and a
+  // manager who reads "STALE APPROVED 0" while 100+ approvals are aging has
+  // been told the opposite of the truth. Render the KpiCard skeletons instead,
+  // and an em-dash (never a zero) when the query failed outright.
+  const cardState: 'loading' | 'error' | 'ready' = salesOpsQuery.isPending
+    ? 'loading'
+    : salesOpsError
+      ? 'error'
+      : 'ready';
+  const loading = cardState === 'loading';
   const outcomeDistribution = outcomes
     ? [
       { label: 'submitted', value: outcomes.applications_submitted },
@@ -121,10 +153,16 @@ export function SalesOpsSection() {
           </div>
         </div>
         <div className="chip-row">
-          <Chip variant="neutral">{salesTeam.length} active LOs</Chip>
-          <Chip variant="neutral">
-            {salesTeam.reduce((sum, member) => sum + member.capacity_per_day, 0)} daily capacity
-          </Chip>
+          {salesTeamQuery.isPending ? (
+            <Chip variant="neutral">Loading roster…</Chip>
+          ) : (
+            <>
+              <Chip variant="neutral">{salesTeam.length} active LOs</Chip>
+              <Chip variant="neutral">
+                {salesTeam.reduce((sum, member) => sum + member.capacity_per_day, 0)} daily capacity
+              </Chip>
+            </>
+          )}
           {salesTeamError && <Chip variant="warning">Team unavailable</Chip>}
         </div>
       </div>
@@ -140,9 +178,11 @@ export function SalesOpsSection() {
           </div>
         )}
         <div className="sales-ops-grid">
-          <div className="sales-ops-card">
+          <div className="sales-ops-card" aria-busy={loading}>
             <div className="eyebrow">Stale approved</div>
-            <div className="kpi__value">{staleLeads.length >= 100 ? '100+' : staleLeads.length.toLocaleString()}</div>
+            <CardValue state={cardState}>
+              {staleLeads.length >= 100 ? '100+' : staleLeads.length.toLocaleString()}
+            </CardValue>
             <div className="muted fs-12">
               Approved over 7 days ago with no LO disposition{staleLeads.length >= 100 ? '; showing first 100.' : '.'}
             </div>
@@ -157,37 +197,53 @@ export function SalesOpsSection() {
               ))}
             </div>
           </div>
-          <div className="sales-ops-card">
+          <div className="sales-ops-card" aria-busy={loading}>
             <div className="eyebrow">Yesterday standup</div>
-            <div className="kpi__value">{(standup?.calls_logged ?? 0).toLocaleString()}</div>
-            <div className="muted fs-12">
-              {(standup?.contacts_reached ?? 0).toLocaleString()} reached · {(standup?.callbacks_scheduled ?? 0).toLocaleString()} callbacks · {(standup?.applications_started ?? 0).toLocaleString()} apps.
-            </div>
+            <CardValue state={cardState}>{(standup?.calls_logged ?? 0).toLocaleString()}</CardValue>
+            {loading ? (
+              <span className="skeleton kpi__delta-skeleton" aria-hidden="true" />
+            ) : (
+              <div className="muted fs-12">
+                {(standup?.contacts_reached ?? 0).toLocaleString()} reached · {(standup?.callbacks_scheduled ?? 0).toLocaleString()} callbacks · {(standup?.applications_started ?? 0).toLocaleString()} apps.
+              </div>
+            )}
           </div>
-          <div className="sales-ops-card">
+          <div className="sales-ops-card" aria-busy={loading}>
             <div className="eyebrow">Week-to-date conversion</div>
             <div className="sales-ops-list">
-              {(conversion?.rows ?? []).slice(0, 3).map((row) => (
-                <div key={row.group_key} className="split-row">
-                  <span className="mono fs-12">{row.group_key}</span>
-                  <span className="mono num">{Math.round(row.application_start_rate * 100)}%</span>
-                </div>
-              ))}
-              {(conversion?.rows ?? []).length === 0 && (
+              {loading
+                ? [0, 1, 2].map((row) => (
+                  <span key={row} className="skeleton kpi__delta-skeleton" aria-hidden="true" />
+                ))
+                : (conversion?.rows ?? []).slice(0, 3).map((row) => (
+                  <div key={row.group_key} className="split-row">
+                    <span className="mono fs-12">{row.group_key}</span>
+                    <span className="mono num">{Math.round(row.application_start_rate * 100)}%</span>
+                  </div>
+                ))}
+              {/* "No dispositions" is a CLAIM about the week, so it may only
+                  render once the window has actually been read. */}
+              {!loading && (conversion?.rows ?? []).length === 0 && (
                 <div className="muted fs-12">No LO dispositions logged this week.</div>
               )}
             </div>
           </div>
-          <div className="sales-ops-card">
+          <div className="sales-ops-card" aria-busy={loading}>
             <div className="eyebrow">
               {hasDryRunOutcomeRows ? 'Outcome ledger · includes dry run' : 'Closed-loop outcomes'}
             </div>
-            <div className="kpi__value">{outcomesError ? '--' : (outcomes?.closed_funded ?? 0).toLocaleString()}</div>
-            <div className="muted fs-12">
-              {outcomesError
-                ? 'Customer-system outcome counts are unavailable.'
-                : `${(outcomes?.applications_submitted ?? 0).toLocaleString()} submitted · ${(outcomes?.lost_to_competitor ?? 0).toLocaleString()} lost elsewhere · ${(outcomes?.withdrawn ?? 0).toLocaleString()} withdrawn · ${(outcomes?.not_qualified ?? 0).toLocaleString()} not qualified this week.`}
-            </div>
+            <CardValue state={cardState}>
+              {outcomesError ? '--' : (outcomes?.closed_funded ?? 0).toLocaleString()}
+            </CardValue>
+            {loading ? (
+              <span className="skeleton kpi__delta-skeleton" aria-hidden="true" />
+            ) : (
+              <div className="muted fs-12">
+                {outcomesError
+                  ? 'Customer-system outcome counts are unavailable.'
+                  : `${(outcomes?.applications_submitted ?? 0).toLocaleString()} submitted · ${(outcomes?.lost_to_competitor ?? 0).toLocaleString()} lost elsewhere · ${(outcomes?.withdrawn ?? 0).toLocaleString()} withdrawn · ${(outcomes?.not_qualified ?? 0).toLocaleString()} not qualified this week.`}
+              </div>
+            )}
             <div className="muted fs-12 mt-1">
               Imported, read-only outcome ledger; no write-back to customer systems.
               {hasDryRunOutcomeRows
@@ -199,7 +255,7 @@ export function SalesOpsSection() {
                 Outcome summary unavailable: {outcomesError}
               </div>
             ) : null}
-            {!outcomesError && (outcomes?.total_outcomes ?? 0) > 0 ? (
+            {loading ? null : !outcomesError && (outcomes?.total_outcomes ?? 0) > 0 ? (
               <div className="sales-ops-list mt-2">
                 {outcomeDistribution.map((row) => (
                   <div key={row.label} className="split-row">

--- a/frontend/src/routes/analytics.sales-ops.tsx
+++ b/frontend/src/routes/analytics.sales-ops.tsx
@@ -133,6 +133,17 @@ export function SalesOpsSection() {
       ? 'error'
       : 'ready';
   const loading = cardState === 'loading';
+  // Conversion rows are grouped by LO EMAIL (`group_by: 'lo'`), which is an
+  // internal identifier -- the queue shows every other LO reference as
+  // "Summit LO 01". Resolve through the roster the same page already loads,
+  // and fall back to the raw key when the roster has no entry (a manager or a
+  // deactivated LO can still own dispositions) so a name is never invented.
+  const loanOfficerLabel = (groupKey: string): string => {
+    const match = salesTeam.find(
+      (member) => member.email.toLowerCase() === groupKey.trim().toLowerCase(),
+    );
+    return match?.display_label ?? groupKey;
+  };
 
   return (
     <div className="surface">
@@ -208,7 +219,9 @@ export function SalesOpsSection() {
                 ))
                 : (conversion?.rows ?? []).slice(0, 3).map((row) => (
                   <div key={row.group_key} className="split-row">
-                    <span className="mono fs-12">{row.group_key}</span>
+                    <span className="fs-12" title={row.group_key}>
+                      {loanOfficerLabel(row.group_key)}
+                    </span>
                     <span className="mono num">{Math.round(row.application_start_rate * 100)}%</span>
                   </div>
                 ))}

--- a/frontend/src/routes/analytics.sales-ops.tsx
+++ b/frontend/src/routes/analytics.sales-ops.tsx
@@ -133,15 +133,6 @@ export function SalesOpsSection() {
       ? 'error'
       : 'ready';
   const loading = cardState === 'loading';
-  const outcomeDistribution = outcomes
-    ? [
-      { label: 'submitted', value: outcomes.applications_submitted },
-      { label: 'funded', value: outcomes.closed_funded },
-      { label: 'lost elsewhere', value: outcomes.lost_to_competitor },
-      { label: 'withdrawn', value: outcomes.withdrawn },
-      { label: 'not qualified', value: outcomes.not_qualified },
-    ]
-    : [];
 
   return (
     <div className="surface">
@@ -232,8 +223,14 @@ export function SalesOpsSection() {
             <div className="eyebrow">
               {hasDryRunOutcomeRows ? 'Outcome ledger · includes dry run' : 'Closed-loop outcomes'}
             </div>
+            {/* The headline is the WINDOW TOTAL, not the funded count. It used
+                to render `closed_funded`, so the card showed a bold 0 above
+                its own subline reading "8 submitted" -- a card contradicting
+                itself. Funded now leads the breakdown, where it can't be
+                mistaken for the total. `total_outcomes` is SUM over every
+                outcome type in the window (sales_state.outcome_summary). */}
             <CardValue state={cardState}>
-              {outcomesError ? '--' : (outcomes?.closed_funded ?? 0).toLocaleString()}
+              {outcomesError ? '--' : (outcomes?.total_outcomes ?? 0).toLocaleString()}
             </CardValue>
             {loading ? (
               <span className="skeleton kpi__delta-skeleton" aria-hidden="true" />
@@ -241,7 +238,7 @@ export function SalesOpsSection() {
               <div className="muted fs-12">
                 {outcomesError
                   ? 'Customer-system outcome counts are unavailable.'
-                  : `${(outcomes?.applications_submitted ?? 0).toLocaleString()} submitted · ${(outcomes?.lost_to_competitor ?? 0).toLocaleString()} lost elsewhere · ${(outcomes?.withdrawn ?? 0).toLocaleString()} withdrawn · ${(outcomes?.not_qualified ?? 0).toLocaleString()} not qualified this week.`}
+                  : `Outcomes recorded this week: ${(outcomes?.closed_funded ?? 0).toLocaleString()} funded · ${(outcomes?.applications_submitted ?? 0).toLocaleString()} submitted · ${(outcomes?.lost_to_competitor ?? 0).toLocaleString()} lost elsewhere · ${(outcomes?.withdrawn ?? 0).toLocaleString()} withdrawn · ${(outcomes?.not_qualified ?? 0).toLocaleString()} not qualified.`}
               </div>
             )}
             <div className="muted fs-12 mt-1">
@@ -255,14 +252,11 @@ export function SalesOpsSection() {
                 Outcome summary unavailable: {outcomesError}
               </div>
             ) : null}
+            {/* The per-type distribution moved into the caption above (funded
+                first), so this list carries only what the caption does not:
+                which competitors took the lost loans. */}
             {loading ? null : !outcomesError && (outcomes?.total_outcomes ?? 0) > 0 ? (
               <div className="sales-ops-list mt-2">
-                {outcomeDistribution.map((row) => (
-                  <div key={row.label} className="split-row">
-                    <span className="mono fs-12">{row.label}</span>
-                    <span className="mono num">{row.value.toLocaleString()}</span>
-                  </div>
-                ))}
                 {(outcomes?.top_competitors ?? []).slice(0, 2).map((row) => (
                   <div key={row.competitor_lender_label} className="split-row">
                     <span className="mono fs-12">{row.competitor_lender_label}</span>

--- a/frontend/src/routes/analytics.tabs.a11y.test.tsx
+++ b/frontend/src/routes/analytics.tabs.a11y.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * The Analytics view tabs must expose their visible label as their accessible
+ * name. A 2026-08-08 UX walk reported the tab elements as having EMPTY
+ * accessible names; the component renders `<Icon aria-hidden>` plus a
+ * `.filter__value` span carrying the real label, so the name is the label and
+ * the empty reading was a tooling artifact. This pins that: the day someone
+ * hides `.filter__value` behind a breakpoint or swaps it for a pseudo-element,
+ * the tabs really would go nameless, and that must fail here rather than in a
+ * screen reader.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TABS } from './analytics.lib';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../lib/useWarmingUpRetry', () => ({
+  useWarmingUpRetry: () => ({
+    data: null,
+    warmingUp: null,
+    error: null,
+    isFetching: false,
+    manualRetry: vi.fn(),
+  }),
+}));
+
+vi.mock('../lib/configOptionsQuery', () => ({
+  useConfigOptionsQuery: () => ({ data: { target_lender_refs: ['All'] }, isError: false }),
+}));
+
+vi.mock('../components/FootprintProvider', () => ({
+  useFootprint: () => ({
+    ready: true,
+    usingFallback: false,
+    states: [
+      { state_code: 'IL', state_name: 'Illinois', display_order: 1, is_default_state: true },
+    ],
+  }),
+}));
+
+vi.mock('../lib/api', () => ({ api: {} }));
+
+import AnalyticsRoute from './analytics';
+
+describe('Analytics view tabs accessibility', () => {
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="root"></div>';
+    root = createRoot(document.getElementById('root') as HTMLElement);
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    queryClient.clear();
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  it('names every tab with its visible label and keeps the icon out of the name', async () => {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/analytics']}>
+            <AnalyticsRoute />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+
+    const tabs = [...document.querySelectorAll<HTMLButtonElement>('button[role="tab"]')];
+    expect(tabs.length).toBe(TABS.length);
+    expect(tabs.map((tab) => tab.textContent?.trim())).toEqual(TABS.map((tab) => tab.label));
+
+    for (const tab of tabs) {
+      // Text content, not an aria-label override: the accessible name comes
+      // from the label the user can see.
+      expect(tab.getAttribute('aria-label')).toBeNull();
+      expect(tab.textContent?.trim()).not.toBe('');
+      // Decorative icon must not leak into the computed name.
+      expect(tab.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+    }
+
+    const tablist = document.querySelector('[role="tablist"]');
+    expect(tablist?.getAttribute('aria-label')).toBe('Analytics views');
+    expect(tabs.filter((tab) => tab.getAttribute('aria-selected') === 'true').length).toBe(1);
+  });
+});

--- a/frontend/src/routes/borrower-360.tsx
+++ b/frontend/src/routes/borrower-360.tsx
@@ -17,6 +17,7 @@ import { Icon } from '../components/Icon';
 import { Skeleton } from '../components/ui/Skeleton';
 import { WarmingUpBlock } from '../components/ui/WarmingUpBlock';
 import { Reveal } from '../components/fx/Reveal';
+import { metroLoanTypeLabel } from '../lib/dossierCodes';
 import { descriptorFor, descriptorForEvidence } from '../lib/drawerSources';
 import { offerDisplayLabel, offerRationale, offerShortDescription } from '../lib/offerLanguage';
 import { safeSegmentName, segmentByCode } from '../lib/segmentMetadata';
@@ -385,10 +386,16 @@ export default function Borrower360() {
                 }
               />
               <Field k="Related properties" v={`${b.related_property_count} (via owner graph)`} />
+              {/* Raw source codes read as noise ("42660 · CNV"): the CBSA gets
+                  labelled (gold carries no metro NAME column, so this is as
+                  far as it can honestly go) and the Cotality loan type code is
+                  expanded. Unknown codes pass through verbatim — never guessed
+                  into a product bucket. The raw pair stays on the title for
+                  anyone reconciling against the source row. */}
               <Field
                 k="Metro / loan type"
-                v={`${b.situs_cbsa_code ?? 'CBSA unavailable'} · ${b.first_pos_loan_type ?? 'Loan type unavailable'}`}
-                mono
+                v={metroLoanTypeLabel(b.situs_cbsa_code, b.first_pos_loan_type)}
+                title={`${b.situs_cbsa_code ?? '—'} · ${b.first_pos_loan_type ?? '—'}`}
               />
               <Field
                 k="Relationship flags"
@@ -593,11 +600,28 @@ export default function Borrower360() {
   );
 }
 
-function Field({ k, v, mono, childEl }: { k: ReactNode; v: string; mono?: boolean; childEl?: ReactElement }) {
+function Field({
+  k,
+  v,
+  mono,
+  childEl,
+  title,
+}: {
+  k: ReactNode;
+  v: string;
+  mono?: boolean;
+  childEl?: ReactElement;
+  /** Raw source value, when the rendered one is a friendly expansion of it. */
+  title?: string;
+}) {
   return (
     <div>
       <div className="field__label">{k}</div>
-      {childEl ?? <div className={`field__value ${mono ? 'mono num' : ''}`}>{v}</div>}
+      {childEl ?? (
+        <div className={`field__value ${mono ? 'mono num' : ''}`} title={title}>
+          {v}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/routes/borrower-360.tsx
+++ b/frontend/src/routes/borrower-360.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type CSSProperties, type ReactElement, type ReactN
 import { Link, Navigate, useParams } from 'react-router';
 import { api, ApiError } from '../lib/api';
 import type { Borrower360 as Borrower360Type } from '../types';
-import { currency, ratePct, ratePctFromFraction, signedBpsLabel } from '../lib/formatters';
+import { currency, rangeLabel, ratePct, ratePctFromFraction, signedBpsLabel } from '../lib/formatters';
 import { PageShell } from '../components/layout/PageShell';
 import { TriggerTimeline } from '../components/mortgage/TriggerTimeline';
 import { BorrowerStoryCard } from '../components/mortgage/BorrowerStoryCard';
@@ -254,7 +254,11 @@ export default function Borrower360() {
   const saved = isLeadSaved(b.borrower_id);
   const lienBandLow = b.current_lien_balance_low ?? b.current_lien_balance;
   const lienBandHigh = b.current_lien_balance_high ?? b.current_lien_balance;
-  const lienBandLabel = `${currency(lienBandLow)}-${currency(lienBandHigh)}`;
+  // A band whose ends are equal is a point estimate, not a range: rendering it
+  // as "$100,000-$100,000" made a confident number look like a sloppy one. It
+  // is also the shape EVERY row takes when the confidence-band columns are
+  // absent and both ends fall back to `current_lien_balance`.
+  const lienBandLabel = rangeLabel(lienBandLow, lienBandHigh, currency);
   const estimatedUpbBandSource = descriptorFor('fn_estimated_upb_confidence_band');
   const saveCurrentLead = () => {
     saveLead({

--- a/frontend/src/routes/portfolio-builder.population-kpi.test.tsx
+++ b/frontend/src/routes/portfolio-builder.population-kpi.test.tsx
@@ -1,0 +1,139 @@
+/** @vitest-environment happy-dom
+ *
+ * The population KPI names the predicate it applied. Portfolio Builder builds
+ * with CONTACTABILITY = "Eligible only" by default, so the count has the
+ * governed contactability gate pushed down: it is the MARKETABLE
+ * (contact-eligible) subset, and both the headline and the evidence chip must
+ * say so. The chip previously read "Addressable population" — Home's
+ * predicate, which is the opposite gate — on a number that had the gate
+ * applied.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PortfolioPreview } from '../types';
+
+const portfolioPreview = vi.fn();
+const campaigns = vi.fn();
+const salesCampaignPerformance = vi.fn();
+
+vi.mock('../lib/api', () => ({
+  api: {
+    portfolioPreview: (...args: unknown[]) => portfolioPreview(...args),
+    portfolioCreate: vi.fn(),
+    campaignRecommendation: vi.fn(),
+    campaigns: (...args: unknown[]) => campaigns(...args),
+    salesCampaignPerformance: (...args: unknown[]) => salesCampaignPerformance(...args),
+  },
+  ApiError: class extends Error {},
+  isAbortError: () => false,
+  isWarmingUpError: () => false,
+}));
+
+vi.mock('../lib/configOptionsQuery', () => {
+  const value = {
+    data: {
+      lender_name: 'Summit Mortgage',
+      target_lender_refs: ['All'],
+      target_lender_refs_status: 'live',
+    },
+    isError: false,
+  };
+  return { useConfigOptionsQuery: () => value };
+});
+
+vi.mock('../components/FootprintProvider', () => {
+  const value = { ready: true, usingFallback: false, states: [] };
+  return { useFootprint: () => value };
+});
+
+vi.mock('../components/AppContext', () => ({
+  useApp: () => ({
+    setDrawer: vi.fn(),
+    showEvidence: true,
+    showConfidence: true,
+    canAccessAdmin: false,
+  }),
+}));
+
+import PortfolioBuilder from './portfolio-builder';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const PREVIEW = {
+  marketable_population: 76_487,
+  campaign_build_contact_count: 76_487,
+  campaign_build_limit: 100_000,
+  campaign_build_eligible: true,
+  avg_score: 71,
+  top_tier_opportunities: 3_990,
+  offers_recommended: 44_700,
+  high_intent_leads: 1_200,
+} as unknown as PortfolioPreview;
+
+describe('PortfolioBuilder population KPI', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    portfolioPreview.mockReset();
+    campaigns.mockReset();
+    salesCampaignPerformance.mockReset();
+    portfolioPreview.mockResolvedValue(PREVIEW);
+    campaigns.mockResolvedValue({ campaigns: [] });
+    salesCampaignPerformance.mockResolvedValue({
+      unique_leads_attempted: 0,
+      unique_contacts_reached: 0,
+      unique_application_starts: 0,
+      unique_applications_submitted: 0,
+      unique_closed_funded: 0,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function mount() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/portfolio-builder']}>
+            <PortfolioBuilder />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+    for (let i = 0; i < 20; i += 1) {
+      if (container.textContent?.includes('76,487')) break;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+    }
+  }
+
+  it('labels the gated count marketable and cites the contact-eligible predicate', async () => {
+    await mount();
+
+    const populationCard = [...container.querySelectorAll<HTMLElement>('.kpi')].find((card) =>
+      card.querySelector('.kpi__label')?.textContent?.includes('population'),
+    );
+    expect(populationCard).toBeTruthy();
+    expect(populationCard?.querySelector('.kpi__label')?.textContent).toBe('Marketable population');
+    expect(populationCard?.querySelector('.kpi__value')?.textContent).toContain('76,487');
+
+    const chip = populationCard?.querySelector('.kpi__source .evidence-chip');
+    expect(chip?.textContent).toContain('Marketable population — contact-eligible subset');
+    // The addressable chip belongs to Home's ungated count, not this one.
+    expect(chip?.textContent).not.toContain('Addressable population');
+  });
+});

--- a/frontend/src/routes/portfolio-builder.tsx
+++ b/frontend/src/routes/portfolio-builder.tsx
@@ -47,6 +47,7 @@ import {
   type CampaignSetupState,
 } from './portfolio-builder.logic';
 import { HIGH_OPPORTUNITY_KPI_LABEL } from '../lib/opportunityScore';
+import { populationKpiLabel } from '../lib/populationLabels';
 
 /**
  * Portfolio Builder — prototype `.surface` + `.filter-row` composition.
@@ -638,15 +639,26 @@ export default function PortfolioBuilder() {
           {preview && <CampaignBuildGuard preview={preview} />}
 
           <div className="kpi-row kpi-row--spaced">
+            {/* Label AND evidence chip follow the CONTACTABILITY criterion the
+                preview was built with. At the default ("Eligible only") this
+                count has the governed contactability gate pushed down, so it
+                is the marketable subset and the chip must say so — it read
+                "Addressable population", the predicate Home applies, which is
+                the opposite gate. Switch CONTACTABILITY to Any / Suppressed
+                only and both the label and the chip follow. */}
             <KpiCard
-              label="Marketable population"
+              label={populationKpiLabel(committedFilters.marketing_eligibility)}
               valueAnimated={dayZeroSafe(preview, preview?.marketable_population)}
               trend={preview?.trends?.marketable_population?.series}
               delta={formatDelta(preview?.trends?.marketable_population)}
               deltaDir={preview?.trends?.marketable_population?.direction}
               trendNote={preview?.trends?.marketable_population?.note}
               loading={building}
-              source={DRAWER_SOURCES.population}
+              source={
+                committedFilters.marketing_eligibility === 'Eligible only'
+                  ? DRAWER_SOURCES.populationMarketable
+                  : DRAWER_SOURCES.population
+              }
             />
             <KpiCard
               label="Avg. borrower score"


### PR DESCRIPTION
Frontend fixes for the defects found in the 2026-08-08 hands-on UX walk. Ten
reports; eight were real and are fixed, two did not reproduce in source and
got tripwires instead of changes.

## Fixed

1. **Approval-funnel tab headlined the addressable count as "marketable"** —
   5,156,184 is the whole reachable book (COUNT(*) with no contactability
   gate), not the ~76K contact-eligible subset. Home and Portfolio Builder were
   renamed in the 2026-08-07 data audit; this tab was missed. The two strings
   are now pinned in `lib/populationLabels.ts` and the stage headline resolves
   through the same helper its evidence drawer uses. **The number is unchanged.**
2. **Portfolio Builder KPI chip described the opposite gate** — the headline
   said "Marketable population" (correct: the build applies CONTACTABILITY =
   "Eligible only") while the evidence chip said "Addressable population". New
   `populationMarketable` drawer source names the governed gate
   (marketing_eligible / consent / suppression / DNC); both halves now follow
   the committed criterion, so switching CONTACTABILITY moves them together.
3. **Sales-ops cards rendered loading state as confident zeros** — `?? []` /
   `?? 0` fallbacks meant "STALE APPROVED 0" and "No LO dispositions logged
   this week" appeared before the query resolved. A manager acts on that.
   Cards now render the existing KpiCard skeleton slots (no new CSS) with
   `aria-busy`, window-level claims wait for the window to be read, and a
   failed query renders an em-dash rather than a zero.
4. **Closed-loop outcomes card contradicted its own subline** — headlined
   `closed_funded` (0) above a caption reading "8 submitted". Headline is now
   the window total; funded leads the breakdown where it cannot be mistaken
   for the total. The per-type list it duplicated is dropped; competitor rows
   stay.
5. **Week-to-date conversion showed `lo02@summit.example`** — resolved through
   the sales roster the page already loads, raw key kept on `title`, unmatched
   keys pass through rather than inventing a name.
6. **Lead-queue property ref split mid-token** — `overflow-wrap: anywhere`
   broke the CLIP into "clip_ref_d8b9f5890b" / "66". Ellipsis truncation with
   the full ref on `title`. CSS delta measured: **+0.09 KiB raw / +0.01 KiB
   gzip**.
8. **Degenerate estimated-UPB range** — "$100,000-$100,000" collapses to the
   single value via a new shared `rangeLabel` formatter (compares the
   FORMATTED ends, so values rounding to the same dollar collapse too).
9. **Raw source codes in the dossier** — "42660 · CNV" now reads
   "CBSA 42660 · Conventional". The CBSA is labelled rather than named because
   gold carries the code only; loan-type codes expand through a small map and
   an unknown code passes through verbatim rather than being guessed into a
   product bucket.

## Not reproducible — tripwires added instead

7. **"+330&nbsp;&nbsp;bps"** — every bps string comes from `signedBpsLabel`,
   which emits exactly one space. No double space, no `&nbsp;`, no literal NBSP
   anywhere in the tree. The visible gap is the Geist Mono space glyph in a
   `.mono.num` span beside proportional text. Pinned so a hand-rolled template
   cannot introduce a real one.
10. **Empty accessible names on the Analytics tabs** — each tab renders
    `<Icon aria-hidden>` plus a `.filter__value` span with the visible label,
    and nothing hides that span, so the accessible name IS the label. No
    redundant aria-label added; a test now fails if the label is ever hidden.

## Follow-up found, not fixed here (SQL scope)

Live gold carries `CNV` for conventional first liens, while
`sql/uc_functions/fn_loan_product_type.sql` and the fit sub-score branch in
`sql/transformations/gold_borrower_360.sql` test for `CONV`. If that is real,
every conventional loan is bucketed `other` by the PRODUCT TYPE filter and
misses the owner-occupied fit branch. This PR makes the dossier read correctly
for both spellings; it does not touch the SQL.

## Validation

`npm --prefix frontend run lint` · `run test` (132 files, 1007 tests) ·
`run build` · `run budget` (initial CSS 147.06 KiB / 24.88 KiB gzip, under the
148 / 25 limits) · `tools/check_file_sizes.py` — all green. No backend or SQL
files touched.
