### PR TITLE
fix(data): conventional loans score as conventional — the share spells it CNV

### DIFF
--- a/.claude/agent-memory/backend-databricks-engineer/MEMORY.md
+++ b/.claude/agent-memory/backend-databricks-engineer/MEMORY.md
@@ -10,3 +10,6 @@
 - [No Pydantic validation on PII fields](feedback_no_pydantic_validation_on_pii_fields.md) — 422 echoes raw input; validate PII fields in the route via HTTPException, not Pydantic validators
 - [Genie live-first routing](project_genie_live_first.md) — live Genie primary; canonical interceptors are a disclosed degraded fallback gated by mip_genie_live_first
 - [Genie visible-text Title-Case trap](project_genie_visible_text_titlecase_trap.md) — server-authored strings trip the name-shape guard; probe every new Genie string first
+- [Shared worktree: never git add -A](feedback_shared_worktree_git_add.md) — other agents edit and commit the same branch concurrently; stage explicit paths, never rewrite history
+- [Fake Lakebase SQL substring dispatch](project_fake_lakebase_sql_dispatch.md) — a reused CTE name silently hits the wrong conftest handler; grep markers before adding SQL
+- [County key removed, geo drill dead](project_county_key_removed_drill_dead.md) — county_fips_5 is NULL everywhere since audit C2; every county-keyed geo read returns empty

--- a/backend/services/scoring.py
+++ b/backend/services/scoring.py
@@ -613,7 +613,7 @@ def loan_product_type(
     code = loan_type_code.strip().upper()
     if not code:
         return None
-    if code == "CONV":
+    if code in ("CNV", "CONV"):
         if (
             original_loan_amount is not None
             and conforming_limit_usd is not None

--- a/docs/data-contract-module0.md
+++ b/docs/data-contract-module0.md
@@ -692,7 +692,9 @@ sub-scores. The scoring surface does not consume race, color, religion,
 national origin, sex, marital status, age, receipt of public assistance,
 consumer-protection exercise, FICO, or credit-bureau tradeline data.
 
-CONV/FHA/VA parity is a contract: owner-occupied `CONV`, `FHA`, and `VA`
+CONV/FHA/VA parity is a contract (the live Cotality share spells conventional
+`CNV`; both spellings are accepted since the 2026-08-08 audit): owner-occupied
+`CNV`/`CONV`, `FHA`, and `VA`
 first-position loan types receive identical fit treatment (`70` before
 property-size additions). Future changes must not rank those three loan types
 asymmetrically without a signed lender fair-lending review. The

--- a/sql/fixtures/loan_product_type_validation.sql
+++ b/sql/fixtures/loan_product_type_validation.sql
@@ -31,7 +31,11 @@ WITH golden (id, loan_type_code, original_loan_amount, conforming_limit_usd, exp
     ('case_08_unrecognized_code_other',           'PP',   340000, 806500, 'other'),
     ('case_09_case_and_whitespace_normalized',    ' conv ', 950000, 806500, 'jumbo'),
     ('case_10_conv_null_amount_conventional',     'CONV', CAST(NULL AS BIGINT), 806500, 'conventional'),
-    ('case_11_conv_null_limit_conventional',      'CONV', 950000, CAST(NULL AS BIGINT), 'conventional')
+    ('case_11_conv_null_limit_conventional',      'CONV', 950000, CAST(NULL AS BIGINT), 'conventional'),
+    ('case_12_cnv_below_limit_conventional',      'CNV', 340000, 806500, 'conventional'),
+    ('case_13_cnv_above_limit_jumbo',             'CNV', 950000, 806500, 'jumbo'),
+    ('case_14_cnv_lowercase_trimmed',             ' cnv ', CAST(NULL AS BIGINT), 806500, 'conventional'),
+    ('case_15_pp_private_party_other',            'PP', 300000, 806500, 'other')
 )
 SELECT
   id,

--- a/sql/transformations/gold_borrower_360.sql
+++ b/sql/transformations/gold_borrower_360.sql
@@ -985,7 +985,7 @@ subscores AS (
     -- (owner-occupant + CONV/FHA/VA with many bedrooms beats everything).
     CAST(LEAST(100, GREATEST(0,
         CASE
-          WHEN w.is_owner_occupied AND w.first_pos_loan_type IN ('CONV','FHA','VA') THEN 70
+          WHEN w.is_owner_occupied AND w.first_pos_loan_type IN ('CNV','CONV','FHA','VA') THEN 70
           WHEN w.is_owner_occupied                                                  THEN 60
           WHEN w.owner_is_corporate                                                 THEN 50
           ELSE 40

--- a/sql/transformations/gold_evidence_events.sql
+++ b/sql/transformations/gold_evidence_events.sql
@@ -320,7 +320,7 @@ loan_type_fit_rows AS (
     6                                                AS signal_rank
   FROM mip.silver.lien_current AS lc
   WHERE COALESCE(lc.owner_occupancy_code, '') = 'O'
-    AND lc.first_pos_loan_type IN ('CONV','FHA','VA')
+    AND lc.first_pos_loan_type IN ('CNV','CONV','FHA','VA')
     AND lc.situs_state IS NOT NULL
 ),
 -- 8. competitor_lien: current servicer known and not a tenant-lender alias.

--- a/sql/transformations/gold_lead_scores.sql
+++ b/sql/transformations/gold_lead_scores.sql
@@ -166,7 +166,7 @@ subscores AS (
     -- from the same silver property master row used by borrower_360.
     CAST(LEAST(100, GREATEST(0,
       CASE
-        WHEN b.is_owner_occupied AND b.first_pos_loan_type IN ('CONV','FHA','VA') THEN 70
+        WHEN b.is_owner_occupied AND b.first_pos_loan_type IN ('CNV','CONV','FHA','VA') THEN 70
         WHEN b.is_owner_occupied                                                  THEN 60
         WHEN b.is_corporate_owner                                                 THEN 50
         ELSE 40

--- a/sql/uc_functions/fn_loan_product_type.sql
+++ b/sql/uc_functions/fn_loan_product_type.sql
@@ -8,8 +8,11 @@
 --            product-type evidence rows.
 --
 -- Domain:    Cotality ships `first_position_mortgage_loan_type_code`
---            (silver.lien_current.first_pos_loan_type) as CONV / FHA / VA /
---            other coded values. "Jumbo" is not a source code -- it is a
+--            (silver.lien_current.first_pos_loan_type) as CNV / FHA / VA /
+--            other coded values (2026-08-08 audit: the live share uses CNV —
+--            2,585,874 rows — while this function tested only the legacy
+--            CONV spelling, so every conventional loan bucketed 'other' and
+--            missed the owner-occupied fit branch; both spellings map). "Jumbo" is not a source code -- it is a
 --            derived classification: a conventional first lien whose
 --            ORIGINAL amount exceeds the governed conforming loan limit.
 --
@@ -20,10 +23,10 @@
 --            - NULL / blank loan_type_code -> NULL. An unknown source code
 --              must read as "unknown", never as a guessed product. This is
 --              the same fail-closed posture as fn_in_the_money's NULL rule.
---            - 'CONV' with original_loan_amount > conforming_limit_usd
+--            - 'CNV'/'CONV' with original_loan_amount > conforming_limit_usd
 --              -> 'jumbo' (strictly greater; a loan exactly at the limit is
 --              conforming by FHFA definition).
---            - 'CONV' otherwise (including NULL amount / NULL limit, where
+--            - 'CNV'/'CONV' otherwise (including NULL amount / NULL limit, where
 --              the jumbo test cannot be evaluated) -> 'conventional'.
 --            - 'FHA' -> 'fha'; 'VA' -> 'va'.
 --            - Any other non-blank source code -> 'other' (the code is real
@@ -57,12 +60,12 @@ COMMENT 'Module 0 canonical loan product-type classification: conventional / jum
 RETURN
   CASE
     WHEN loan_type_code IS NULL OR LENGTH(TRIM(loan_type_code)) = 0 THEN NULL
-    WHEN UPPER(TRIM(loan_type_code)) = 'CONV'
+    WHEN UPPER(TRIM(loan_type_code)) IN ('CNV', 'CONV')
      AND original_loan_amount IS NOT NULL
      AND conforming_limit_usd IS NOT NULL
      AND original_loan_amount > conforming_limit_usd
     THEN 'jumbo'
-    WHEN UPPER(TRIM(loan_type_code)) = 'CONV' THEN 'conventional'
+    WHEN UPPER(TRIM(loan_type_code)) IN ('CNV', 'CONV') THEN 'conventional'
     WHEN UPPER(TRIM(loan_type_code)) = 'FHA'  THEN 'fha'
     WHEN UPPER(TRIM(loan_type_code)) = 'VA'   THEN 'va'
     ELSE 'other'

--- a/tests/fixtures/loan_product_type_golden.json
+++ b/tests/fixtures/loan_product_type_golden.json
@@ -6,69 +6,153 @@
   "cases": [
     {
       "id": "case_01_conv_below_limit_conventional",
-      "inputs": {"loan_type_code": "CONV", "original_loan_amount": 340000, "conforming_limit_usd": 806500},
+      "inputs": {
+        "loan_type_code": "CONV",
+        "original_loan_amount": 340000,
+        "conforming_limit_usd": 806500
+      },
       "expected_product_type": "conventional",
       "note": "Happy path: conventional code, amount below the limit."
     },
     {
       "id": "case_02_conv_above_limit_jumbo",
-      "inputs": {"loan_type_code": "CONV", "original_loan_amount": 950000, "conforming_limit_usd": 806500},
+      "inputs": {
+        "loan_type_code": "CONV",
+        "original_loan_amount": 950000,
+        "conforming_limit_usd": 806500
+      },
       "expected_product_type": "jumbo",
       "note": "Conventional code with original amount strictly above the governed limit classifies as jumbo."
     },
     {
       "id": "case_03_conv_exactly_at_limit_conventional",
-      "inputs": {"loan_type_code": "CONV", "original_loan_amount": 806500, "conforming_limit_usd": 806500},
+      "inputs": {
+        "loan_type_code": "CONV",
+        "original_loan_amount": 806500,
+        "conforming_limit_usd": 806500
+      },
       "expected_product_type": "conventional",
       "note": "Boundary: a loan EXACTLY at the conforming limit is conforming by FHFA definition. The > contract means equality stays conventional; flipping to >= would fail this case loudly."
     },
     {
       "id": "case_04_fha_maps_fha",
-      "inputs": {"loan_type_code": "FHA", "original_loan_amount": 900000, "conforming_limit_usd": 806500},
+      "inputs": {
+        "loan_type_code": "FHA",
+        "original_loan_amount": 900000,
+        "conforming_limit_usd": 806500
+      },
       "expected_product_type": "fha",
       "note": "FHA maps to fha regardless of amount -- the jumbo overlay applies only to conventional first liens."
     },
     {
       "id": "case_05_va_maps_va",
-      "inputs": {"loan_type_code": "VA", "original_loan_amount": 250000, "conforming_limit_usd": 806500},
+      "inputs": {
+        "loan_type_code": "VA",
+        "original_loan_amount": 250000,
+        "conforming_limit_usd": 806500
+      },
       "expected_product_type": "va",
       "note": "VA maps to va."
     },
     {
       "id": "case_06_null_code_returns_null",
-      "inputs": {"loan_type_code": null, "original_loan_amount": 950000, "conforming_limit_usd": 806500},
+      "inputs": {
+        "loan_type_code": null,
+        "original_loan_amount": 950000,
+        "conforming_limit_usd": 806500
+      },
       "expected_product_type": null,
       "note": "No source code -> NULL (unknown). A large amount alone must NOT be guessed as jumbo: without the code we cannot rule out FHA/VA."
     },
     {
       "id": "case_07_blank_code_returns_null",
-      "inputs": {"loan_type_code": "   ", "original_loan_amount": 340000, "conforming_limit_usd": 806500},
+      "inputs": {
+        "loan_type_code": "   ",
+        "original_loan_amount": 340000,
+        "conforming_limit_usd": 806500
+      },
       "expected_product_type": null,
       "note": "Whitespace-only code is treated as missing."
     },
     {
       "id": "case_08_unrecognized_code_other",
-      "inputs": {"loan_type_code": "PP", "original_loan_amount": 340000, "conforming_limit_usd": 806500},
+      "inputs": {
+        "loan_type_code": "PP",
+        "original_loan_amount": 340000,
+        "conforming_limit_usd": 806500
+      },
       "expected_product_type": "other",
       "note": "A real but unmapped Cotality code (e.g. private-party) lands in other -- the signal is preserved, never dropped or guessed into a marketed bucket."
     },
     {
       "id": "case_09_case_and_whitespace_normalized",
-      "inputs": {"loan_type_code": " conv ", "original_loan_amount": 950000, "conforming_limit_usd": 806500},
+      "inputs": {
+        "loan_type_code": " conv ",
+        "original_loan_amount": 950000,
+        "conforming_limit_usd": 806500
+      },
       "expected_product_type": "jumbo",
       "note": "UPPER(TRIM(...)) normalization: lowercase/padded source codes still classify."
     },
     {
       "id": "case_10_conv_null_amount_conventional",
-      "inputs": {"loan_type_code": "CONV", "original_loan_amount": null, "conforming_limit_usd": 806500},
+      "inputs": {
+        "loan_type_code": "CONV",
+        "original_loan_amount": null,
+        "conforming_limit_usd": 806500
+      },
       "expected_product_type": "conventional",
       "note": "Missing original amount disables only the jumbo test; the code-mapped bucket still returns."
     },
     {
       "id": "case_11_conv_null_limit_conventional",
-      "inputs": {"loan_type_code": "CONV", "original_loan_amount": 950000, "conforming_limit_usd": null},
+      "inputs": {
+        "loan_type_code": "CONV",
+        "original_loan_amount": 950000,
+        "conforming_limit_usd": null
+      },
       "expected_product_type": "conventional",
       "note": "Missing governed limit disables only the jumbo test (misconfiguration must not inflate jumbo counts)."
+    },
+    {
+      "id": "case_12_cnv_below_limit_conventional",
+      "inputs": {
+        "loan_type_code": "CNV",
+        "original_loan_amount": 340000,
+        "conforming_limit_usd": 806500
+      },
+      "expected_product_type": "conventional",
+      "note": "2026-08-08 audit: the live Cotality share spells conventional CNV (2,585,874 rows); the legacy CONV-only test bucketed all of them 'other'."
+    },
+    {
+      "id": "case_13_cnv_above_limit_jumbo",
+      "inputs": {
+        "loan_type_code": "CNV",
+        "original_loan_amount": 950000,
+        "conforming_limit_usd": 806500
+      },
+      "expected_product_type": "jumbo",
+      "note": "CNV follows the same conforming-limit jumbo derivation as CONV."
+    },
+    {
+      "id": "case_14_cnv_lowercase_trimmed",
+      "inputs": {
+        "loan_type_code": " cnv ",
+        "original_loan_amount": null,
+        "conforming_limit_usd": 806500
+      },
+      "expected_product_type": "conventional",
+      "note": "Case/whitespace-insensitive like every other code."
+    },
+    {
+      "id": "case_15_pp_private_party_other",
+      "inputs": {
+        "loan_type_code": "PP",
+        "original_loan_amount": 300000,
+        "conforming_limit_usd": 806500
+      },
+      "expected_product_type": "other",
+      "note": "Private-party financing is real signal outside the marketed buckets."
     }
   ]
 }

--- a/tests/unit/test_gold_ddl_contract.py
+++ b/tests/unit/test_gold_ddl_contract.py
@@ -701,11 +701,11 @@ def test_fit_loan_type_parity_and_explainability_contract() -> None:
     evidence_sql = (TRANSFORM_DIR / "gold_evidence_events.sql").read_text(encoding="utf-8")
     docs = (REPO_ROOT / "docs" / "data-contract-module0.md").read_text(encoding="utf-8")
 
-    parity_pattern = r"first_pos_loan_type\s+IN\s+\('CONV','FHA','VA'\)\s+THEN\s+70"
+    parity_pattern = r"first_pos_loan_type\s+IN\s+\('CNV','CONV','FHA','VA'\)\s+THEN\s+70"
     assert re.search(parity_pattern, borrower_sql)
     assert re.search(parity_pattern, lead_scores_sql)
     assert "'loan_type_fit'                                  AS signal_type" in evidence_sql
-    assert "first_pos_loan_type IN ('CONV','FHA','VA')" in evidence_sql
+    assert "first_pos_loan_type IN ('CNV','CONV','FHA','VA')" in evidence_sql
     # S1.6 extended the explainability-only exclusion list: product_type and
     # origination_channel rows must never retune the evidence sub-score.
     exclusion = "signal_type NOT IN ('permit', 'loan_type_fit', 'product_type', 'origination_channel')"


### PR DESCRIPTION
2026-08-08 hands-on audit (escalated by the frontend agent, verified
against silver): the live Cotality share codes conventional first liens
CNV — 2,585,874 rows, half the book — while fn_loan_product_type, the
Python parity mirror, and the three gold fit branches tested only the
legacy CONV spelling. Every conventional loan bucketed 'other' in the
PRODUCT TYPE dimension and missed the owner-occupied fit branch (70
points of the fit sub-score), silently depressing opportunity scores
platform-wide since inception.

Both spellings now map everywhere the vocabulary appears: the UDF,
scoring.py, gold_borrower_360 / gold_lead_scores / gold_evidence_events
fit branches, the golden fixtures (4 new CNV/PP cases), the warehouse
validation fixture, the DDL-contract parity pin, and the data contract
doc. CONV/FHA/VA fit parity remains symmetric — CNV joins the same
governed bucket, no fair-lending asymmetry introduced.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
