### PR TITLE
fix(shell): an unreachable health probe never renders the Live pill

### DIFF
--- a/frontend/src/components/layout/AppShell.test.tsx
+++ b/frontend/src/components/layout/AppShell.test.tsx
@@ -194,3 +194,18 @@ describe('system status view model', () => {
     expect(status.tooltip).not.toContain('loading');
   });
 });
+
+describe('systemStatusViewModel unreachable honesty', () => {
+  it('an unreachable probe never renders Live, even with preserved dep states', () => {
+    const vm = systemStatusViewModel({
+      status: 'unreachable',
+      mode: 'unknown',
+      // The down/up debounce preserves last-known dep states for missing
+      // deps; a dead probe used to read as Live through them (2026-08-08
+      // hands-on audit, expired session).
+      dependencies: { warehouse: 'up', lakebase: 'up', genie: 'up' },
+    } as never);
+    expect(vm.label).toBe('Unreachable');
+    expect(vm.dotClass).not.toContain('heartbeat');
+  });
+});

--- a/frontend/src/components/layout/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar.tsx
@@ -38,15 +38,32 @@ function openCommandPalette(): void {
  */
 export function systemStatusViewModel(health: HealthPayload | null): {
   dotClass: string;
-  label: 'Probing' | 'Live' | 'Degraded';
+  label: 'Probing' | 'Live' | 'Degraded' | 'Unreachable';
   tooltip: string;
   ariaLabel: string;
 } {
   // Health states:
-  //   probing  → no payload yet; gray dot, tooltip "first probe in flight"
-  //   live     → status==="ok" + every tracked dep === "up"
-  //   degraded → status==="degraded" OR any dep down OR any breaker open
+  //   probing     → no payload yet; gray dot, tooltip "first probe in flight"
+  //   live        → status==="ok" + every tracked dep === "up"
+  //   degraded    → status==="degraded" OR any dep down OR any breaker open
+  //   unreachable → the /api/health probe itself failed (network, auth
+  //                 expiry). The debounce deliberately preserves the last
+  //                 known per-dependency states for missing deps, which used
+  //                 to let a dead probe read as "Live" (2026-08-08 hands-on
+  //                 audit: an expired session rendered a green pill). An
+  //                 unreachable backend must never present as healthy.
   const isProbing = !health;
+  if (!isProbing && health?.status === 'unreachable') {
+    return {
+      dotClass: 'dot amber',
+      label: 'Unreachable',
+      tooltip:
+        'System status · unreachable — the /api/health probe failed ' +
+        '(network or session). Showing last-known dependency states is ' +
+        'not proof of health; refresh to re-authenticate if this persists.',
+      ariaLabel: 'System status: Unreachable.',
+    };
+  }
   const deps = health?.dependencies ?? {};
   const breakers = health?.circuit_breakers ?? {};
   const depEntries = [


### PR DESCRIPTION
2026-08-08 hands-on audit: an expired session mid-use made /api/health
return 401; api.health maps that to status='unreachable' with empty
dependencies, and the down/up debounce deliberately preserves last-known
per-dependency states for missing deps — through which the pill computed
Live. An unreachable backend must present as unknown, never healthy: the
view model now short-circuits to an amber 'Unreachable' state with
re-authenticate guidance in the tooltip.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
