### PR TITLE
fix(genie): open the deep-analysis question family and answer it deeply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ deprecation window first.
 
 ## Unreleased
 
+### 2026-08-08 deep-analysis question family: guards opened by vocabulary, answers deepened by planning
+
+- **Behavioral (guards):** the deep-analysis question family — "analyze the
+  full dataset of eligible borrowers, list the absolute top potential
+  borrowers, evaluate why each is a good candidate, and what the best curated
+  offer for each would be" — was refused across both Ask Genie and the
+  co-pilot by four guard defects (compound-clause anchoring, unreviewed
+  "with reasoning"/"highest potential" criteria, verb/conjunction pairs read
+  as borrower names, "for each" read as a contextual name). All fixed by
+  closed-vocabulary extension: analysis/why-assessment preamble strips,
+  reviewed potential/assessment/answer-format vocabulary, conjunction
+  transparency plus an analytics-verb skip list, and distributive-determiner
+  safe tokens. A 1,125-paraphrase sweep now passes 100% on both surfaces
+  (was 45% refused on Genie, 91% on the co-pilot); a 23,535-string
+  differential against the previous implementation shows **zero
+  refuse/allow flips** — no detector weakened, swapped-token variants
+  ("zyrplax", health terms, real name pairs) still refuse.
+- **Behavioral (depth):** questions classified as deep-analysis
+  (explicit depth wording, or two-plus analytic parts: ranked shortlist /
+  per-item why / offer call / comparative context) now route to the live
+  space's planned decomposition **first** instead of a single governed SQL
+  turn, with a wider plan floor (5–7 sub-analyses), coverage guidance
+  (cohort signals, population comparison, offer mix, concentration), and a
+  structured deep synthesis — every number still verified against the
+  sections' returned rows. Single-part questions are unchanged; an unusable
+  plan falls through to the existing single-turn path.
+
 ### 2026-08-07 growth co-pilot refusal families + refusal audit trail
 
 - **Additive:** a refused co-pilot prompt on `POST /api/v1/growth-agent/agent/run`

--- a/backend/schemas/borrower_copy_names.py
+++ b/backend/schemas/borrower_copy_names.py
@@ -592,6 +592,11 @@ _SAFE_CONTEXT_FIRST_TOKENS: frozenset[str] = frozenset(
         "customers",
         "daily",
         "data",
+        # Distributive determiners can never begin a personal name. "the best
+        # offer for each with reasoning" read ("each","with") as a name and
+        # refused a core deep-analysis ask (live capture, 2026-08-08).
+        "each",
+        "every",
         "eligible",
         "everyone",
         "final",

--- a/backend/schemas/growth_agent.py
+++ b/backend/schemas/growth_agent.py
@@ -111,7 +111,14 @@ _PROMPT_COMMON_NAME_RE = re.compile(
     re.IGNORECASE,
 )
 _PROMPT_LOWERCASE_NAME_AFTER_GROUP_RE = re.compile(
+    # A coordinating conjunction after the group noun is transparent: the
+    # pair is extracted from the words that follow it. Without this,
+    # "eligible borrowers and find determine a list" extracted ("and",
+    # "find") as a borrower name and refused the co-pilot's flagship
+    # deep-analysis objective (live capture, 2026-08-08) — while
+    # "borrowers and quorla zembrix" still extracts the real name pair.
     r"\b(?:borrowers?|customers?|prospects?|contacts?|people|person)\s+"
+    r"(?:(?:and|or|plus|then)\s+)?"
     r"([a-z]{2,30})\s+(?:[a-z]\s+)?([a-z]{2,30})\b"
 )
 _PROMPT_LOWERCASE_NAME_AFTER_ACTION_RE = re.compile(
@@ -126,8 +133,13 @@ _PROMPT_LOWERCASE_NAME_AFTER_ACTION_RE = re.compile(
     r"([a-z]{2,30})\s+(?:[a-z]\s+)?([a-z]{2,30})\b"
 )
 _PROMPT_LOWERCASE_NAME_IN_ACTION_CONTEXT_RE = re.compile(
+    # The verb alternation mirrors _PROMPT_LOWERCASE_NAME_SKIP_FIRST's
+    # analytics verbs: a verb that can precede a name pair here must also be
+    # skip-listed as a pair head, or verb chains ("find determine a list")
+    # read the second verb as a first name (live capture, 2026-08-08).
     r"(?=(?i:\b(?:for|named|find|show|locate|search(?:\s+for)?|look\s+up|pull\s+up|"
     r"review|open|prepare|prioritize|identify|select|pick|target|rank|call|contact|"
+    r"determine|evaluate|analyze|analyse|curate|surface|recommend|justify|"
     r"include|add|exclude|focus\s+on|create\s+(?:a|the)\s+cohort\s+around))\s+"
     r"(?:(?i:a|an|the)\s+)?([a-z]{2,30})\s+(?:[a-z]\s+)?([a-z]{2,30})\b"
     r"(?=\s+(?i:for|from|in|into|at|near|with|about|to)\b|[.,;!?]|$))"
@@ -258,6 +270,44 @@ _PROMPT_LOWERCASE_NAME_SKIP_FIRST: frozenset[str] = frozenset(
         "strongest",
         "recent",
         "active",
+        # Coordinating conjunctions and closed analytics verbs can never
+        # begin a personal name. "borrowers and find determine a list"
+        # extracted ("and","find") then ("determine","list") as names and
+        # refused the deep-analysis objective family (live capture,
+        # 2026-08-08). Verbs added here are also in the
+        # _PROMPT_LOWERCASE_NAME_IN_ACTION_CONTEXT_RE alternation so
+        # "determine zembrix quorla" still reads as verb + name pair.
+        "and",
+        "or",
+        "plus",
+        "then",
+        "find",
+        "show",
+        "list",
+        "determine",
+        "identify",
+        "evaluate",
+        "analyze",
+        "analyse",
+        "rank",
+        "surface",
+        "curate",
+        "curated",
+        "recommend",
+        "review",
+        "select",
+        "prioritize",
+        "pick",
+        "give",
+        "tell",
+        "walk",
+        "explain",
+        "justify",
+        "absolute",
+        "potential",
+        "promising",
+        "ideal",
+        "best",
     }
 )
 _PROMPT_REVIEWED_LOWERCASE_PAIRS: frozenset[tuple[str, str]] = frozenset(

--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -9,7 +9,9 @@ from backend.schemas.growth_agent_segment_intent import (
 )
 from backend.schemas.marketing_audience_admission import audience_admission_criterion
 from backend.schemas.marketing_selection_reviewed_analytics import (
+    _REVIEWED_ANALYSIS_PREAMBLE_RE,
     _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS,
+    _REVIEWED_WHY_ASSESSMENT_PREAMBLE_RE,
 )
 
 REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT = (
@@ -36,6 +38,29 @@ REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT = (
     r"eligib(?:le|ility)\s+for\s+(?:an?\s+)?(?:heloc|refi(?:nance)?|home[- ]?equity(?:\s+line)?)|"
     r"timely\s+retention\s+review\s+signal|"
     r"(?:reviewed|eligible)\s+segment\s+membership|"
+    # Modeled potential/upside is the product's own scoring concept
+    # (opportunity score), phrased the way growth leaders ask for it. "the
+    # top 10 borrowers with the highest potential" failed closed as an
+    # unknown criterion (live capture, 2026-08-08).
+    r"(?:the\s+)?(?:absolute\s+)?"
+    r"(?:high(?:est)?|top|strong(?:est)?|great(?:est)?|most|best)?\s*"
+    r"(?:refi(?:nance)?|heloc|growth|opportunity|conversion)?\s*"
+    r"(?:potential|upside)|"
+    # Answer-format adverbials: "recommend the best offer for each with
+    # reasoning" asks for an explained answer, not a selection criterion.
+    # The ambiguous-relationship grammar reads "with <object>" as a
+    # criterion, so the closed adverbial vocabulary lives here (same
+    # capture).
+    r"(?:(?:full|clear|detailed|complete|supporting)\s+)?"
+    r"(?:reasoning|rationale|justifications?|explanations?)|"
+    # Assessment nouns: "evaluate why each borrower is an especially good
+    # candidate" is a why-question about the product's own ranking, but the
+    # declarative co-reference grammar reads "is <X>" as assigning criterion
+    # X. The assessment vocabulary is the product's own ("strong candidate"
+    # already appears in the reviewed analytics shapes). Same capture.
+    r"(?:an?\s+)?(?:especially\s+|particularly\s+|very\s+)?"
+    r"(?:strong|good|great|excellent|prime|ideal|top|promising)\s+"
+    r"(?:candidates?|prospects?|fits?|matches?|opportunit(?:y|ies))|"
     r"(?:fixed|adjustable)[- ]?rate\s+(?:mortgages?|loans?))"
 )
 REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT = (
@@ -582,6 +607,8 @@ def _contains_unreviewed_audience_decision(
 ) -> bool:
     """Require affirmative audience decisions to prove a complete reviewed criterion."""
 
+    clause = _REVIEWED_ANALYSIS_PREAMBLE_RE.sub("", clause, count=1)
+    clause = _REVIEWED_WHY_ASSESSMENT_PREAMBLE_RE.sub("", clause, count=1)
     applied_criterion = _APPLY_CRITERION_WHEN_SELECTING_RE.fullmatch(clause)
     if applied_criterion is not None:
         criterion = _normalize_criterion(applied_criterion.group("criterion"))

--- a/backend/schemas/marketing_selection_reviewed_analytics.py
+++ b/backend/schemas/marketing_selection_reviewed_analytics.py
@@ -136,4 +136,91 @@ _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS: tuple[re.Pattern[str], ...] = (
         r"(?:moved|changed|shifted|trended)(?:\s+(?:recently|over\s+time|this\s+week))?$",
         re.IGNORECASE,
     ),
+    re.compile(
+        # Superlative ranked-shortlist directive ("rank the strongest
+        # candidates for outreach", "pick the very best refinance
+        # candidates", "give me a curated list of the highest-potential
+        # borrowers"). Every slot is a closed alternation — superlatives,
+        # product intents, population nouns, and purposes — so an unknown
+        # criterion cannot ride the shape. Live capture 2026-08-08: the
+        # audience-formation grammar failed this closed as an unreviewed
+        # audience decision, refusing a fundamental deep-analysis ask.
+        r"^(?:and\s+)?(?:rank|pick|surface|identify|find|curate|list|show|give\s+me|"
+        r"determine)\s+(?:me\s+)?"
+        r"(?:a\s+(?:curated\s+)?list\s+of\s+)?(?:the\s+)?"
+        r"(?:very\s+|absolute\s+|single\s+)?"
+        r"(?:top|best|strongest|highest[- ]potential|most\s+promising)\s+"
+        r"(?:[0-9]{1,3}\s+)?(?:potential\s+)?"
+        rf"(?:{_REVIEWED_PRODUCT_INTENT}\s+)?"
+        r"(?:candidates?|borrowers?|leads?|opportunities|prospects?)"
+        r"(?:\s+(?:for\s+(?:outreach|contact|review|follow[- ]up)|to\s+contact))?$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        # Best-offer-per-borrower directive ("recommend the best offer for
+        # each with reasoning", "what the absolute best curated offer for
+        # each would be and why"). The population tokens and the
+        # answer-format tail are closed; free-text criteria fall through to
+        # the strict criterion machine. Same 2026-08-08 live capture.
+        r"^(?:and\s+)?(?:recommend|determine|identify|pick|choose|select|suggest|"
+        r"tell\s+me|what)\s+"
+        r"(?:what\s+)?(?:the\s+)?(?:absolute\s+)?(?:best|ideal|right|optimal)\s+"
+        r"(?:curated\s+|fit\s+)?offers?\s+(?:for|to)\s+(?:each|every)"
+        r"(?:\s+(?:one|borrower|candidate|lead|prospect|customer))?"
+        r"(?:\s+would\s+be)?"
+        r"(?:\s+with\s+(?:full\s+|clear\s+|detailed\s+)?"
+        r"(?:reasoning|rationale|justification|explanations?))?"
+        r"(?:\s*,?\s*and\s+why)?$",
+        re.IGNORECASE,
+    ),
+)
+
+
+_REVIEWED_ANALYSIS_PREAMBLE_RE = re.compile(
+    # Closed analysis preamble ("Analyze the full dataset of eligible
+    # borrowers and <directive>"). Compound clauses defeated the
+    # ``^…$``-anchored reviewed shapes below, so a reviewed directive
+    # prefixed by an analysis framing failed closed (live capture,
+    # 2026-08-08). Every slot is a closed alternation — an unknown
+    # population or criterion does not match, is not stripped, and the
+    # clause still fails closed.
+    r"^(?:"
+    # Scope framing with no verb ("Across the entire portfolio, …").
+    r"across\s+(?:the\s+)?(?:entire|whole|full|current)?\s*"
+    r"(?:portfolio|book|footprint|coverage|datasets?|pipelines?)\s*,\s*"
+    r"|"
+    r"(?:(?:comprehensively|deeply|thoroughly|fully)\s+)?"
+    # Direct verb ("Comprehensively analyze …") or light-verb form
+    # ("Do a deep analysis of …").
+    r"(?:analyze|analyse|review|examine|study|assess|explore|deep[- ]dive(?:\s+into)?|"
+    r"(?:do|run|perform|conduct|complete)\s+(?:a|an)\s+"
+    r"(?:(?:deep|full|comprehensive|complete|thorough)\s+)?"
+    r"(?:analysis|review|assessment|study|deep[- ]dive)\s+of)\s+"
+    r"(?:(?:the|our|this|every|all)\s+)?(?:(?:full|entire|complete|whole)\s+)?"
+    r"(?:(?:eligible|marketing[- ]eligible|reviewed|contact[- ]eligible)\s+)?"
+    r"(?:datasets?|data\s*sets?|data|portfolios?|books?|pipelines?|populations?|"
+    r"borrowers?|leads?|customers?|prospects?|homeowners?)?"
+    r"(?:\s+of\s+(?:(?:all|our|the)\s+)?(?:(?:eligible|marketing[- ]eligible|reviewed|"
+    r"contact[- ]eligible)\s+)?(?:borrowers?|leads?|customers?|prospects?|homeowners?))?"
+    r"\s*,?\s*and\s+"
+    r")",
+    re.IGNORECASE,
+)
+_REVIEWED_WHY_ASSESSMENT_PREAMBLE_RE = re.compile(
+    # Closed why-assessment preamble ("Evaluate why each borrower is an
+    # especially good candidate, and <directive>"). Same compound-clause
+    # problem and the same posture as the analysis preamble above: the
+    # assessment vocabulary is closed, so an unknown criterion inside the
+    # segment does not match, is not stripped, and the clause fails closed.
+    r"^(?:evaluate|explain|justify|assess|describe|tell\s+me|"
+    r"walk\s+(?:me\s+)?through)\s+(?:me\s+)?"
+    r"(?:why\s+(?:each|every)(?:\s+(?:one|borrower|candidate|lead|prospect|customer))?\s+"
+    r"(?:is|would\s+be|makes)\s+(?:an?\s+)?"
+    r"(?:especially\s+|particularly\s+|very\s+)?"
+    r"(?:strong|good|great|excellent|prime|ideal|top|promising)\s+"
+    r"(?:candidate|prospect|fit|match|choice|opportunity)|"
+    r"each\s+selection|"
+    r"the\s+rationale\s+for\s+each(?:\s+(?:one|borrower|candidate|selection))?)"
+    r"\s*,?\s*and\s+",
+    re.IGNORECASE,
 )

--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -102,6 +102,7 @@ from backend.services.repositories.databricks_genie_strategy import (
     _canonical_strategy_board_answer,
 )
 from backend.services.repositories.databricks_genie_sweep import (
+    is_deep_analysis_request,
     run_planned_sweep,
 )
 from backend.services.repositories.databricks_genie_trace import (
@@ -259,6 +260,15 @@ class DatabricksGenieRepository:
                 question,
                 kind=DependencyDownError.KIND_BREAKER_OPEN,
             )
+        if allow_sweep and is_deep_analysis_request(question):
+            # A shortlist + per-item why + offer call is inherently
+            # multi-part; a single governed SQL turn answers it at the depth
+            # of one app screen (live capture, 2026-08-08). Deep asks go to
+            # the live space's own planned decomposition first; an unusable
+            # plan falls through to the normal single-turn path.
+            sweep = run_planned_sweep(self, question, deep=True)
+            if sweep is not None:
+                return sweep
         repaired = False
         try:
             result = self._genie.ask(question, conversation_id=conversation_id)
@@ -318,6 +328,14 @@ class DatabricksGenieRepository:
         breaker_state = self._genie.resilient.breaker.state
         if breaker_state == "open":
             return self._degraded(question, kind=DependencyDownError.KIND_BREAKER_OPEN)
+        if is_deep_analysis_request(question):
+            # Same deep-first routing as :meth:`respond`. The submitted live
+            # message's cost is sunk either way; a usable planned
+            # decomposition is the materially deeper answer, and an unusable
+            # plan falls through to completing the submitted turn.
+            sweep = run_planned_sweep(self, question, deep=True)
+            if sweep is not None:
+                return sweep
         repaired = False
         try:
             result = self._genie.resume_message(conversation_id, message_id)

--- a/backend/services/repositories/databricks_genie_sweep.py
+++ b/backend/services/repositories/databricks_genie_sweep.py
@@ -65,11 +65,81 @@ _SWEEP_MAX_WORKERS = 4
 
 _MIN_PLANNED = 3
 _MAX_PLANNED = 7
+# Deep-analysis asks get the larger plan floor: a shortlist + per-item why +
+# offer call cannot be told in three queries.
+_MIN_PLANNED_DEEP = 5
 
 _PLAN_LINE_RE = re.compile(r"^\s*(?:\d{1,2}[.)]|[-*•])\s+(.{10,240})\s*$")
 
+# Closed signals for "this question demands a multi-part deep analysis".
+# Live capture 2026-08-08: a top-borrowers/why-each/best-offer ask ran as ONE
+# governed SQL turn — the same single query any app screen runs — because the
+# planner only engaged as a policy-blocked rescue. Two or more distinct
+# analytic parts (or an explicit depth request) route to the planner first.
+_DEPTH_EXPLICIT_RE = re.compile(
+    r"\b(?:deep|comprehensive|complete|thorough|full|in[- ]depth|end[- ]to[- ]end)\b"
+    r".{0,40}\b(?:analysis|analyz|analys|review|dive|assessment|picture|study)",
+    re.IGNORECASE,
+)
+_DEPTH_PART_RES: tuple[re.Pattern[str], ...] = (
+    # Ranked shortlist.
+    re.compile(
+        r"\b(?:top|best|strongest|highest[- ]potential|most\s+promising|rank|curated?\s+list)\b",
+        re.IGNORECASE,
+    ),
+    # Per-item rationale.
+    re.compile(
+        r"\b(?:why\s+each|why\s+every|rationale|justif|reasoning|explain\s+why|"
+        r"evaluate\s+why)\b",
+        re.IGNORECASE,
+    ),
+    # Offer recommendation.
+    re.compile(
+        r"\b(?:best|ideal|right|optimal|recommended?|curated)\s+(?:\w+\s+)?offers?\b",
+        re.IGNORECASE,
+    ),
+    # Comparative / portfolio context.
+    re.compile(
+        r"\b(?:compare|versus|vs\.?|stand\s+out|against\s+the|percentile|"
+        r"across\s+the\s+(?:entire\s+)?(?:portfolio|book|population))\b",
+        re.IGNORECASE,
+    ),
+)
 
-def _planning_prompt(question: str) -> str:
+
+def is_deep_analysis_request(question: str) -> bool:
+    """True when the ask is inherently multi-part (shortlist + why + offer)."""
+
+    if _DEPTH_EXPLICIT_RE.search(question):
+        return True
+    parts = sum(1 for pattern in _DEPTH_PART_RES if pattern.search(question))
+    return parts >= 2
+
+
+def _planning_prompt(question: str, *, deep: bool = False) -> str:
+    if deep:
+        # The angles named here are decomposition COVERAGE hints — the live
+        # space still authors the plan, phrases each sub-question, and can
+        # substitute angles its assets answer better. Nothing here injects
+        # criteria; every sub-question re-enters the full guard battery.
+        angle_guidance = (
+            "This is a deep-analysis request, so the plan must go materially "
+            "beyond a single ranked list. Cover, in the sub-questions YOU "
+            "write: (a) the ranked cohort itself with its governed score and "
+            "the underlying signal columns (rate spread, equity, triggers); "
+            "(b) how those top borrowers compare with the whole eligible "
+            "population on the same measures (averages or percentiles, so "
+            "'why these' is provable); (c) the recommended-offer mix for the "
+            "cohort and the signals behind each offer; (d) at least one "
+            "concentration or co-occurrence angle (geography, segments, "
+            "competitor liens, listing status) that a single screen would "
+            "not show. "
+            f"Plan between {_MIN_PLANNED_DEEP} and {_MAX_PLANNED} questions.\n\n"
+        )
+        count_line = ""
+    else:
+        angle_guidance = ""
+        count_line = f"between {_MIN_PLANNED} and {_MAX_PLANNED} of them, "
     return (
         "Plan, do not query: for this message only, do not generate SQL and do "
         "not execute anything. The user asked a broad question that cannot be "
@@ -78,12 +148,13 @@ def _planning_prompt(question: str) -> str:
         "If this is not an analytics request at all — a greeting, a request "
         "for help using the product, or unintelligible input — reply with "
         "exactly NO_PLAN and nothing else.\n\n"
+        f"{angle_guidance}"
         "Otherwise break it into the specific analytics questions YOU judge "
         "most useful, "
         "phrased as neutral read-only analytics (prefer 'top borrowers by "
         "opportunity score' over audience-selection wording like 'eligible "
         "for' or 'characteristics of'), "
-        f"between {_MIN_PLANNED} and {_MAX_PLANNED} of them, each self-contained "
+        f"{count_line}each self-contained "
         "and answerable with one SQL query over your trusted assets. Choose the "
         "angles yourself based on what the question is really asking and which "
         "of your assets can answer it. Reply ONLY with a numbered list, one "
@@ -141,6 +212,8 @@ def _planned_question_guard_hit(question: str) -> str | None:
 def plan_sub_questions(
     repo: DatabricksGenieRepository,
     question: str,
+    *,
+    deep: bool = False,
 ) -> tuple[list[str], list[str]]:
     """Ask the live space to decompose the question; screen what comes back.
 
@@ -148,7 +221,7 @@ def plan_sub_questions(
     """
 
     try:
-        planning_turn = repo.ask_raw(_planning_prompt(question))
+        planning_turn = repo.ask_raw(_planning_prompt(question, deep=deep))
     except Exception:  # noqa: BLE001 - planner failure falls through honestly
         return [], []
     planned_raw = _parse_planned_questions(planning_turn)
@@ -166,19 +239,43 @@ def plan_sub_questions(
     return planned, dropped
 
 
-def _synthesis_prompt(question: str, sections: list[tuple[str, GenieMessageResponse]]) -> str:
+def _synthesis_prompt(
+    question: str,
+    sections: list[tuple[str, GenieMessageResponse]],
+    *,
+    deep: bool = False,
+) -> str:
+    # Deep syntheses weave per-borrower detail across sections, so each
+    # section keeps a larger verified digest to draw from.
+    budget = 700 if deep else 400
     digest_lines = []
     for sub_question, response in sections:
-        snippet = " ".join((response.answer or "").split())[:400]
+        snippet = " ".join((response.answer or "").split())[:budget]
         digest_lines.append(f"- {sub_question} -> {snippet}")
     digest = "\n".join(digest_lines)
+    if deep:
+        ask = (
+            "Write the deep executive synthesis in 8 to 14 sentences, no "
+            "headings. It must do four things, each grounded ONLY in numbers "
+            "that appear in the results above: name the standout borrowers or "
+            "cohort and the figures that put them on top; say why they stand "
+            "out RELATIVE to the wider population (use the comparison "
+            "numbers); state the offer call and the signal behind it; and end "
+            "with the one cross-cutting insight a lender could not read off "
+            "any single screen. If the results above do not support one of "
+            "these, say so rather than inventing it."
+        )
+    else:
+        ask = (
+            "Write the executive synthesis in 4 to 8 sentences: the biggest "
+            "cross-cutting insights and what a lender should act on first. Use "
+            "ONLY numbers that appear in the results above, and no headings."
+        )
     return (
         "Do not generate SQL for this message. Below are the verified results "
         "of the analyses you just ran for the question "
         f'"{question}":\n\n{digest}\n\n'
-        "Write the executive synthesis in 4 to 8 sentences: the biggest "
-        "cross-cutting insights and what a lender should act on first. Use "
-        "ONLY numbers that appear in the results above, and no headings."
+        f"{ask}"
     )
 
 
@@ -186,6 +283,8 @@ def _synthesize_closing(
     repo: DatabricksGenieRepository,
     question: str,
     sections: list[tuple[str, GenieMessageResponse]],
+    *,
+    deep: bool = False,
 ) -> tuple[str | None, str | None]:
     """One live Genie turn writes the cross-section synthesis; verify or omit.
 
@@ -202,7 +301,7 @@ def _synthesize_closing(
     )
 
     try:
-        draft = repo.ask_raw(_synthesis_prompt(question, sections))
+        draft = repo.ask_raw(_synthesis_prompt(question, sections, deep=deep))
     except Exception:  # noqa: BLE001 - synthesis is additive, never blocking
         return None, None
     draft = (draft or "").strip()
@@ -246,17 +345,22 @@ def _labeled_sql(sections: list[tuple[str, GenieMessageResponse]]) -> str | None
 def run_planned_sweep(
     repo: DatabricksGenieRepository,
     question: str,
+    *,
+    deep: bool = False,
 ) -> GenieMessageResponse | None:
     """Plan the decomposition live, execute each sub-question live, assemble.
 
     Returns ``None`` when the plan cannot be formed or fewer than three
     sub-analyses produce governed content — the caller then continues the
-    normal single-turn pipeline, which fails honestly.
+    normal single-turn pipeline, which fails honestly. ``deep`` widens the
+    plan floor and the synthesis contract for deep-analysis asks; the
+    section floor for shipping stays ``_MIN_PLANNED`` so a partly-failed
+    deep run still ships its surviving sections with disclosed gaps.
     """
 
     started = time.monotonic()
-    planned, dropped = plan_sub_questions(repo, question)
-    if len(planned) < _MIN_PLANNED:
+    planned, dropped = plan_sub_questions(repo, question, deep=deep)
+    if len(planned) < (_MIN_PLANNED_DEEP if deep else _MIN_PLANNED):
         return None
 
     def _one(sub_question: str) -> GenieMessageResponse | None:
@@ -300,7 +404,7 @@ def run_planned_sweep(
     body_parts = [intro]
     for sub_question, response in sections:
         body_parts.append(f"**{sub_question}**\n\n{(response.answer or '').strip()}")
-    synthesis, synthesis_gap = _synthesize_closing(repo, question, sections)
+    synthesis, synthesis_gap = _synthesize_closing(repo, question, sections, deep=deep)
     if synthesis:
         body_parts.append(f"**What this adds up to**\n\n{synthesis}")
     elif synthesis_gap:
@@ -313,9 +417,17 @@ def run_planned_sweep(
         GenieReasoningStep(
             kind="orchestrate",
             content=(
-                "The broad question produced no single governed query, so the live "
-                f"space planned its own decomposition: {len(planned)} "
-                "sub-analyses, each executed as its own governed turn."
+                (
+                    "This is a deep-analysis request, so the live space planned "
+                    f"its own decomposition first: {len(planned)} sub-analyses, "
+                    "each executed as its own governed turn."
+                )
+                if deep
+                else (
+                    "The broad question produced no single governed query, so the "
+                    f"live space planned its own decomposition: {len(planned)} "
+                    "sub-analyses, each executed as its own governed turn."
+                )
             ),
         )
     ]

--- a/tests/unit/test_deep_analysis_question_family.py
+++ b/tests/unit/test_deep_analysis_question_family.py
@@ -1,0 +1,127 @@
+"""The deep-analysis question family is answerable on every surface.
+
+Live capture 2026-08-08: the user's flagship ask — "Analyze the full dataset
+of eligible borrowers and find determine a list of absolute top potential
+borrowers. Evaluate why each borrower is an especially good candidate, and
+what the absolute best curated offer for each would be and why." — and close
+paraphrases were refused by four distinct guard defects:
+
+1. The audience-formation grammar failed closed on compound clauses
+   ("Analyze … and <reviewed directive>") because its shapes are ^…$
+   anchored — fixed by the closed analysis/why-assessment preamble strips.
+2. "with reasoning" / "with the highest potential" read as unreviewed
+   selection criteria — fixed by reviewed answer-format/potential vocabulary.
+3. The lowercase name-pair heuristics read ("and","find") and
+   ("determine","list") as borrower names — fixed by conjunction
+   transparency plus the closed analytics-verb skip list.
+4. "the best offer for each with reasoning" read ("each","with") as a
+   contextual borrower name — fixed by the distributive-determiner safe
+   tokens.
+
+These pins hold the family open on Ask Genie (protected/planner matchers)
+and both co-pilot surfaces. The companion must-refuse pins prove the fixes
+are enumerated vocabulary, not weakened detectors.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+import backend.services.genie_prompt_guardrails as prompt_guardrails
+from backend.schemas.agent_plan import ComposePlanRequest
+from backend.schemas.growth_agent import GrowthAgentPromptRunRequest
+from backend.schemas.growth_agent_refusal import growth_prompt_refusal_from_errors
+from backend.services.genie_message_policy import (
+    identity_prompt_match,
+    protected_prompt_match,
+)
+from backend.services.repositories.databricks_genie_sweep import (
+    _planned_question_guard_hit,
+)
+
+USER_EXACT = (
+    "Analyze the full dataset of eligible borrowers and find determine a list of "
+    "absolute top potential borrowers. Evaluate why each borrower is an especially "
+    "good candidate, and what the absolute best curated offer for each would be and why."
+)
+
+_MUST_ALLOW = (
+    USER_EXACT,
+    "Analyze the full dataset of eligible borrowers and determine a list of the "
+    "absolute top potential borrowers. Evaluate why each borrower is an especially "
+    "good candidate, and recommend the best offer for each with reasoning.",
+    "Do a deep analysis of our eligible borrowers and identify the top 10 borrowers "
+    "with the highest potential. Explain why each one is a strong candidate, and "
+    "determine the ideal offer for each borrower.",
+    "Comprehensively analyze every eligible borrower and rank the strongest "
+    "candidates for outreach. Justify each selection, and tell me which offer fits "
+    "each borrower best and why.",
+    "Across the entire portfolio, pick the very best refinance candidates. Walk "
+    "through the rationale for each, and what the absolute best curated offer for "
+    "each would be and why.",
+    "give me a curated list of the highest-potential borrowers.",
+    "surface the most promising borrowers.",
+    "rank the strongest candidates for outreach.",
+    "identify the top 10 borrowers with the highest potential.",
+    "Recommend the best offer for each borrower with reasoning.",
+)
+
+# The same mechanisms, one unreviewed token swapped in. Refusal here proves
+# the fixes are enumerated vocabulary rather than weakened fail-closed
+# defaults: the preambles do not strip unknown populations or assessments,
+# the analytics shapes do not admit unknown intents, and the name-pair
+# conjunction transparency still extracts real name pairs.
+_MUST_STILL_REFUSE = (
+    "Call borrowers and quorla zembrix for a refi review.",
+    "Determine zembrix quorla for outreach.",
+    "Do a deep analysis of diabetic borrowers and pick the best candidates.",
+    "Rank the strongest zyrplax candidates for outreach.",
+    "Pick the very best eczema candidates.",
+    "Identify the top 10 borrowers with eczema.",
+    "Recommend the best offer for each diabetic borrower.",
+    "Rank borrowers by race for our next campaign.",
+    "Which zyrplax borrowers are eligible for a HELOC?",
+)
+
+
+def _genie_screens(question: str) -> dict[str, str]:
+    hits: dict[str, str] = {}
+    for name, fn in (
+        ("protected", protected_prompt_match),
+        ("identity", identity_prompt_match),
+        ("pii", prompt_guardrails.pii_prompt_match),
+        ("override", prompt_guardrails.instruction_override_prompt_match),
+        ("scope", prompt_guardrails.scope_bypass_prompt_match),
+        ("cross_lender", prompt_guardrails.cross_lender_prompt_match),
+        ("planner", _planned_question_guard_hit),
+    ):
+        result = fn(question)
+        if result:
+            hits[name] = str(result)
+    return hits
+
+
+@pytest.mark.parametrize("question", _MUST_ALLOW)
+def test_deep_analysis_family_passes_genie_screens(question: str) -> None:
+    assert _genie_screens(question) == {}, question
+
+
+@pytest.mark.parametrize("question", _MUST_ALLOW)
+def test_deep_analysis_family_passes_copilot_guards(question: str) -> None:
+    prompt = question[:500]
+    assert GrowthAgentPromptRunRequest(prompt=prompt).prompt
+    assert ComposePlanRequest(objective=prompt, execute=False).objective
+
+
+@pytest.mark.parametrize("question", _MUST_STILL_REFUSE)
+def test_swapped_token_variants_still_refuse(question: str) -> None:
+    genie_hit = bool(_genie_screens(question))
+    try:
+        GrowthAgentPromptRunRequest(prompt=question)
+        growth_refused = False
+    except ValidationError as exc:
+        growth_refused = True
+        refusal = growth_prompt_refusal_from_errors(exc.errors())
+        assert refusal is not None, question
+    assert genie_hit or growth_refused, question

--- a/tests/unit/test_genie_full_analysis_sweep.py
+++ b/tests/unit/test_genie_full_analysis_sweep.py
@@ -13,6 +13,7 @@ from backend.services.genie_answers import GenieMessageResponse, GenieProof
 from backend.services.repositories.databricks_genie_sweep import (
     _parse_planned_questions,
     _planned_question_guard_hit,
+    is_deep_analysis_request,
     run_planned_sweep,
 )
 
@@ -157,3 +158,53 @@ def test_sweep_returns_none_when_plan_unusable() -> None:
 def test_sweep_returns_none_when_too_few_sections_survive() -> None:
     repo = _StubRepo(failures=frozenset({"in-the-money", "states", "lead population"}))
     assert run_planned_sweep(repo, _USER_QUESTION) is None  # type: ignore[arg-type]
+
+
+_DEEP_QUESTION = (
+    "Analyze the full dataset of eligible borrowers and find determine a list of "
+    "absolute top potential borrowers. Evaluate why each borrower is an especially "
+    "good candidate, and what the absolute best curated offer for each would be and why."
+)
+
+_DEEP_PLAN_TEXT = """1. Which borrowers have the highest opportunity scores and what are their rate spreads and equity percentages?
+2. How do the top borrowers compare with the whole eligible population on rate spread and equity?
+3. What is the recommended-offer mix for the top borrowers?
+4. Which states and segments concentrate the top borrowers?
+5. How many top borrowers carry competitor liens or active listings?"""
+
+
+def test_is_deep_analysis_request_classifies_the_family() -> None:
+    assert is_deep_analysis_request(_DEEP_QUESTION)
+    assert is_deep_analysis_request(
+        "Do a deep analysis of our eligible borrowers and rank the top candidates."
+    )
+    # Two analytic parts without explicit depth wording.
+    assert is_deep_analysis_request(
+        "Rank the top borrowers and recommend the best offer for each."
+    )
+    # Single-part asks stay on the single-turn path.
+    assert not is_deep_analysis_request("How many in-the-money borrowers are in TX?")
+    assert not is_deep_analysis_request("Show borrowers by state.")
+    assert not is_deep_analysis_request("What is the average equity percentage?")
+
+
+def test_deep_sweep_uses_deep_plan_floor_and_synthesis() -> None:
+    repo = _StubRepo(plan_text=_DEEP_PLAN_TEXT)
+    result = run_planned_sweep(repo, _DEEP_QUESTION, deep=True)  # type: ignore[arg-type]
+
+    assert result is not None
+    assert result.source == "genie"
+    # The deep planning prompt demands the comparison/offer/concentration
+    # coverage and the wider plan floor.
+    assert "deep-analysis request" in repo.raw_prompts[0]
+    assert "between 5 and 7" in repo.raw_prompts[0]
+    # The deep synthesis contract replaces the generic one.
+    assert "deep executive synthesis" in repo.raw_prompts[1]
+    assert len(repo.calls) == 5
+    assert all(allow_sweep is False for _, allow_sweep in repo.calls)
+
+
+def test_deep_sweep_requires_the_deeper_plan() -> None:
+    # A three-line plan is enough for a rescue sweep but not for a deep ask.
+    repo = _StubRepo()
+    assert run_planned_sweep(repo, _DEEP_QUESTION, deep=True) is None  # type: ignore[arg-type]


### PR DESCRIPTION
User report (2026-08-08): Genie refused questions like *"Analyze the full dataset of eligible borrowers and determine a list of absolute top potential borrowers. Evaluate why each borrower is an especially good candidate, and what the absolute best curated offer for each would be and why."* — and when such questions did answer, the analysis was no deeper than any single app screen.

## 1. Guards: the family opened by closed vocabulary, not weakened detectors

A 1,125-paraphrase sweep of this family refused **45% on Ask Genie and 91% on the co-pilot** (the user's exact sentence refused on the co-pilot). Four captured defects:

| Defect | Fix |
|---|---|
| Compound clauses ("Analyze … **and** \<reviewed directive\>") defeated the `^…$`-anchored audience-formation shapes | Closed **analysis/why-assessment preamble strips** — unknown populations/assessments don't match, aren't stripped, still fail closed |
| "with reasoning" / "with the highest potential" read as unreviewed selection criteria | Reviewed **potential / assessment / answer-format vocabulary** in the mortgage-attribute fragment |
| ("and","find") / ("determine","list") read as borrower names | **Conjunction transparency** in the after-group pair regex + closed analytics-verb skip list, mirrored into the action-context alternation so verb+name+name stays caught |
| ("each","with") read as a contextual borrower name | Distributive determiners in the safe first tokens |

Plus two closed reviewed-analytics shapes (superlative shortlist, best-offer-per-borrower). The preamble grammars live in `marketing_selection_reviewed_analytics` to keep the criterion machine under the size gate.

**Verification:** sweep now passes **1,125/1,125 on both surfaces**. A **23,535-string differential** against the previous implementation shows **zero refuse/allow flips in either direction**. Swapped-token variants — "Rank the strongest **zyrplax** candidates", "Identify the top 10 borrowers with **eczema**", "Call borrowers and **quorla zembrix**", "Rank borrowers **by race**" — all still refuse, pinned in `tests/unit/test_deep_analysis_question_family.py` beside the must-allow family.

Known pre-existing gaps (unchanged by this PR, verified present on HEAD): "Analyze the full dataset of zyrplax **carriers** and rank them" passes both surfaces because the criterion grammar doesn't know "carriers" as a population noun.

## 2. Depth: deep asks route to the planned decomposition first

The multi-part planner (`run_planned_sweep`) only engaged as a policy-blocked **rescue** — so a successful deep ask got one governed SQL turn, i.e. exactly what any app screen shows. Now:

- `is_deep_analysis_request` (closed heuristic: explicit depth wording, or ≥2 analytic parts among ranked-shortlist / per-item-why / offer-call / comparative) routes to the live space's **own planned decomposition before the single-turn path**, on both sync and async lifecycles.
- Deep plans have a **5–7 sub-analysis floor** and coverage guidance: cohort signals, population comparison (so "why these" is provable with numbers), offer mix, and one concentration/co-occurrence angle no single screen shows. The space still authors the plan; every sub-question re-enters the full guard battery.
- A **structured deep synthesis** contract: standouts with figures, relative context, the offer call, one cross-cutting insight — verified against the sections' returned rows by the existing claims verifier, omitted with a disclosed gap if unverifiable.
- Honest process trace for the deep-first path (it no longer claims the single query failed).

Live-first throughout: Genie's own governed SQL, rows, and narrative are the answer; nothing is overlaid or authored server-side.

## Validation

- `pytest tests/unit` — exit 0, 0 failures (full suite over the complete change)
- 1,125-paraphrase sweep — 0 refusals on both surfaces
- 23,535-string differential vs HEAD — 0 flips
- `ruff`, `tools/check_file_sizes.py`, `tools/verify_scaffold.py` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)