### PR TITLE
fix/state zip drill

### DIFF
--- a/backend/api/geo.py
+++ b/backend/api/geo.py
@@ -11,10 +11,14 @@ given state, backed by ``mip.gold.county_rollup``. The UI lazy-fetches
 when the user drills into a state; counties not present in the payload
 render "—" (honest null).
 
-/api/geo/zip-rollups?county_fips=NNNNN — per-ZIP aggregates within a county
-(5-char FIPS), backed by ``mip.gold.zip_rollup``. Each row carries a
-stable ``sample_borrower_id`` so the UI's ZIP-tile click-through deep-
-links to a real borrower dossier.
+/api/geo/zip-rollups?state=XX — per-ZIP aggregates within a state, backed
+by ``mip.gold.zip_rollup``. Each row carries a stable
+``sample_borrower_id`` so the UI's ZIP-tile click-through deep-links to a
+real borrower dossier. This is the drill the map uses: the Cotality share
+carries exactly one county FIPS per state, so ``county_fips_5`` is NULL on
+every gold row and a county-keyed drill dead-ends. ``?county_fips=NNNNN``
+is still accepted (and returns [] today) so a licensed county dataset can
+light the county grain back up without a contract change.
 """
 from typing import Annotated, Literal
 
@@ -267,7 +271,10 @@ def assignment_overlay(
             min_length=2,
             max_length=2,
             pattern=r"^[A-Za-z]{2}$",
-            description="2-char USPS state code. Required when level=county.",
+            description=(
+                "2-char USPS state code. Required when level=county; the "
+                "live key when level=zip."
+            ),
         ),
     ] = None,
     county_fips: Annotated[
@@ -277,7 +284,10 @@ def assignment_overlay(
             min_length=5,
             max_length=5,
             pattern=r"^\d{5}$",
-            description="5-char county FIPS. Required when level=zip.",
+            description=(
+                "5-char county FIPS. Alternative key when level=zip, "
+                "reserved for licensed county data."
+            ),
         ),
     ] = None,
 ) -> GeoAssignmentOverlayResponse:
@@ -293,8 +303,14 @@ def assignment_overlay(
     """
     if level == "county" and not state:
         raise HTTPException(status_code=422, detail="state is required when level=county")
-    if level == "zip" and not county_fips:
-        raise HTTPException(status_code=422, detail="county_fips is required when level=zip")
+    if level == "zip" and bool(state) == bool(county_fips):
+        # Same XOR contract as /zip-rollups: the ZIP layer is drilled from a
+        # state now that the share carries no usable county grain, and the
+        # overlay must key on the same unit as the tiles it recolors.
+        raise HTTPException(
+            status_code=422,
+            detail="exactly one of state or county_fips is required when level=zip",
+        )
     try:
         return service.overlay(level, state=state, county_fips=county_fips)
     except LakebaseError as exc:
@@ -309,16 +325,32 @@ def assignment_overlay(
 @router.get("/zip-rollups", response_model=ZipRollupResponse)
 def zip_rollups(
     repo: RepoDep,
+    state: Annotated[
+        str | None,
+        Query(
+            min_length=2,
+            max_length=2,
+            pattern=r"^[A-Za-z]{2}$",
+            description=(
+                "2-char USPS state code (uppercased server-side). The live "
+                "ZIP drill key. Mutually exclusive with county_fips."
+            ),
+        ),
+    ] = None,
     county_fips: Annotated[
-        str,
+        str | None,
         Query(
             alias="county_fips",
             min_length=5,
             max_length=5,
             pattern=r"^\d{5}$",
-            description="5-char county FIPS (2-char state + 3-char county).",
+            description=(
+                "5-char county FIPS (2-char state + 3-char county). Reserved "
+                "for licensed county data; returns [] against the current "
+                "share. Mutually exclusive with state."
+            ),
         ),
-    ],
+    ] = None,
     segment_codes: Annotated[
         str | None,
         Query(
@@ -351,15 +383,29 @@ def zip_rollups(
     consent_status: Annotated[str | None, Query(alias="consent_status", max_length=32)] = None,
     recency: Annotated[str | None, Query(alias="recency", max_length=32)] = None,
 ) -> ZipRollupResponse:
-    """Return per-ZIP rollups for the given county FIPS.
+    """Return per-ZIP rollups for the given state, or for a county FIPS.
+
+    Exactly one key is required — 422 when both or neither are supplied,
+    because a request that names two geographies has no single honest
+    answer and a request that names none would scan the country.
+
+    ``state`` is the drill the map uses. ``county_fips`` is kept for a
+    future licensed county dataset; against the current Cotality share it
+    returns an empty list for every county, since the share carries one
+    county FIPS per state and ``mip.gold.zip_rollup.county_fips_5`` is
+    NULL on every row.
 
     Each ZIP carries a stable-ranked ``sample_borrower_id`` so the UI's
     ZIP-tile click-through can deep-link to ``/borrower-360/<id>``.
-    Empty list when the county has no rollup rows (county outside the current
-    Cotality-backed coverage or CTAS hasn't run).
     """
+    if bool(state) == bool(county_fips):
+        raise HTTPException(
+            status_code=422,
+            detail="exactly one of state or county_fips is required",
+        )
     return repo.zip_rollups(
         county_fips,
+        state=state.upper() if state else None,
         segment_codes=_parse_segment_codes(segment_codes),
         segment_mode=_parse_segment_mode(segment_mode),
         portfolio_criteria=_portfolio_criteria_from_geo_query(

--- a/backend/schemas/geo.py
+++ b/backend/schemas/geo.py
@@ -121,8 +121,17 @@ class ZipRollup(BaseModel):
 
 
 class ZipRollupResponse(BaseModel):
-    """Wire envelope — list of ZIPs for a given county FIPS + snapshot date."""
+    """Wire envelope — list of ZIPs for the requested key + snapshot date.
 
-    fips_5: str = Field(min_length=5, max_length=5)
+    Exactly one of ``state`` / ``fips_5`` is populated, echoing whichever
+    key the caller asked with. The state key is the drill the UI uses:
+    the Cotality share carries a single county FIPS per state, so
+    ``county_fips_5`` is NULL on every ``mip.gold.zip_rollup`` row and a
+    county-keyed request legitimately returns zero rollups. The FIPS key
+    stays on the contract for a future licensed county dataset.
+    """
+
+    fips_5: str | None = Field(default=None, min_length=5, max_length=5)
+    state: str | None = Field(default=None, min_length=2, max_length=2)
     rollups: list[ZipRollup]
     snapshot_date: str | None = None

--- a/backend/services/geo_assignment_overlay.py
+++ b/backend/services/geo_assignment_overlay.py
@@ -13,6 +13,11 @@ Combines the two live systems of record the platform already trusts:
   (county FIPS in ``coverage_counties``, or the unit's state in
   ``coverage_states``); no geometry.
 
+The ZIP level is keyed on ``state`` (2026-08-08): the Cotality share
+carries one county FIPS per state, so ``county_fips_5`` is NULL across
+``borrower_360`` and a FIPS-keyed ZIP overlay would recolor nothing. The
+FIPS key is still accepted for a future licensed county dataset.
+
 ``unattended = lead_count - assigned_count`` is non-negative by
 construction: the assigned side only counts borrowers that are ALSO in
 the unit's marketing-eligible lead set, so an assignment held by a
@@ -189,6 +194,21 @@ class GeoAssignmentOverlayService:
         "GROUP BY zip"
     )
 
+    # 2026-08-08: the ZIP layer is drilled from a STATE — the share carries
+    # one county FIPS per state, so `county_fips_5` is NULL on every
+    # borrower_360 row and the FIPS-keyed query above returns nothing. The
+    # state projection is a literal, not ANY_VALUE, because the WHERE
+    # clause pins it.
+    _LEAD_ZIP_BY_STATE_SQL = (
+        "SELECT zip AS unit_id, CAST(COUNT(*) AS INT) AS lead_count, "
+        "  :state AS state "
+        f"FROM {qualify('gold', 'borrower_360')} "
+        "WHERE marketing_eligible = TRUE "
+        "  AND state = :state "
+        "  AND zip IS NOT NULL AND LENGTH(zip) = 5 "
+        "GROUP BY zip"
+    )
+
     # Active assignments only: released rows are history, not workload.
     _ASSIGNED_BORROWERS_SQL = (
         "SELECT DISTINCT borrower_id FROM mip_app.lead_assignments "
@@ -272,6 +292,8 @@ class GeoAssignmentOverlayService:
             rows = self._sql.execute(self._LEAD_STATE_SQL) or []
         elif level == "county":
             rows = self._sql.execute(self._LEAD_COUNTY_SQL, {"state": state}) or []
+        elif state:
+            rows = self._sql.execute(self._LEAD_ZIP_BY_STATE_SQL, {"state": state}) or []
         else:
             rows = self._sql.execute(self._LEAD_ZIP_SQL, {"fips_5": county_fips}) or []
         counts: dict[str, int] = {}
@@ -342,9 +364,17 @@ class GeoAssignmentOverlayService:
             if row_state != (state or "") or len(row_fips) != 5:
                 return None
             return row_fips
-        if row_fips != (county_fips or "") or len(row_zip) != 5:
+        # ZIP level: the unit is the ZIP, scoped by whichever key was
+        # drilled. State is the live key; FIPS is reserved for licensed
+        # county data. Neither key means nothing to scope against, so the
+        # row is dropped rather than counted into an unbounded overlay.
+        if len(row_zip) != 5:
             return None
-        return row_zip
+        if county_fips:
+            return row_zip if row_fips == county_fips else None
+        if state:
+            return row_zip if row_state == state else None
+        return None
 
     def _active_officers(self) -> list[CoverageOfficer]:
         rows = self._lakebase.fetchall(self._OFFICERS_SQL, limit=1_000)

--- a/backend/services/repositories/databricks_geo.py
+++ b/backend/services/repositories/databricks_geo.py
@@ -246,8 +246,9 @@ class DatabricksGeoRepository:
       ``StateRollup.top_segment_code`` extension.
     * ``mip.gold.county_rollup`` -- filtered to the given state at the
       latest snapshot.
-    * ``mip.gold.zip_rollup`` -- filtered to the given county FIPS at
-      the latest snapshot.
+    * ``mip.gold.zip_rollup`` -- filtered to the given state (the live
+      drill) or county FIPS (reserved for licensed county data) at the
+      latest snapshot.
 
     Short-TTL cached (60s default) per-method so a presenter clicking
     between segment-intelligence and home pays one warehouse round-trip
@@ -326,7 +327,13 @@ class DatabricksGeoRepository:
         "ORDER BY addressable_borrowers DESC"
     )
 
-    _ZIP_SQL = (
+    # 2026-08-08: the ZIP layer is keyed on STATE, not county. The Cotality
+    # share carries exactly one county FIPS per state (audit C2), so the
+    # fabricated county keys were removed and `county_fips_5` is NULL on
+    # every zip_rollup row — a county-keyed read returns zero rows for every
+    # county, always. `_ZIP_SQL` (FIPS-keyed) stays for a future licensed
+    # county dataset; `_ZIP_STATE_SQL` is what the map actually drills.
+    _ZIP_SELECT = (
         "SELECT "
         "  zip, "
         "  state, "
@@ -337,10 +344,15 @@ class DatabricksGeoRepository:
         "  sample_borrower_id, "
         "  snapshot_date "
         f"FROM {qualify('gold', 'zip_rollup')} "
-        "WHERE county_fips_5 = :fips_5 "
+    )
+    _ZIP_SNAPSHOT_AND_ORDER = (
         f"  AND snapshot_date = (SELECT MAX(snapshot_date) FROM {qualify('gold', 'zip_rollup')}) "
         "ORDER BY addressable_borrowers DESC"
     )
+
+    _ZIP_SQL = _ZIP_SELECT + "WHERE county_fips_5 = :fips_5 " + _ZIP_SNAPSHOT_AND_ORDER
+
+    _ZIP_STATE_SQL = _ZIP_SELECT + "WHERE state = :state " + _ZIP_SNAPSHOT_AND_ORDER
 
     _STATE_CACHE_KEY = "geo.state_rollups"
     _SCOPE_CACHE_KEY = "geo.scope"
@@ -447,7 +459,10 @@ class DatabricksGeoRepository:
         "    opportunity_score, "
         "    segment_codes "
         f"  FROM {qualify('gold', 'borrower_360')} "
-        "  WHERE county_fips_5 = :fips_5 "
+        # {geo_predicate} is `state = :state` (the live drill) or
+        # `county_fips_5 = :fips_5` (reserved for licensed county data).
+        # Both sides are repo-owned literals — never caller text.
+        "  WHERE {geo_predicate} "
         "    AND zip IS NOT NULL "
         "    AND LENGTH(zip) = 5 "
         "    AND {filter_clause} "
@@ -781,26 +796,39 @@ class DatabricksGeoRepository:
 
     def zip_rollups(
         self,
-        fips_5: str,
+        fips_5: str | None = None,
         segment_codes: list[str] | None = None,
         segment_mode: str = "any",
         portfolio_criteria: PortfolioCriteria | None = None,
+        *,
+        state: str | None = None,
     ) -> ZipRollupResponse:
-        """Fetch per-ZIP rollups for the given 5-char county FIPS."""
-        normalised = str(fips_5 or "")[:5]
+        """Fetch per-ZIP rollups keyed by state (live) or county FIPS.
+
+        Callers pass exactly one key. ``state`` is the drill the map uses
+        — ``mip.gold.zip_rollup`` is grained on state + ZIP and its
+        ``county_fips_5`` is NULL for every row in the current Cotality
+        share, so a FIPS-keyed read returns nothing. ``fips_5`` stays
+        wired for a future licensed county dataset.
+        """
+        normalised_state = str(state or "").upper()[:2]
+        normalised_fips = str(fips_5 or "")[:5]
+        by_state = bool(normalised_state)
+        # Distinct cache grains: `state:WA` can never collide with a FIPS.
+        grain = f"state:{normalised_state}" if by_state else f"fips:{normalised_fips}"
         normalised_segments = self._normalise_geo_segments(segment_codes)
         use_filtered_path = bool(normalised_segments) or portfolio_criteria is not None
         portfolio_key = self._portfolio_cache_key(portfolio_criteria)
         cache_key = (
             self._filtered_geo_cache_key(
                 "geo.zip_rollups",
-                normalised,
+                grain,
                 segment_codes=normalised_segments,
                 segment_mode=segment_mode,
             )
             + f":{portfolio_key}"
             if use_filtered_path
-            else f"geo.zip_rollups:{normalised}"
+            else f"geo.zip_rollups:{grain}"
         )
         def build() -> ZipRollupResponse:
             if use_filtered_path:
@@ -809,13 +837,21 @@ class DatabricksGeoRepository:
                     segment_mode=segment_mode,
                     portfolio_criteria=portfolio_criteria,
                 )
-                params["fips_5"] = normalised
+                if by_state:
+                    params["state"] = normalised_state
+                else:
+                    params["fips_5"] = normalised_fips
                 sql = self._ZIP_FILTER_SQL_TPL.format(
+                    geo_predicate="state = :state" if by_state else "county_fips_5 = :fips_5",
                     filter_clause=filter_clause,
                 )
                 rows = self._client.execute(sql, params) or []
+            elif by_state:
+                rows = self._client.execute(
+                    self._ZIP_STATE_SQL, {"state": normalised_state}
+                ) or []
             else:
-                rows = self._client.execute(self._ZIP_SQL, {"fips_5": normalised}) or []
+                rows = self._client.execute(self._ZIP_SQL, {"fips_5": normalised_fips}) or []
             rollups = [
                 ZipRollup(
                     zip=str(r.get("zip") or "")[:5],
@@ -838,7 +874,8 @@ class DatabricksGeoRepository:
                 raw = rows[0].get("snapshot_date")
                 snapshot_date = str(raw) if raw is not None else None
             return ZipRollupResponse(
-                fips_5=normalised,
+                fips_5=None if by_state else normalised_fips,
+                state=normalised_state or None,
                 rollups=rollups,
                 snapshot_date=snapshot_date,
             )

--- a/backend/services/repositories/protocols.py
+++ b/backend/services/repositories/protocols.py
@@ -341,8 +341,9 @@ class GeoRepository(Protocol):
       given state at the latest snapshot_date, or ``mip.gold.borrower_360``
       when a segment filter is active.
     * ``zip_rollups`` — ``mip.gold.zip_rollup`` filtered to the given
-      5-char county FIPS at the latest snapshot_date, or ``mip.gold.borrower_360``
-      when a segment filter is active.
+      2-char state (the live drill) or 5-char county FIPS (reserved for
+      licensed county data) at the latest snapshot_date, or
+      ``mip.gold.borrower_360`` when a segment filter is active.
 
     Every method returns a structured response with ``snapshot_date``
     so the UI can show a "data as of YYYY-MM-DD" provenance chip.
@@ -379,10 +380,12 @@ class GeoRepository(Protocol):
 
     def zip_rollups(
         self,
-        fips_5: str,
+        fips_5: str | None = None,
         segment_codes: list[str] | None = None,
         segment_mode: str = "any",
         portfolio_criteria: PortfolioCriteria | None = None,
+        *,
+        state: str | None = None,
     ) -> ZipRollupResponse:
         ...
 

--- a/frontend/src/components/mortgage/USChoroplethMap.render.test.tsx
+++ b/frontend/src/components/mortgage/USChoroplethMap.render.test.tsx
@@ -7,7 +7,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { USChoroplethMap } from './USChoroplethMap';
-import type { CountyRollupResponse, StateRollupResponse } from '../../types';
+import type { StateRollupResponse, ZipRollupResponse } from '../../types';
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -57,48 +57,70 @@ async function waitForSelector<T extends Element>(selector: string): Promise<T |
   return node;
 }
 
-const COUNTY_TOPOLOGY = {
-  type: 'Topology',
-  transform: { scale: [1, 1], translate: [0, 0] },
-  objects: {
-    counties: {
-      type: 'GeometryCollection',
-      geometries: [
-        { type: 'Polygon', id: '17031', properties: { name: 'Cook' }, arcs: [[0]] },
-        { type: 'Polygon', id: '17043', properties: { name: 'DuPage' }, arcs: [[1]] },
-      ],
+const IL_ZIP_ROLLUPS: ZipRollupResponse = {
+  state: 'IL',
+  fips_5: null,
+  snapshot_date: '2026-08-07',
+  rollups: [
+    {
+      zip: '60611',
+      state: 'IL',
+      county_fips_5: null,
+      addressable_borrowers: 94,
+      avg_opportunity_score: 94,
+      top_segment_code: 'itm',
+      sample_borrower_id: 'B-0000000000001',
     },
-  },
-  arcs: [
-    [[0, 0], [10, 0], [0, 10], [-10, -10]],
-    [[20, 0], [10, 0], [0, 10], [-10, -10]],
+    {
+      zip: '60647',
+      state: 'IL',
+      county_fips_5: null,
+      addressable_borrowers: 0,
+      avg_opportunity_score: 0,
+      top_segment_code: null,
+      sample_borrower_id: null,
+    },
   ],
 };
 
-describe('USChoroplethMap county visual states', () => {
+function stateRollupPayload(zipUnassigned = 0): StateRollupResponse {
+  return {
+    rollups: [
+      {
+        state: 'IL',
+        addressable: 10,
+        in_the_money: 4,
+        top_tier_opportunities: 2,
+        avg_score: 78,
+        zip_unassigned_count: zipUnassigned,
+        top_segment_code: 'itm',
+      },
+    ],
+    snapshot_date: '2026-06-19',
+  };
+}
+
+async function drillIntoIllinois(): Promise<void> {
+  const illinois = await waitForSelector<SVGPathElement>('path[aria-label="Illinois"]');
+  expect(illinois).toBeTruthy();
+  for (let i = 0; i < 80 && !illinois?.classList.contains('has-data'); i += 1) {
+    await settle();
+    await new Promise((resolve) => window.setTimeout(resolve, 5));
+  }
+  await act(async () => {
+    illinois?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+  await settle();
+}
+
+describe('USChoroplethMap state -> ZIP drill', () => {
   let root: Root;
-  let countyRollups: ReturnType<typeof deferred<CountyRollupResponse>>;
-  const loadCountyTopology = () => Promise.resolve(COUNTY_TOPOLOGY);
 
   beforeEach(() => {
     document.body.innerHTML = '<div id="root"></div>';
     root = createRoot(document.getElementById('root') as HTMLElement);
-    countyRollups = deferred<CountyRollupResponse>();
-    apiMocks.stateRollups.mockResolvedValue({
-      rollups: [
-        {
-          state: 'IL',
-          addressable: 10,
-          in_the_money: 4,
-          top_tier_opportunities: 2,
-          avg_score: 78,
-          top_segment_code: 'itm',
-        },
-      ],
-      snapshot_date: '2026-06-19',
-    } satisfies StateRollupResponse);
-    apiMocks.countyRollups.mockReturnValue(countyRollups.promise);
-    apiMocks.zipRollups.mockResolvedValue({ rollups: [], refreshed_at: null });
+    apiMocks.stateRollups.mockResolvedValue(stateRollupPayload());
+    apiMocks.zipRollups.mockResolvedValue(IL_ZIP_ROLLUPS);
   });
 
   afterEach(() => {
@@ -113,7 +135,7 @@ describe('USChoroplethMap county visual states', () => {
     await act(async () => {
       root.render(
         <MemoryRouter>
-          <USChoroplethMap countyTopologyLoader={loadCountyTopology} />
+          <USChoroplethMap />
         </MemoryRouter>,
       );
     });
@@ -127,19 +149,7 @@ describe('USChoroplethMap county visual states', () => {
     expect(document.querySelector('[role="status"]')?.textContent).toContain('Loading state borrower rollups');
 
     await act(async () => {
-      stateRollups.resolve({
-        rollups: [
-          {
-            state: 'IL',
-            addressable: 10,
-            in_the_money: 4,
-            top_tier_opportunities: 2,
-            avg_score: 78,
-            top_segment_code: 'itm',
-          },
-        ],
-        snapshot_date: '2026-06-19',
-      });
+      stateRollups.resolve(stateRollupPayload());
     });
     await settle();
 
@@ -149,89 +159,70 @@ describe('USChoroplethMap county visual states', () => {
     expect(document.querySelector('[role="status"]')?.textContent).toContain('Geography rollups loaded');
   });
 
-  it('distinguishes county rollup loading, positive data, and empty counties', async () => {
+  it('drills a state straight to its ZIP tiles, skipping any county level', async () => {
     await act(async () => {
       root.render(
         <MemoryRouter>
-          <USChoroplethMap
-            segmentFilter={['itm', 'equity']}
-            segmentFilterMode="any"
-            countyTopologyLoader={loadCountyTopology}
-          />
+          <USChoroplethMap segmentFilter={['itm', 'equity']} segmentFilterMode="any" />
         </MemoryRouter>,
       );
     });
-    const illinois =
-      (await waitForSelector<SVGPathElement>('path[aria-label="Illinois"]'))
-      ?? (await waitForSelector<SVGPathElement>('path[aria-label="IL"]'));
-    expect(illinois).toBeTruthy();
-    for (let i = 0; i < 80 && !illinois?.classList.contains('has-data'); i += 1) {
-      await settle();
-      await new Promise((resolve) => window.setTimeout(resolve, 5));
-    }
-    expect(illinois?.classList.contains('has-data')).toBe(true);
-    const currentIllinois =
-      document.querySelector<SVGPathElement>('path[aria-label="Illinois"]')
-      ?? document.querySelector<SVGPathElement>('path[aria-label="IL"]');
-    expect(currentIllinois).toBeTruthy();
-    await act(async () => {
-      currentIllinois?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    const cookLoading = await waitForSelector<SVGPathElement>('path[aria-label="Cook County"]');
-    expect(cookLoading).toBeTruthy();
-    expect(cookLoading?.classList.contains('is-loading')).toBe(true);
-    expect(cookLoading?.classList.contains('lvl-1')).toBe(false);
+    await drillIntoIllinois();
 
-    await act(async () => {
-      countyRollups.resolve({
-        rollups: [
-          {
-            fips_5: '17031',
-            state: 'IL',
-            county_name: 'Cook',
-            addressable_borrowers: 1,
-            in_the_money_borrowers: 1,
-            high_opportunity_borrowers: 1,
-            avg_opportunity_score: 79,
-            top_segment_code: 'itm',
-          },
-          {
-            fips_5: '17043',
-            state: 'IL',
-            county_name: 'DuPage',
-            addressable_borrowers: 0,
-            in_the_money_borrowers: 0,
-            high_opportunity_borrowers: 0,
-            avg_opportunity_score: 0,
-            top_segment_code: null,
-          },
-        ],
-        state: 'IL',
-        snapshot_date: '2026-06-19',
-      });
-    });
-    await settle();
+    const tiles = await waitForSelector('.zip-tiles');
+    expect(tiles).toBeTruthy();
+    // The API is asked for ZIPs by STATE — never by a (dead) county FIPS.
+    expect(apiMocks.zipRollups).toHaveBeenCalledWith(
+      { state: 'IL' },
+      undefined,
+      ['itm', 'equity'],
+      'any',
+      undefined,
+    );
+    expect(apiMocks.countyRollups).not.toHaveBeenCalled();
+    // No county polygons render on the way down.
+    expect(document.querySelector('path[aria-label$="County"]')).toBeNull();
 
-    const cookLoaded = document.querySelector('path[aria-label="Cook County"]') as SVGPathElement;
-    const dupageLoaded = document.querySelector('path[aria-label="DuPage County"]') as SVGPathElement;
-    expect(cookLoaded.classList.contains('is-loading')).toBe(false);
-    expect(cookLoaded.classList.contains('has-data')).toBe(true);
-    expect(cookLoaded.classList.contains('lvl-1')).toBe(true);
-    expect(dupageLoaded.classList.contains('is-empty')).toBe(true);
-    expect(dupageLoaded.classList.contains('lvl-1')).toBe(false);
+    const codes = Array.from(document.querySelectorAll('.zip-tile__code')).map(
+      (n) => n.textContent,
+    );
+    expect(codes).toEqual(['60611', '60647']);
+    expect(document.querySelector('.zip-tile__count')?.textContent).toBe('94');
   });
 
-  it('drills geography with keyboard Enter and Space separately from pointer tests', async () => {
+  it('labels the drill by state, not by county', async () => {
     await act(async () => {
       root.render(
         <MemoryRouter>
-          <USChoroplethMap countyTopologyLoader={loadCountyTopology} />
+          <USChoroplethMap />
+        </MemoryRouter>,
+      );
+    });
+    await drillIntoIllinois();
+    await waitForSelector('.zip-tiles');
+
+    // Breadcrumb trail is US > Illinois; the county rung is gone.
+    const crumbs = document.querySelector('.map-crumbs')?.textContent ?? '';
+    expect(crumbs).toContain('US');
+    expect(crumbs).toContain('Illinois');
+    expect(crumbs).not.toContain('County');
+    expect(document.querySelector('.zip-tiles')?.getAttribute('aria-label')).toBe(
+      'ZIPs in Illinois',
+    );
+    expect(document.body.textContent).toContain('ZIPs in Illinois');
+    expect(document.body.textContent).not.toContain('County');
+  });
+
+  it('drills geography with keyboard Enter and returns to US via the breadcrumb', async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <USChoroplethMap />
         </MemoryRouter>,
       );
     });
 
     const illinois = await waitForSelector<SVGPathElement>('path[aria-label="Illinois"]');
-    expect(illinois).toBeTruthy();
     for (let i = 0; i < 80 && !illinois?.classList.contains('has-data'); i += 1) {
       await settle();
       await new Promise((resolve) => window.setTimeout(resolve, 5));
@@ -240,47 +231,24 @@ describe('USChoroplethMap county visual states', () => {
     await act(async () => {
       illinois?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     });
+    expect(await waitForSelector('.zip-tiles')).toBeTruthy();
+    expect(document.querySelector('.map-crumbs')?.textContent).toContain('Illinois');
 
-    const cook = await waitForSelector<SVGPathElement>('path[aria-label="Cook County"]');
-    expect(cook).toBeTruthy();
-
+    // Back out: the US crumb is the single back step now.
+    const usCrumb = document.querySelector<HTMLButtonElement>('.map-crumbs__trail button');
     await act(async () => {
-      countyRollups.resolve({
-        rollups: [
-          {
-            fips_5: '17031',
-            state: 'IL',
-            county_name: 'Cook',
-            addressable_borrowers: 1,
-            in_the_money_borrowers: 1,
-            high_opportunity_borrowers: 1,
-            avg_opportunity_score: 79,
-            top_segment_code: 'itm',
-          },
-        ],
-        state: 'IL',
-        snapshot_date: '2026-06-19',
-      });
+      usCrumb?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await settle();
-
-    await act(async () => {
-      cook?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
-    });
-    await settle();
-
-    expect(document.querySelector('.map-crumbs')?.textContent).toContain('Cook County');
+    expect(document.querySelector('.zip-tiles')).toBeNull();
+    expect(await waitForSelector('path[aria-label="Illinois"]')).toBeTruthy();
   });
 
   it('does not expose raw unknown segment filters in the map caption', async () => {
     await act(async () => {
       root.render(
         <MemoryRouter>
-          <USChoroplethMap
-            segmentFilter={['permit', 'retention-risk']}
-            segmentFilterMode="any"
-            countyTopologyLoader={loadCountyTopology}
-          />
+          <USChoroplethMap segmentFilter={['permit', 'retention-risk']} segmentFilterMode="any" />
         </MemoryRouter>,
       );
     });
@@ -290,39 +258,83 @@ describe('USChoroplethMap county visual states', () => {
     expect(document.body.textContent).not.toContain('retention-risk');
   });
 
-  it('keeps county geography busy while county shapes are still loading', async () => {
-    const topology = deferred<typeof COUNTY_TOPOLOGY>();
-    apiMocks.countyRollups.mockResolvedValueOnce({
-      rollups: [],
-      state: 'IL',
-      snapshot_date: '2026-06-19',
-    });
+  it('keeps the map busy while ZIP rollups are still in flight', async () => {
+    const zipRollups = deferred<ZipRollupResponse>();
+    apiMocks.zipRollups.mockReturnValueOnce(zipRollups.promise);
     await act(async () => {
       root.render(
         <MemoryRouter>
-          <USChoroplethMap countyTopologyLoader={() => topology.promise} />
+          <USChoroplethMap />
         </MemoryRouter>,
       );
     });
-
-    const illinois = await waitForSelector<SVGPathElement>('path[aria-label="Illinois"]');
-    await act(async () => {
-      illinois?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    await settle();
+    await drillIntoIllinois();
 
     const levels = document.querySelector('.map-levels');
     expect(levels?.getAttribute('aria-busy')).toBe('true');
     expect(document.querySelector('[role="status"]')?.textContent).toContain(
-      'Loading county map shapes for Illinois',
+      'Loading ZIP rollups for Illinois',
     );
 
     await act(async () => {
-      topology.resolve(COUNTY_TOPOLOGY);
+      zipRollups.resolve(IL_ZIP_ROLLUPS);
     });
     await settle();
 
     expect(levels?.getAttribute('aria-busy')).toBe('false');
     expect(document.querySelector('[role="status"]')?.textContent).toContain('Geography rollups loaded');
+  });
+
+  it('discloses borrowers the ZIP layer cannot show, and stays silent at zero', async () => {
+    // The ZIP tiles sum BELOW the state total whenever the share carries no
+    // usable ZIP. A reader who adds up the tiles must be told why.
+    apiMocks.stateRollups.mockResolvedValue(stateRollupPayload(1234));
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <USChoroplethMap />
+        </MemoryRouter>,
+      );
+    });
+    await drillIntoIllinois();
+    await waitForSelector('.zip-tiles');
+    expect(document.body.textContent).toContain('1,234 borrowers without ZIP assignment');
+
+    // Full ZIP coverage discloses nothing — no zero-value noise.
+    act(() => root.unmount());
+    document.body.innerHTML = '<div id="root"></div>';
+    root = createRoot(document.getElementById('root') as HTMLElement);
+    apiMocks.stateRollups.mockResolvedValue(stateRollupPayload(0));
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <USChoroplethMap />
+        </MemoryRouter>,
+      );
+    });
+    await drillIntoIllinois();
+    await waitForSelector('.zip-tiles');
+    expect(document.body.textContent).not.toContain('without ZIP assignment');
+  });
+
+  it('falls back to the state lead queue when no ZIP rollup exists', async () => {
+    apiMocks.zipRollups.mockResolvedValue({
+      state: 'IL',
+      fips_5: null,
+      rollups: [],
+      snapshot_date: null,
+    } satisfies ZipRollupResponse);
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <USChoroplethMap />
+        </MemoryRouter>,
+      );
+    });
+    await drillIntoIllinois();
+    await settle();
+
+    expect(document.body.textContent).toContain('No ZIP-level rollup for Illinois');
+    expect(document.body.textContent).toContain('Open Lead Queue for Illinois');
   });
 });

--- a/frontend/src/components/mortgage/USChoroplethMap.tsx
+++ b/frontend/src/components/mortgage/USChoroplethMap.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { useNavigate } from 'react-router';
-import type { FeatureCollection } from 'geojson';
-import type { GeometryCollection, Topology } from 'topojson-specification';
 import { Icon } from '../Icon';
 import { Chip, EvidenceChip } from '../Primitives';
 import { api } from '../../lib/api';
@@ -10,15 +8,12 @@ import { ApiError } from '../../lib/api';
 import { DRAWER_SOURCES } from '../../lib/drawerSources';
 import { buildCampaignPrefillSearch, makeCampaignPrefill } from '../../lib/campaignPrefill';
 import { useOptionalFootprint } from '../FootprintProvider';
-import type { CountyRollup, StateRollup, ZipRollup } from '../../types';
+import type { StateRollup, ZipRollup } from '../../types';
 import {
   USCODE_TO_FIPS,
-  buildCountiesPayload,
   buildLeadQueuePath,
   buildQuantileBucketer,
-  countyDisplayName,
   lvlFromCount,
-  type CountiesPayload,
   type HoverState,
   type Level,
   type Selected,
@@ -29,11 +24,10 @@ import { loadUsaStateMap } from './USStateMapData';
 import { USChoroplethMapTooltip } from './USChoroplethMapTooltip';
 import { safeSegmentName } from '../../lib/segmentMetadata';
 
-// Slice13-accuracy-validation: county + ZIP hover numbers now come from
-// /api/geo/county-rollups + /api/geo/zip-rollups (backed by
-// mip.gold.county_rollup + mip.gold.zip_rollup respectively). The prior
-// local county/ZIP fixture literals are gone -- any county / ZIP not
-// returned in the payload renders "—" on hover (honest null).
+// State + ZIP hover numbers come from /api/geo/state-rollups and
+// /api/geo/zip-rollups (backed by mip.gold.funnel_snapshot_daily and
+// mip.gold.zip_rollup). There are no local fixture literals -- any state /
+// ZIP not returned in the payload renders "—" on hover (honest null).
 // The fill-level bucket is derived from addressable_borrowers below.
 
 /**
@@ -42,26 +36,39 @@ import { safeSegmentName } from '../../lib/segmentMetadata';
  * Matches the prototype's `ChoroplethMap`:
  *   - .map-wrap chassis with breadcrumbs, drill-hint chip, legend, map-tip.
  *   - map-region lvl-1..4 fills (color-mix with --accent), is-selected accent.
- *   - level state: 'state' → 'county' → 'zip' → Lead Queue deep-link.
+ *   - level state: 'state' → 'zip' → Lead Queue deep-link.
  *
  * Upgrade vs. prototype: the prototype used hand-drawn stylized polygons. We
  * use us-atlas state TopoJSON (Albers USA pre-projected paths) for real US
  * geography so it reads as a product, not a sketch.
  *
- * Geography scope is data-driven. Click a populated state to drill into
- * whatever counties are present in the live gold rollups, then ZIP-level
- * rollups. The UI copy uses backend scope labels rather than hardcoded demo
- * assumptions.
+ * DESIGN-CONTRACT DEVIATION, 2026-08-08. The prototype's ChoroplethMap
+ * drills state → county → ZIP (`design_files/Module 0 Prototype.html`
+ * ~L1802-1812: `level === 'county' ? TX_COUNTIES : TRAVIS_ZIPS`). We drop
+ * the county step. The Cotality share carries exactly one county FIPS per
+ * state, so `county_fips_5` is NULL on all 5,156,184 borrower_360 rows and
+ * all 677 zip_rollup rows once the fabricated keys were removed as
+ * dishonest. The county level rendered unfilled polygons whose every hover
+ * read "outside the footprint", and county boundaries cannot be drawn
+ * truthfully at all. The prototype's breadcrumb/hint-chip vocabulary is
+ * preserved exactly — only the middle rung is gone. Restore the level when
+ * a licensed county dataset lands; `/api/geo/county-rollups` and the county
+ * geometry helpers in `./USChoroplethMap.utils` are kept for that.
+ *
+ * Geography scope is data-driven: click a populated state to drill into
+ * whatever ZIPs are present in the live gold rollups. The UI copy uses
+ * backend scope labels rather than hardcoded demo assumptions.
  */
 
-// ---------- Live per-state facts ----------
-
-type CountyTopology = Topology<{ counties: GeometryCollection }>;
-
-/** Selection payload emitted on every state/county/ZIP click. State is
- *  2-char uppercase USPS code so consumers can run predicates against
- *  `LeadSummary.state` directly. `county` is the 5-digit FIPS; `zip` is
- *  the 5-digit string. `null` means the user navigated back to US level. */
+/** Selection payload emitted on every state/ZIP click. State is a 2-char
+ *  uppercase USPS code so consumers can run predicates against
+ *  `LeadSummary.state` directly; `zip` is the 5-digit string. `null` means
+ *  the user navigated back to US level.
+ *
+ *  `county` is always null since 2026-08-08 — the map has no county level.
+ *  The field stays on the contract (consumers still forward it to
+ *  `/api/leads`, which still accepts a county predicate) so a licensed
+ *  county dataset needs no consumer change. */
 export interface MapSelection {
   state: string | null;
   county: string | null;
@@ -85,19 +92,10 @@ interface USChoroplethMapProps {
    *  filter the LeadTable). `"navigate"` deep-links to
    *  `/lead-queue?state=XX` so the home-page map acts as a teaser. */
   drillBehavior?: 'filter' | 'navigate';
-  /** Test injection for county TopoJSON; production loads /us-counties.json. */
-  countyTopologyLoader?: () => Promise<unknown>;
-}
-
-async function defaultCountyTopologyLoader(): Promise<unknown> {
-  const topoRes = await fetch('/us-counties.json');
-  if (!topoRes.ok) throw new Error(`topology fetch ${topoRes.status}`);
-  return topoRes.json();
 }
 
 /**
- * US Choropleth Map — state → county → ZIP drill-down over Cotality public
- * records.
+ * US Choropleth Map — state → ZIP drill-down over Cotality public records.
  */
 export function USChoroplethMap({
   height = 420,
@@ -106,7 +104,6 @@ export function USChoroplethMap({
   portfolioCriteria,
   onSelectionChange,
   drillBehavior = 'filter',
-  countyTopologyLoader = defaultCountyTopologyLoader,
 }: USChoroplethMapProps) {
   const [level, setLevel] = useState<Level>('state');
   const [selected, setSelected] = useState<Selected | null>(null);
@@ -121,26 +118,19 @@ export function USChoroplethMap({
     setHover(null);
   }, [level, selected]);
   const [usaMap, setUsaMap] = useState<UsaSvgMap | null>(null);
-  // Which supported state we drilled into (for county rendering).
-  const [countyStateId, setCountyStateId] = useState<string | null>(null);
-  const [countiesByState, setCountiesByState] = useState<Record<string, CountiesPayload>>({});
-  const [countyLoadError, setCountyLoadError] = useState<string | null>(null);
+  // Which state we drilled into (lowercase, matching map location ids).
+  // At ZIP level this is the drilled context and stays put while the user
+  // hovers/clicks individual tiles.
+  const [drillStateId, setDrillStateId] = useState<string | null>(null);
   // Per-state rollups from /api/geo/state-rollups. `null` = loading; `{}`
   // = API unreachable. We keep the static geography interactive, but do
   // not surface static borrower counts while live rollups are loading.
   // Keyed by lowercase state code to match state map location ids.
   const [liveStateFacts, setLiveStateFacts] = useState<Record<string, StateRollup> | null>(null);
-  // Per-state county rollups lazy-loaded on drill. Keyed by uppercase
-  // state code. Each value is a dict keyed by 5-char FIPS so the map's
-  // county renderer can O(1) look up a county's live count / avg score.
-  const [liveCountyFacts, setLiveCountyFacts] = useState<Record<string, Record<string, CountyRollup>>>({});
-  // Per-county ZIP rollups lazy-loaded on county drill. Keyed by 5-char
-  // county FIPS. Value is a dict keyed by 5-digit ZIP.
+  // Per-state ZIP rollups lazy-loaded on drill. Keyed by UPPERCASE state
+  // code (the API key); each value is a dict keyed by 5-digit ZIP so the
+  // tile renderer can O(1) look up a ZIP's live count / avg score.
   const [liveZipFacts, setLiveZipFacts] = useState<Record<string, Record<string, ZipRollup>>>({});
-  // Optional scope note surfaced from /api/geo/county-rollups when the
-  // backend carries `scope_note` on the response. Keyed by uppercase
-  // state code.
-  const [countyScopeByState, setCountyScopeByState] = useState<Record<string, string>>({});
   // S9 assigned-vs-unattended overlay. `overlayOn` toggles the recolor +
   // tooltip extension. `overlayData` is the response for the CURRENT drill
   // level; `null` = not yet loaded, `overlayError` = fetch failed (degraded
@@ -152,13 +142,11 @@ export function USChoroplethMap({
   const navigate = useNavigate();
   const footprint = useOptionalFootprint();
 
-  // Footprint-aware drill allowlist. FIPS is intrinsic geography metadata,
-  // while the active state set comes from FootprintProvider. Every configured
-  // state can drill; renderCountyLevel handles the two cases:
-  //   (a) TopoJSON has polygons for this state   -> render the polys.
-  //   (b) TopoJSON does not                      -> render a scope card
-  //       from live county rollups and let the user jump to ZIPs.
-  const supportedCountyStates = useMemo<Record<string, string>>(() => {
+  // Footprint-aware drill allowlist: the active state set comes from
+  // FootprintProvider, filtered through the intrinsic USPS->FIPS table so a
+  // malformed configured code can never become a drillable region. Every
+  // configured state drills straight to its ZIP tiles.
+  const footprintStates = useMemo<Record<string, string>>(() => {
     const out: Record<string, string> = {};
     for (const code of footprint.stateCodes) {
       const lc = code.toLowerCase();
@@ -183,9 +171,7 @@ export function USChoroplethMap({
 
   useEffect(() => {
     setHover(null);
-    setLiveCountyFacts({});
     setLiveZipFacts({});
-    setCountyScopeByState({});
   }, [segmentFilterKey, segmentFilterMode, portfolioCriteriaKey]);
 
   // Lazy-load the state geography so the TopoJSON conversion lands in its
@@ -241,60 +227,18 @@ export function USChoroplethMap({
     };
   }, [segmentFilter, segmentFilterMode, portfolioCriteria, portfolioCriteriaKey]);
 
-  // Lazy-fetch county rollups on drill. /api/geo/county-rollups?state=XX
-  // returns real counts / avg_score / top_segment_code per FIPS from
-  // mip.gold.county_rollup. Missing counties render "—" (honest null).
+  // Lazy-fetch ZIP rollups when the user drills into a state.
+  // /api/geo/zip-rollups?state=XX reads mip.gold.zip_rollup on its real
+  // grain. A state with no ZIP rows resolves to an empty list; the ZIP
+  // renderer shows an honest empty state with a Lead Queue fallback.
   useEffect(() => {
-    if (level !== 'county' || !countyStateId) return;
-    const stateUC = countyStateId.toUpperCase();
-    if (liveCountyFacts[stateUC]) return;
-    let cancelled = false;
-    api
-      .countyRollups(
-        stateUC,
-        undefined,
-        segmentFilter && segmentFilter.length > 0 ? segmentFilter : null,
-        segmentFilterMode,
-        portfolioCriteria,
-      )
-      .then((payload) => {
-        if (cancelled) return;
-        const byFips: Record<string, CountyRollup> = {};
-        for (const r of payload.rollups) byFips[r.fips_5] = r;
-        setLiveCountyFacts((cur) => ({ ...cur, [stateUC]: byFips }));
-        // Preserve the backend's scope_note verbatim when present so the
-        // UI renders discovered geography coverage without fabricating copy.
-        const scope =
-          (payload as { scope_note?: string | null }).scope_note ?? null;
-        if (scope) {
-          setCountyScopeByState((cur) => ({ ...cur, [stateUC]: scope }));
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          // Empty dict means "we tried, nothing came back" -- hover falls
-          // back to "—" instead of blocking re-fetches on every render.
-          setLiveCountyFacts((cur) => ({ ...cur, [stateUC]: {} }));
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [level, countyStateId, liveCountyFacts, segmentFilter, segmentFilterMode, portfolioCriteria, portfolioCriteriaKey]);
-
-  // Lazy-fetch ZIP rollups when the user drills into any county. The
-  // CTAS only populates ZIPs for counties with borrower rows, so
-  // out-of-footprint counties resolve to an empty list; the UI renders
-  // an "—" hover + no-op click for those.
-  useEffect(() => {
-    if (level !== 'zip') return;
-    const fips = selected?.level === 'county' ? selected.id : null;
-    if (!fips) return;
-    if (liveZipFacts[fips]) return;
+    if (level !== 'zip' || !drillStateId) return;
+    const stateUC = drillStateId.toUpperCase();
+    if (liveZipFacts[stateUC]) return;
     let cancelled = false;
     api
       .zipRollups(
-        fips,
+        { state: stateUC },
         undefined,
         segmentFilter && segmentFilter.length > 0 ? segmentFilter : null,
         segmentFilterMode,
@@ -304,72 +248,22 @@ export function USChoroplethMap({
         if (cancelled) return;
         const byZip: Record<string, ZipRollup> = {};
         for (const r of payload.rollups) byZip[r.zip] = r;
-        setLiveZipFacts((cur) => ({ ...cur, [fips]: byZip }));
+        setLiveZipFacts((cur) => ({ ...cur, [stateUC]: byZip }));
       })
       .catch(() => {
-        if (!cancelled) setLiveZipFacts((cur) => ({ ...cur, [fips]: {} }));
+        // Empty dict means "we tried, nothing came back" -- the renderer
+        // shows the empty state instead of re-fetching on every render.
+        if (!cancelled) setLiveZipFacts((cur) => ({ ...cur, [stateUC]: {} }));
       });
     return () => {
       cancelled = true;
     };
-  }, [level, selected, liveZipFacts, segmentFilter, segmentFilterMode, portfolioCriteria, portfolioCriteriaKey]);
-
-  // Lazy-load real county polygons when drilled into a supported state.
-  // us-counties.json is the national us-atlas county TopoJSON shipped as a
-  // static asset in public/. topojson-client decodes it at runtime; both fetch
-  // + import happen only on first county drill.
-  useEffect(() => {
-    if (level !== 'county' || !countyStateId) return;
-    if (countiesByState[countyStateId]) return;
-    const fips = supportedCountyStates[countyStateId];
-    if (!fips) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const [topoClient, topoRes] = await Promise.all([
-          import('topojson-client'),
-          countyTopologyLoader(),
-        ]);
-        const topology = topoRes as CountyTopology;
-        // topojson-client's feature() returns a GeoJSON FeatureCollection when
-        // the object is a GeometryCollection.
-        // topojson-client's `feature()` typing narrows to Feature for a
-        // single Geometry and FeatureCollection for a GeometryCollection; our
-        // payload is the latter. Cast via `unknown` to bypass the union.
-        const fc = topoClient.feature(
-          topology,
-          topology.objects.counties,
-        ) as unknown as FeatureCollection;
-        // Empty features set = this state is in the footprint but not in
-        // the shipped TopoJSON. Skip storing a payload so the live-rollup
-        // fallback in renderCountyLevel takes over. Without this guard we'd
-        // store an empty CountiesPayload with an Infinity viewBox and render
-        // a blank SVG.
-        const payload = buildCountiesPayload(fc, countyStateId, fips);
-        if (!payload) return;
-        if (!cancelled) {
-          setCountiesByState((cur) => ({ ...cur, [countyStateId]: payload }));
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setCountyLoadError(
-            err instanceof Error
-              ? `Couldn't load county polygons: ${err.message}`
-              : "Couldn't load county polygons.",
-          );
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [level, countyStateId, countiesByState, supportedCountyStates, countyTopologyLoader]);
+  }, [level, drillStateId, liveZipFacts, segmentFilter, segmentFilterMode, portfolioCriteria, portfolioCriteriaKey]);
 
   // S9 overlay fetch. Re-runs on drill level + toggle. Each level maps to a
-  // distinct /api/geo/assignment-overlay call (state | county+state |
-  // zip+county_fips). A fetch failure sets an honest degraded note and
-  // leaves the base borrower view untouched -- never a silent fallback.
-  const overlayCountyFips = selected?.level === 'county' ? selected.id : null;
+  // distinct /api/geo/assignment-overlay call (state | zip+state). A fetch
+  // failure sets an honest degraded note and leaves the base borrower view
+  // untouched -- never a silent fallback.
   useEffect(() => {
     if (!overlayOn) {
       setOverlayData(null);
@@ -378,14 +272,13 @@ export function USChoroplethMap({
       return;
     }
     // Determine the request for the current drill level. Skip until the
-    // parent geo needed for a county/zip request is known.
+    // parent state needed for a ZIP request is known. The ZIP overlay keys
+    // on the same state as the tiles it recolors.
     let request: { level: GeoOverlayLevel; state?: string | null; countyFips?: string | null } | null = null;
     if (level === 'state') {
       request = { level: 'state' };
-    } else if (level === 'county' && countyStateId) {
-      request = { level: 'county', state: countyStateId.toUpperCase() };
-    } else if (level === 'zip' && overlayCountyFips) {
-      request = { level: 'zip', countyFips: overlayCountyFips };
+    } else if (level === 'zip' && drillStateId) {
+      request = { level: 'zip', state: drillStateId.toUpperCase() };
     }
     if (!request) {
       setOverlayData(null);
@@ -418,7 +311,7 @@ export function USChoroplethMap({
       cancelled = true;
       controller.abort();
     };
-  }, [overlayOn, level, countyStateId, overlayCountyFips]);
+  }, [overlayOn, level, drillStateId]);
 
   // The overlay only drives coloring once its payload is actually loaded;
   // while loading or degraded the base borrower coloring stays up (the
@@ -479,32 +372,23 @@ export function USChoroplethMap({
           avgScore: live.avg_score,
           lvl: stateBucketer(live.addressable),
           topSegment: liveTopSegment || undefined,
+          zipUnassigned: live.zip_unassigned_count ?? null,
         };
       }
       return undefined;
     };
   }, [liveStateFacts, stateBucketer]);
 
-  // Quantile bucketer for the county layer of the currently-drilled
-  // state. Computed per-payload so the gradient reads whether the real
-  // counts are in the hundreds or the hundred-thousands (see
-  // `buildQuantileBucketer` docstring).
-  const countyBucketer = useMemo(() => {
-    const stateUC = countyStateId?.toUpperCase() ?? '';
-    const byFips = liveCountyFacts[stateUC];
-    if (!byFips) return lvlFromCount;
-    const counts = Object.values(byFips).map((r) => r.addressable_borrowers ?? 0);
-    return buildQuantileBucketer(counts);
-  }, [countyStateId, liveCountyFacts]);
-
-  // Quantile bucketer for the ZIP layer of the currently-drilled county.
+  // Quantile bucketer for the ZIP layer of the currently-drilled state.
+  // Computed per-payload so the gradient reads whether the real counts are
+  // in the hundreds or the hundred-thousands (see `buildQuantileBucketer`).
   const zipBucketer = useMemo(() => {
-    const fips = selected?.level === 'county' ? selected.id : '';
-    const byZip = liveZipFacts[fips];
+    const stateUC = drillStateId?.toUpperCase() ?? '';
+    const byZip = liveZipFacts[stateUC];
     if (!byZip) return lvlFromCount;
     const counts = Object.values(byZip).map((r) => r.addressable_borrowers ?? 0);
     return buildQuantileBucketer(counts);
-  }, [selected, liveZipFacts]);
+  }, [drillStateId, liveZipFacts]);
 
   // Fire the selection callback when the user drills into / out of a
   // level. Collecting into a single effect keeps the producer logic in
@@ -514,13 +398,14 @@ export function USChoroplethMap({
     const stateCode =
       selected?.level === 'state'
         ? selected.id.toUpperCase()
-        : countyStateId
-          ? countyStateId.toUpperCase()
+        : drillStateId
+          ? drillStateId.toUpperCase()
           : null;
-    const countyFips = selected?.level === 'county' ? selected.id : null;
     const zip = selected?.level === 'zip' ? selected.id : null;
-    onSelectionChange({ state: stateCode, county: countyFips, zip });
-  }, [selected, countyStateId, onSelectionChange]);
+    // `county` is always null: the map has no county level (see
+    // MapSelection). Consumers keep forwarding the field unchanged.
+    onSelectionChange({ state: stateCode, county: null, zip });
+  }, [selected, drillStateId, onSelectionChange]);
 
   const totalCount = useMemo(() => {
     if (level === 'state') {
@@ -529,22 +414,9 @@ export function USChoroplethMap({
       }
       return 0;
     }
-    if (level === 'county') {
-      const stateUC = countyStateId?.toUpperCase() ?? '';
-      const liveByFips = liveCountyFacts[stateUC];
-      if (liveByFips) {
-        return Object.values(liveByFips).reduce(
-          (a, r) => a + (r.addressable_borrowers ?? 0),
-          0,
-        );
-      }
-      // Pre-fetch placeholder: show the state-level count so the legend
-      // doesn't flash 0 while the county payload is in flight.
-      return liveStateFacts?.[countyStateId ?? '']?.addressable ?? 0;
-    }
-    // ZIP level — key off the selected county, not a hardcoded FIPS.
-    const fips = selected?.level === 'county' ? selected.id : null;
-    const liveByZip = fips ? liveZipFacts[fips] : undefined;
+    // ZIP level — key off the drilled state.
+    const stateUC = drillStateId?.toUpperCase() ?? '';
+    const liveByZip = stateUC ? liveZipFacts[stateUC] : undefined;
     if (liveByZip) {
       return Object.values(liveByZip).reduce(
         (a, r) => a + (r.addressable_borrowers ?? 0),
@@ -552,76 +424,40 @@ export function USChoroplethMap({
       );
     }
     return 0;
-  }, [level, countyStateId, selected, liveStateFacts, liveCountyFacts, liveZipFacts]);
+  }, [level, drillStateId, liveStateFacts, liveZipFacts]);
   const mapBusy = useMemo(() => {
     if (!usaMap || liveStateFacts === null) return true;
-    if (level === 'county') {
-      const stateUC = countyStateId?.toUpperCase() ?? '';
-      const rollupsPending = Boolean(countyStateId && liveCountyFacts[stateUC] === undefined);
-      const topologyPending = Boolean(
-        countyStateId
-        && supportedCountyStates[countyStateId]
-        && !countiesByState[countyStateId]
-        && !countyLoadError,
-      );
-      return rollupsPending || topologyPending;
-    }
     if (level === 'zip') {
-      const fips = selected?.level === 'county' ? selected.id : '';
-      return Boolean(fips && liveZipFacts[fips] === undefined);
+      const stateUC = drillStateId?.toUpperCase() ?? '';
+      return Boolean(stateUC && liveZipFacts[stateUC] === undefined);
     }
     return false;
-  }, [
-    countiesByState,
-    countyLoadError,
-    countyStateId,
-    level,
-    liveCountyFacts,
-    liveStateFacts,
-    liveZipFacts,
-    selected,
-    supportedCountyStates,
-    usaMap,
-  ]);
+  }, [drillStateId, level, liveStateFacts, liveZipFacts, usaMap]);
+  // Borrowers in the drilled state that the ZIP layer cannot show. The
+  // backend derives it as (state total - sum of ZIP tiles) off one refresh
+  // anchor, so it IS the on-screen gap rather than a second estimate of it.
+  const zipUnassignedForDrill = useMemo(() => {
+    if (!drillStateId) return 0;
+    return liveStateFacts?.[drillStateId]?.zip_unassigned_count ?? 0;
+  }, [drillStateId, liveStateFacts]);
+  const drillStateName = useMemo(() => {
+    if (!drillStateId) return '';
+    return (
+      usaMap?.locations.find((l) => l.id === drillStateId)?.name
+      ?? drillStateId.toUpperCase()
+    );
+  }, [drillStateId, usaMap]);
   const mapStatus = useMemo(() => {
     if (!usaMap) return 'Loading geography.';
     if (liveStateFacts === null) return 'Loading state borrower rollups.';
-    if (level === 'county') {
-      const stateName = countyStateId
-        ? usaMap.locations.find((l) => l.id === countyStateId)?.name ?? countyStateId.toUpperCase()
-        : 'state';
-      const stateUC = countyStateId?.toUpperCase() ?? '';
-      if (countyStateId && liveCountyFacts[stateUC] === undefined) {
-        return `Loading county rollups for ${stateName}.`;
-      }
-      if (
-        countyStateId
-        && supportedCountyStates[countyStateId]
-        && !countiesByState[countyStateId]
-        && !countyLoadError
-      ) {
-        return `Loading county map shapes for ${stateName}.`;
-      }
-    }
     if (level === 'zip') {
-      const fips = selected?.level === 'county' ? selected.id : '';
-      if (fips && liveZipFacts[fips] === undefined) {
-        return `Loading ZIP rollups for ${selected?.name ?? 'county'}.`;
+      const stateUC = drillStateId?.toUpperCase() ?? '';
+      if (stateUC && liveZipFacts[stateUC] === undefined) {
+        return `Loading ZIP rollups for ${drillStateName || 'state'}.`;
       }
     }
     return 'Geography rollups loaded.';
-  }, [
-    countiesByState,
-    countyLoadError,
-    countyStateId,
-    level,
-    liveCountyFacts,
-    liveStateFacts,
-    liveZipFacts,
-    selected,
-    supportedCountyStates,
-    usaMap,
-  ]);
+  }, [drillStateId, drillStateName, level, liveStateFacts, liveZipFacts, usaMap]);
   const segmentCaption = useMemo(() => {
     if (!segmentFilter || segmentFilter.length === 0) return 'marketable population';
     const labels = segmentFilter.map((code) => safeSegmentName(code) ?? 'Unknown segment');
@@ -632,55 +468,39 @@ export function USChoroplethMap({
   // whichever level the user is on. Used for the "Start campaign" prefill.
   const activeStateCode = useMemo(() => {
     if (selected?.level === 'state') return selected.id.toUpperCase();
-    if (countyStateId) return countyStateId.toUpperCase();
+    if (drillStateId) return drillStateId.toUpperCase();
     return null;
-  }, [selected, countyStateId]);
+  }, [selected, drillStateId]);
 
-  // S9 "Start campaign from this geography" link target. Built from the
-  // drilled unit the map can actually hold selected: a state at US level,
-  // or a county — which stays the drilled context while its ZIP grid is on
-  // screen, because a zip-tile click deep-links to the Lead Queue by the
-  // existing map contract (a persistent per-ZIP selection does not exist
-  // today; the typed prefill contract still carries `zip` for S10).
-  // Carries the current segment filter + mode and, when the overlay is
-  // loaded, the drilled unit's lead / unattended snapshot counts.
+  // S9 "Start campaign from this geography" link target. The state is the
+  // drilled unit at both levels — it stays the campaign context while its
+  // ZIP grid is on screen, because a zip-tile click deep-links to the Lead
+  // Queue by the existing map contract (a persistent per-ZIP selection does
+  // not exist today; the typed prefill contract still carries `zip` for
+  // S10). Carries the current segment filter + mode and, when the overlay
+  // is loaded, the state's lead / unattended snapshot counts.
   const campaignPrefillPath = useMemo(() => {
-    if (!activeStateCode) return null;
-    let campaignLevel: GeoOverlayLevel;
-    let countyFips: string | null = null;
-    let countyName: string | null = null;
+    if (!activeStateCode || selected?.level !== 'state') return null;
     let leadCount: number | null = null;
     let unattendedCount: number | null = null;
-    if (selected?.level === 'county') {
-      campaignLevel = 'county';
-      countyFips = selected.id;
-      countyName = selected.name;
-      if (overlayOn && overlayData) {
-        if (overlayData.level === 'zip' && overlayData.county_fips === selected.id) {
-          // ZIP grid on screen: the county snapshot is the sum of its
-          // ZIP units — the totals the overlay response already carries.
-          leadCount = overlayData.total_leads;
-          unattendedCount = overlayData.total_unattended;
-        } else {
-          const unit = overlayByUnit[selected.id];
-          leadCount = unit ? unit.lead_count : null;
-          unattendedCount = unit ? unit.unattended_count : null;
-        }
+    if (overlayOn && overlayData) {
+      if (overlayData.level === 'zip') {
+        // ZIP grid on screen: the state snapshot is the sum of its ZIP
+        // units — the totals the overlay response already carries.
+        leadCount = overlayData.total_leads;
+        unattendedCount = overlayData.total_unattended;
+      } else {
+        const unit = overlayByUnit[selected.id.toLowerCase()];
+        leadCount = unit ? unit.lead_count : null;
+        unattendedCount = unit ? unit.unattended_count : null;
       }
-    } else if (selected?.level === 'state') {
-      campaignLevel = 'state';
-      const unit = overlayOn ? overlayByUnit[selected.id.toLowerCase()] : undefined;
-      leadCount = unit ? unit.lead_count : null;
-      unattendedCount = unit ? unit.unattended_count : null;
-    } else {
-      return null;
     }
     try {
       const prefill = makeCampaignPrefill({
-        level: campaignLevel,
+        level: 'state',
         state: activeStateCode,
-        countyFips,
-        countyName,
+        countyFips: null,
+        countyName: null,
         segmentCodes: segmentFilter ?? [],
         segmentMode: segmentFilterMode,
         leadCount,
@@ -688,8 +508,8 @@ export function USChoroplethMap({
       });
       return `/portfolio-builder?${buildCampaignPrefillSearch(prefill).toString()}`;
     } catch {
-      // A geography we can't encode coherently (e.g. a non-FIPS parent) just
-      // hides the affordance rather than shipping a broken link.
+      // A geography we can't encode coherently just hides the affordance
+      // rather than shipping a broken link.
       return null;
     }
   }, [
@@ -719,7 +539,7 @@ export function USChoroplethMap({
     >
       {usaMap.locations.map((loc) => {
         const facts = factsFor(loc.id);
-        const inFootprint = Boolean(supportedCountyStates[loc.id]);
+        const inFootprint = Boolean(footprintStates[loc.id]);
         const stateFactsLoading = liveStateFacts === null;
         const overlayUnit = overlayActive ? overlayByUnit[loc.id] : undefined;
         // When the overlay is loaded, the fill tier reflects UNATTENDED
@@ -771,6 +591,10 @@ export function USChoroplethMap({
                 sourceHint: inFootprint
                   ? 'mip.gold.funnel_snapshot_daily + mip.gold.state_top_segment'
                   : 'Outside Cotality evaluation scope',
+                // Disclose the drill gap BEFORE the user drills, so the
+                // ZIP tiles summing below this state's total is expected
+                // rather than discovered.
+                zipUnassigned: facts?.zipUnassigned ?? null,
                 overlay: overlayUnit
                   ? {
                       leadCount: overlayUnit.lead_count,
@@ -800,8 +624,9 @@ export function USChoroplethMap({
                 return;
               }
               if (inFootprint) {
-                setLevel('county');
-                setCountyStateId(loc.id);
+                // Straight to ZIPs — there is no honest county rung.
+                setLevel('zip');
+                setDrillStateId(loc.id);
                 setSelected({ level: 'state', id: loc.id, name: loc.name });
               } else if (facts) {
                 setSelected({ level: 'state', id: loc.id, name: loc.name });
@@ -818,8 +643,9 @@ export function USChoroplethMap({
                 return;
               }
               if (inFootprint) {
-                setLevel('county');
-                setCountyStateId(loc.id);
+                // Straight to ZIPs — there is no honest county rung.
+                setLevel('zip');
+                setDrillStateId(loc.id);
                 setSelected({ level: 'state', id: loc.id, name: loc.name });
               } else if (facts) {
                 setSelected({ level: 'state', id: loc.id, name: loc.name });
@@ -832,225 +658,34 @@ export function USChoroplethMap({
     );
   };
 
-  // ----- COUNTY level: real county polygons from TopoJSON -----------------
-  // Falls back to a live-rollup scope card only if the county polygons for the
-  // state are unavailable. The county name/FIPS comes from the backend, not a
-  // baked demo lookup.
-  const renderCountyLevel = () => {
-    const payload = countyStateId ? countiesByState[countyStateId] : null;
-    const stateName = countyStateId
-      ? usaMap?.locations.find((l) => l.id === countyStateId)?.name ?? ''
-      : '';
-    const stateUC = countyStateId?.toUpperCase() ?? '';
-    const countyFactsForState = liveCountyFacts[stateUC];
-    const countyFactsLoading = countyFactsForState === undefined;
-    const primaryCounty = countyFactsForState
-      ? Object.values(countyFactsForState).sort(
-        (a, b) => (b.addressable_borrowers ?? 0) - (a.addressable_borrowers ?? 0),
-      )[0]
-      : null;
-    if (!payload && !countyLoadError && primaryCounty) {
-      const count = primaryCounty.addressable_borrowers ?? null;
-      const avgScore = primaryCounty.avg_opportunity_score ?? null;
-      const countyName = countyDisplayName(primaryCounty);
-      const scopeLabel =
-        countyScopeByState[stateUC] ??
-        footprint.dataScope?.scope_label ??
-        'Cotality data coverage discovered from gold county rollups';
-      return (
-        <div className="map-stage">
-          <div className="map-center-card">
-            <div className="eyebrow">Cotality data coverage</div>
-            <div className="h-3 text-1">
-              {countyName}, {stateName}
-            </div>
-            <div className="body muted map-center-copy">
-              {scopeLabel}. Drill into {countyName} to see ZIP-level rollups.
-            </div>
-            <div className="map-center-stats">
-              <span>
-                Marketable{' '}
-                <span className="text-1">
-                  {count !== null ? count.toLocaleString() : '—'}
-                </span>
-              </span>
-              <span>
-                Avg. score{' '}
-                <span className="text-1">
-                  {avgScore !== null ? avgScore : '—'}
-                </span>
-              </span>
-            </div>
-            <div className="map-center-actions">
-              <button
-                type="button"
-                className="btn btn--primary"
-                onClick={() => {
-                  setLevel('zip');
-                  setSelected({ level: 'county', id: primaryCounty.fips_5, name: countyName });
-                }}
-              >
-                Drill into {countyName} ZIPs
-              </button>
-            </div>
-          </div>
-        </div>
-      );
-    }
-    if (!payload) {
-      // Loading or error fallback. Do not render state-specific demo
-      // geometry; county shapes and counts must come from the national
-      // TopoJSON + live rollup payload.
-      return (
-        <div className="map-stage map-stage--empty">
-          {countyLoadError ? (
-            <div className="map-center-card map-center-card--narrow">
-              <div className="text-2 mb-2">{countyLoadError}</div>
-              <button
-                type="button"
-                className="btn btn--ghost"
-                onClick={() => {
-                  setCountyLoadError(null);
-                  setCountiesByState((c) => {
-                    const next = { ...c };
-                    if (countyStateId) delete next[countyStateId];
-                    return next;
-                  });
-                }}
-              >
-                Retry county map
-              </button>
-            </div>
-          ) : (
-            'Loading counties…'
-          )}
-        </div>
-      );
-    }
-
-    return (
-      <svg
-        viewBox={payload.viewBox}
-        preserveAspectRatio="xMidYMid meet"
-        className="map-svg-stage"
-      >
-        {payload.features.map((f) => {
-          const liveFacts = countyFactsForState?.[f.id];
-          const count = liveFacts?.addressable_borrowers ?? null;
-          const avgScore = liveFacts?.avg_opportunity_score ?? null;
-          const topSegCode = liveFacts?.top_segment_code ?? null;
-          const topSegment = topSegCode ? (safeSegmentName(topSegCode) ?? undefined) : undefined;
-          const overlayUnit = overlayActive ? overlayByUnit[f.id] : undefined;
-          const overlayLvl =
-            overlayUnit && overlayUnit.unattended_count > 0
-              ? overlayBucketer(overlayUnit.unattended_count)
-              : null;
-          const hasPositiveCount = count !== null && count > 0;
-          const hasFill = overlayActive ? overlayLvl !== null : hasPositiveCount;
-          const lvl = overlayActive ? overlayLvl : hasPositiveCount ? countyBucketer(count) : null;
-          const classes = [
-            'map-region',
-            countyFactsLoading ? 'is-loading' : '',
-            !countyFactsLoading && hasFill ? 'has-data' : '',
-            !countyFactsLoading && !hasFill ? 'is-empty' : '',
-            lvl ? `lvl-${lvl}` : '',
-            selected?.level === 'county' && selected.id === f.id ? 'is-selected' : '',
-          ]
-            .filter(Boolean)
-            .join(' ');
-          return (
-            <path
-              key={f.id}
-              d={f.paths}
-              className={classes}
-              role="button"
-              tabIndex={0}
-              data-target-size-exempt="geographic-shape"
-              aria-label={`${f.name} County`}
-              aria-keyshortcuts="Enter"
-              onMouseEnter={(e) =>
-                setHover({
-                  x: e.clientX,
-                  y: e.clientY,
-                  name: `${f.name} County, ${stateName}`,
-                  // Honest null while the live payload is loading or when it
-                  // did not return a row for this county. The visual class
-                  // distinguishes loading/empty from a small positive count.
-                  count,
-                  avgScore,
-                  topSegment,
-                  sourceHint: 'mip.gold.county_rollup',
-                  overlay: overlayUnit
-                    ? {
-                        leadCount: overlayUnit.lead_count,
-                        assignedCount: overlayUnit.assigned_count,
-                        unattendedCount: overlayUnit.unattended_count,
-                        coveringOfficerCount: overlayUnit.covering_officer_count,
-                        coveringOfficers: overlayUnit.covering_officers,
-                      }
-                    : undefined,
-                })
-              }
-              onMouseMove={(e) =>
-                setHover((h) => (h ? { ...h, x: e.clientX, y: e.clientY } : h))
-              }
-              onMouseLeave={() => setHover(null)}
-              onClick={() => {
-                // Every county drills to ZIP level. The /api/geo/zip-rollups
-                // fetch may return an empty list for out-of-footprint
-                // counties -- the ZIP render handles that with an empty
-                // state + "open in Lead Queue" fallback.
-                setLevel('zip');
-                setSelected({ level: 'county', id: f.id, name: `${f.name} County` });
-              }}
-              onKeyDown={(e) => {
-                if (e.key !== 'Enter' && e.key !== ' ') return;
-                e.preventDefault();
-                setLevel('zip');
-                setSelected({ level: 'county', id: f.id, name: `${f.name} County` });
-              }}
-            />
-          );
-        })}
-      </svg>
-    );
-  };
-
-  // ----- ZIP level: tile grid for the active county. -----------------------
+  // ----- ZIP level: tile grid for the drilled state. -----------------------
   // The ZIP grid is generated from the live ZIP rollup payload for every
-  // county, so the component has no county-specific visual exceptions.
+  // state, so the component has no state-specific visual exceptions.
   const renderZipLevel = () => {
-    const countyFips = selected?.level === 'county' ? selected.id : null;
-    const countyName = selected?.level === 'county' ? selected.name : '';
-    const stateUC =
-      countyStateId?.toUpperCase() ??
-      (countyFips ? Object.entries(USCODE_TO_FIPS).find(([, v]) => countyFips.startsWith(v))?.[0].toUpperCase() ?? '' : '');
-    if (!countyFips) return null;
-    const byZip = liveZipFacts[countyFips];
+    const stateUC = drillStateId?.toUpperCase() ?? '';
+    if (!stateUC) return null;
+    const byZip = liveZipFacts[stateUC];
     const zipsFromApi = byZip ? Object.values(byZip) : [];
 
     if (byZip && zipsFromApi.length === 0) {
-      // API returned empty — county outside the Cotality eval share or
-      // the CTAS hasn't populated ZIPs for it. Give the user a graceful
-      // fallback path. The Lead Queue preserves the county filter via
-      // ?state=XX&county=FFFFF; the Queue resolves "borrowers in this
-      // county" client-side by intersecting ZIPs (see
-      // /lead-queue.tsx::countyZips).
+      // API returned empty — the state is outside the Cotality eval share
+      // or the CTAS hasn't populated ZIPs for it. Give the user a graceful
+      // fallback path into the state's lead queue.
       return (
         <div className="map-stage">
           <div className="map-center-card map-center-card--narrow">
             <div className="text-2 mb-2">
-              No ZIP-level rollup for {countyName}.
+              No ZIP-level rollup for {drillStateName}.
             </div>
             <div className="mb-3">
-              Browse this county&apos;s lead queue — the filter will narrow to borrowers in {countyName}.
+              Browse this state&apos;s lead queue — the filter will narrow to borrowers in {drillStateName}.
             </div>
             <button
               type="button"
               className="btn btn--ghost"
-              onClick={() => navigate(leadQueuePath({ state: stateUC, county: countyFips }))}
+              onClick={() => navigate(leadQueuePath({ state: stateUC }))}
             >
-              Open Lead Queue for {countyName}
+              Open Lead Queue for {drillStateName}
             </button>
           </div>
         </div>
@@ -1076,7 +711,7 @@ export function USChoroplethMap({
     );
     const visible = sorted.slice(0, 24);
     return (
-      <div className="zip-tiles" role="list" aria-label={`ZIPs in ${countyName}`}>
+      <div className="zip-tiles" role="list" aria-label={`ZIPs in ${drillStateName}`}>
         {visible.map((rollup, tileIndex) => {
           const count = rollup.addressable_borrowers ?? null;
           const avgScore = rollup.avg_opportunity_score ?? null;
@@ -1111,7 +746,7 @@ export function USChoroplethMap({
                 setHover({
                   x: e.clientX,
                   y: e.clientY,
-                  name: `ZIP ${rollup.zip}, ${countyName}`,
+                  name: `ZIP ${rollup.zip}, ${drillStateName}`,
                   count,
                   avgScore,
                   topSegment,
@@ -1134,7 +769,7 @@ export function USChoroplethMap({
               onMouseLeave={() => setHover(null)}
 	              onClick={() => {
 	                setSelected({ level: 'zip', id: rollup.zip, name: rollup.zip });
-	                navigate(leadQueuePath({ state: stateUC, county: countyFips, zip: rollup.zip }));
+	                navigate(leadQueuePath({ state: stateUC, zip: rollup.zip }));
 	              }}
 	            >
               <span className="zip-tile__code">{rollup.zip}</span>
@@ -1160,43 +795,24 @@ export function USChoroplethMap({
         <div className="map-crumbs">
           <div className="eyebrow">Geography drill-down</div>
           <div className="topbar__crumbs map-crumbs__trail">
+            {/* US is the single back step — with the county rung gone,
+                zip -> state IS zip -> national. */}
             <button
               type="button"
               className={`filter filter--compact ${level === 'state' ? 'is-active' : ''}`}
               onClick={() => {
                 setLevel('state');
-                setCountyStateId(null);
+                setDrillStateId(null);
                 setSelected(null);
               }}
             >
               <span className="filter__value">US</span>
             </button>
-            {level !== 'state' && (
-              <>
-                <Icon name="chevright" size={11} />
-                <button
-                  type="button"
-                  className={`filter filter--compact ${level === 'county' ? 'is-active' : ''}`}
-                  onClick={() => {
-                    setLevel('county');
-                    const st = countyStateId ?? 'il';
-                    const stName = usaMap?.locations.find((l) => l.id === st)?.name ?? 'State';
-                    setSelected({ level: 'state', id: st, name: stName });
-                  }}
-                >
-                  <span className="filter__value">
-                    {countyStateId
-                      ? usaMap?.locations.find((l) => l.id === countyStateId)?.name ?? 'State'
-                      : 'State'}
-                  </span>
-                </button>
-              </>
-            )}
-            {level === 'zip' && selected?.level === 'county' && (
+            {level === 'zip' && (
               <>
                 <Icon name="chevright" size={11} />
                 <span className="filter filter--compact is-active">
-                  <span className="filter__value">{selected.name}</span>
+                  <span className="filter__value">{drillStateName || 'State'}</span>
                 </span>
               </>
             )}
@@ -1209,18 +825,17 @@ export function USChoroplethMap({
         <div className="map-corner-chips">
           <Chip variant="neutral" icon="pin">
             {level === 'state'
-              ? footprint.dataScope?.county_count
-                ? `${footprint.dataScope.county_count.toLocaleString()} counties · click to drill`
+              ? footprint.dataScope?.zip_count
+                ? `${footprint.dataScope.zip_count.toLocaleString()} ZIPs · click a state to drill`
                 : 'Loading coverage…'
-              : level === 'county'
-                ? (countyStateId && countyScopeByState[countyStateId.toUpperCase()])
-                  ? countyScopeByState[countyStateId.toUpperCase()]
-                  : footprint.dataScope?.scope_label ?? 'Cotality data coverage'
-                : `ZIPs in ${selected?.level === 'county' ? selected.name : 'county'}`}
+              : `ZIPs in ${drillStateName || 'state'}`}
           </Chip>
-          {level !== 'state' && countyStateId && countyScopeByState[countyStateId.toUpperCase()] && level !== 'county' && (
+          {/* Drill-gap disclosure: the ZIP tiles below sum to LESS than the
+              state tile the user just clicked, because the share carries no
+              usable ZIP for these borrowers. Say it where the gap appears. */}
+          {level === 'zip' && zipUnassignedForDrill > 0 && (
             <Chip variant="neutral" icon="db">
-              {countyScopeByState[countyStateId.toUpperCase()]}
+              {zipUnassignedForDrill.toLocaleString()} borrowers without ZIP assignment
             </Chip>
           )}
           {/* S9 overlay toggle — two .filter-style buttons in the prototype's
@@ -1270,7 +885,6 @@ export function USChoroplethMap({
           {mapStatus}
         </div>
         {level === 'state' && renderStateLevel()}
-        {level === 'county' && renderCountyLevel()}
         {level === 'zip' && renderZipLevel()}
       </div>
 

--- a/frontend/src/components/mortgage/USChoroplethMap.utils.ts
+++ b/frontend/src/components/mortgage/USChoroplethMap.utils.ts
@@ -111,6 +111,9 @@ export interface StateFacts {
   avgScore: number;
   lvl: 1 | 2 | 3 | 4;
   topSegment?: string;
+  /** See `HoverState.zipUnassigned`. Null when the rollup predates the
+   *  disclosure field or the state has full ZIP coverage. */
+  zipUnassigned?: number | null;
 }
 
 export function countyDisplayName(rollup: CountyRollup): string {
@@ -121,7 +124,20 @@ export function countyDisplayName(rollup: CountyRollup): string {
   return rollup.fips_5;
 }
 
-export type Level = 'state' | 'county' | 'zip';
+/**
+ * Map drill levels. The county level was removed on 2026-08-08: the
+ * Cotality share carries exactly one county FIPS per state, so
+ * `county_fips_5` is NULL across gold and every county-keyed rollup
+ * returns zero rows — the level rendered a grid of unfilled polygons
+ * that dead-ended. The honest drill is state -> ZIP.
+ *
+ * The county *geometry* helpers below (`buildCountiesPayload`,
+ * `countyDisplayName`, `CountiesPayload`) are deliberately kept: they are
+ * pure and tested, and a licensed county dataset would light the level
+ * back up. See `/api/geo/county-rollups`, which is kept for the same
+ * reason.
+ */
+export type Level = 'state' | 'zip';
 
 export interface Selected {
   level: Level;
@@ -163,6 +179,10 @@ export interface HoverState {
   sourceHint?: string;
   /** Present when the assignment overlay is active (S9). */
   overlay?: HoverOverlay;
+  /** Borrowers in this state that the ZIP drill cannot show (no usable
+   *  5-digit ZIP in the share). Set only when > 0 — the disclosure exists
+   *  to explain why the ZIP tiles sum below the state tile. */
+  zipUnassigned?: number | null;
 }
 
 export interface LeadQueuePathInput {

--- a/frontend/src/components/mortgage/USChoroplethMapTooltip.tsx
+++ b/frontend/src/components/mortgage/USChoroplethMapTooltip.tsx
@@ -57,6 +57,20 @@ export function USChoroplethMapTooltip({ hover, activeSegNames }: USChoroplethMa
           <span className="map-tip__seg-value">{hover.topSegment}</span>
         </div>
       )}
+      {/* Drill-gap disclosure. The ZIP layer is keyed on a 5-digit ZIP and
+          the share does not carry one for every property, so this state's
+          ZIP tiles will sum BELOW the marketable count above. Disclosed on
+          the state hover — before the drill — so the shortfall is expected
+          rather than discovered. Reuses the existing muted compact row; no
+          new CSS. */}
+      {typeof hover.zipUnassigned === 'number' && hover.zipUnassigned > 0 && (
+        <div className="map-tip__row map-tip__row--compact map-tip__row--muted">
+          <span>ZIP coverage</span>
+          <span className="v map-tip__value--small">
+            {hover.zipUnassigned.toLocaleString()} borrowers without ZIP assignment
+          </span>
+        </div>
+      )}
       {hover.overlay && (
         <div className="map-tip__overlay">
           <div className="map-tip__row map-tip__row--compact">

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -703,7 +703,7 @@ describe('geo API client', () => {
       portfolioCriteria,
     );
     await api.zipRollups(
-      '12011',
+      { state: 'fl' },
       undefined,
       ['itm', 'investor', 'equity', 'retention'],
       'all',
@@ -723,7 +723,11 @@ describe('geo API client', () => {
 
     const zipUrl = new URL(calls[2].path, 'http://localhost');
     expect(zipUrl.pathname).toBe('/api/v1/geo/zip-rollups');
-    expect(zipUrl.searchParams.get('county_fips')).toBe('12011');
+    // The live ZIP drill key is the STATE. The county grain is dead in the
+    // current share (one FIPS per state), so a county-keyed ZIP request
+    // returns nothing — the map must never send one.
+    expect(zipUrl.searchParams.get('state')).toBe('FL');
+    expect(zipUrl.searchParams.get('county_fips')).toBeNull();
     expect(zipUrl.searchParams.get('segment_codes')).toBe('itm,investor,equity,retention');
     expect(zipUrl.searchParams.get('segment_mode')).toBe('all');
 
@@ -736,6 +740,25 @@ describe('geo API client', () => {
       expect(url.searchParams.get('purchase_intent')).toBe('Listed for sale');
       expect(url.searchParams.get('min_equity_pct_label')).toBe('≥ 25%');
     }
+  });
+
+  it('still sends a county-keyed ZIP rollup request for the reserved key', async () => {
+    // The Lead Queue resolves `?county=FFFFF` to a ZIP set for a scope
+    // chip. That key is honestly empty against the current share, but the
+    // client must keep speaking it so a licensed county dataset needs no
+    // frontend change.
+    const calls: Array<{ path: string }> = [];
+    vi.stubGlobal('fetch', async (path: string) => {
+      calls.push({ path });
+      return jsonResponse(200, { rollups: [], snapshot_date: null });
+    });
+
+    await api.zipRollups({ countyFips: '17031' });
+
+    const url = new URL(calls[0].path, 'http://localhost');
+    expect(url.pathname).toBe('/api/v1/geo/zip-rollups');
+    expect(url.searchParams.get('county_fips')).toBe('17031');
+    expect(url.searchParams.get('state')).toBeNull();
   });
 });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -343,6 +343,15 @@ export interface LeadsPageResult {
 export type GeoQueryCriteria = Record<string, string | number | readonly string[] | null | undefined>;
 
 /**
+ * The ZIP-rollup geography key — exactly one, never both. `state` is the
+ * live drill; `countyFips` is reserved for a future licensed county
+ * dataset and returns [] against the current share.
+ */
+export type ZipRollupKey =
+  | { state: string; countyFips?: never }
+  | { countyFips: string; state?: never };
+
+/**
  * S9 assigned-vs-unattended overlay. Mirrors
  * `backend/schemas/geo_overlay.py`: per-geography-unit lead / assigned /
  * unattended counts plus loan-officer coverage. The overlay is the
@@ -1167,15 +1176,28 @@ export const api = {
     );
   },
 
+  /**
+   * Per-ZIP rollups for exactly one geography key.
+   *
+   * `{ state }` is the live drill: the Cotality share carries a single
+   * county FIPS per state, so `county_fips_5` is NULL across gold and a
+   * `{ countyFips }` read returns [] for every county today. The FIPS key
+   * stays on the contract for a future licensed county dataset. The union
+   * type makes "both keys" a compile error, mirroring the API's 422.
+   */
   zipRollups: (
-    countyFips: string,
+    key: ZipRollupKey,
     signal?: AbortSignal,
     segmentCodes?: string[] | null,
     segmentMode: SegmentFilterMode = 'any',
     portfolioCriteria?: GeoQueryCriteria | null,
   ) => {
     const params = new URLSearchParams();
-    params.set('county_fips', countyFips);
+    if (key.state) {
+      params.set('state', key.state.toUpperCase());
+    } else if (key.countyFips) {
+      params.set('county_fips', key.countyFips);
+    }
     if (segmentCodes && segmentCodes.length > 0) {
       params.set('segment_codes', segmentCodes.join(','));
       params.set('segment_mode', segmentMode);

--- a/frontend/src/routes/home.tsx
+++ b/frontend/src/routes/home.tsx
@@ -299,12 +299,15 @@ export default function Home() {
       <div className="section-hdr">
         <div>
           <div className="eyebrow">Geography</div>
-          <div className="h-2">State → county → ZIP → borrower</div>
+          <div className="h-2">State → ZIP → borrower</div>
         </div>
       </div>
-      {/* Home map drills in-place through state/county/ZIP and then opens
-          the filtered Lead Queue. Lead Queue remains the source-of-truth
-          index for borrower selection. Audit exploration is admin-only. */}
+      {/* Home map drills in-place from state to ZIP and then opens the
+          filtered Lead Queue. There is no county rung — the Cotality share
+          carries one county FIPS per state, so county_fips_5 is NULL across
+          gold (see USChoroplethMap's design-contract note). Lead Queue
+          remains the source-of-truth index for borrower selection. Audit
+          exploration is admin-only. */}
       <USChoroplethMap drillBehavior="filter" />
 
       <div className="section-actions">

--- a/frontend/src/routes/lead-queue.tsx
+++ b/frontend/src/routes/lead-queue.tsx
@@ -307,7 +307,7 @@ export default function LeadQueue() {
     let cancelled = false;
     api
       .zipRollups(
-        countyFilter,
+        { countyFips: countyFilter },
         ctrl.signal,
         segmentCodes.length > 0 ? segmentCodes : segment ? [segment] : null,
         segmentMode,

--- a/frontend/src/routes/segment-intelligence.tsx
+++ b/frontend/src/routes/segment-intelligence.tsx
@@ -272,9 +272,10 @@ export default function SegmentIntelligence() {
     setSegmentMode((current) => (current === nextMode ? current : nextMode));
   }, [searchParams]);
   // Geography drill state emitted by USChoroplethMap. State is the 2-char
-  // USPS code; null = US level (no geography filter). County/ZIP are pushed
-  // down to /api/leads so the ranked table follows the same state → county
-  // → ZIP cohort the map counted.
+  // USPS code; null = US level (no geography filter). ZIP is pushed down to
+  // /api/leads so the ranked table follows the same state → ZIP cohort the
+  // map counted. `county` is always null (the map has no county level) but
+  // stays wired through for a future licensed county dataset.
   const [mapSelection, setMapSelection] = useState<MapSelection>({
     state: null,
     county: null,

--- a/frontend/src/types/geo.ts
+++ b/frontend/src/types/geo.ts
@@ -32,6 +32,11 @@ export interface StateRollup {
   in_the_money: number;
   top_tier_opportunities: number;
   avg_score: number;
+  /** How many of `addressable` the ZIP drill will NOT show, because the
+   *  share carries no usable 5-digit ZIP for them. The state tile and the
+   *  sum of its ZIP tiles disagree by exactly this much, so the UI has to
+   *  say so rather than let a reader find the gap themselves. */
+  zip_unassigned_count?: number | null;
   top_segment_code?: string | null;
 }
 
@@ -69,7 +74,9 @@ export interface ZipRollup {
 }
 
 export interface ZipRollupResponse {
-  fips_5: string;
+  /** Echoes whichever key answered — exactly one is populated. */
+  fips_5?: string | null;
+  state?: string | null;
   rollups: ZipRollup[];
   snapshot_date?: string | null;
 }

--- a/frontend/tests/e2e/demo_visual.spec.ts
+++ b/frontend/tests/e2e/demo_visual.spec.ts
@@ -15,8 +15,6 @@ test.use({ baseURL: APP_URL, extraHTTPHeaders: AUTH_HEADERS });
 type MapDrillTarget = {
   state: string;
   stateName: string;
-  countyFips: string;
-  countyName: string;
 };
 
 function escapeRegExp(value: string): string {
@@ -72,35 +70,21 @@ async function discoverMapDrillTarget(
     footprint.states?.find((row: { state_code?: string }) => row.state_code === stateRollup.state)
       ?.state_name ?? stateRollup.state;
 
-  const countyResp = await request.get(
-    `${API_URL}/api/geo/county-rollups?state=${stateRollup.state}${params.toString() ? `&${params.toString()}` : ''}`,
+  // The drill is state -> ZIP; there is no county rung to discover (the
+  // share carries one county FIPS per state, so county rollups are empty).
+  const zipResp = await request.get(
+    `${API_URL}/api/geo/zip-rollups?state=${stateRollup.state}${params.toString() ? `&${params.toString()}` : ''}`,
     { headers: AUTH_HEADERS },
   );
-  expect(countyResp.status(), 'county rollups target discovery').toBe(200);
-  const countyPayload = await countyResp.json();
-  let county: { fips_5?: string; county_name?: string; addressable_borrowers?: number } | undefined;
-  for (const row of countyPayload.rollups as Array<{ fips_5?: string; county_name?: string; addressable_borrowers?: number }>) {
-    if (!row.fips_5 || Number(row.addressable_borrowers ?? 0) <= 0) continue;
-    const zipResp = await request.get(
-      `${API_URL}/api/geo/zip-rollups?county_fips=${row.fips_5}${params.toString() ? `&${params.toString()}` : ''}`,
-      { headers: AUTH_HEADERS },
-    );
-    if (zipResp.status() !== 200) continue;
-    const zipPayload = await zipResp.json();
-    if (Array.isArray(zipPayload.rollups) && zipPayload.rollups.length > 0) {
-      county = row;
-      break;
-    }
-  }
-  expect(county, 'county rollups should expose a populated county').toBeTruthy();
-  const rawCountyName = String(county.county_name || county.fips_5);
+  expect(zipResp.status(), 'zip rollups target discovery').toBe(200);
+  const zipPayload = await zipResp.json();
+  expect(
+    Array.isArray(zipPayload.rollups) && zipPayload.rollups.length > 0,
+    `state ${stateRollup.state} should expose a populated ZIP rollup`,
+  ).toBe(true);
   return {
     state: stateRollup.state,
     stateName,
-    countyFips: county.fips_5,
-    countyName: rawCountyName.toLowerCase().endsWith('county')
-      ? rawCountyName
-      : `${rawCountyName} County`,
   };
 }
 
@@ -157,23 +141,14 @@ async function drillToZipLayer(page: Page, target: MapDrillTarget, segmentCodes:
   const map = page.locator('.map-wrap').first();
   await bringMapIntoViewport(page);
   const state = map.getByRole('button', { name: new RegExp(`^${escapeRegExp(target.stateName)}$`) }).first();
-  const countyResponse = page
-    .waitForResponse(filteredGeoResponse(segmentCodes, '/api/geo/county-rollups'), { timeout: 45_000 })
-    .catch((error: Error) => error);
-  await clickSvgRegion(page, state, target.stateName);
-
-  await bringMapIntoViewport(page);
-  const county = map.getByRole('button', { name: new RegExp(escapeRegExp(target.countyName), 'i') }).first();
-  await expect(county, `${target.stateName} pointer click should drill into counties`).toBeVisible({ timeout: 10_000 });
-  const countyResult = await countyResponse;
-  if (countyResult instanceof Error) throw countyResult;
-
   const zipResponse = page
     .waitForResponse(filteredGeoResponse(segmentCodes, '/api/geo/zip-rollups'), { timeout: 45_000 })
     .catch((error: Error) => error);
-  await clickSvgRegion(page, county, target.countyName);
-  await expect(page.locator('.map-crumbs'), `${target.countyName} pointer click should drill into ZIPs`)
-    .toContainText(target.countyName, { timeout: 5_000 });
+  // One click: state -> ZIP tiles.
+  await clickSvgRegion(page, state, target.stateName);
+  await expect(page.locator('.zip-tiles'), `${target.stateName} pointer click should drill into ZIPs`)
+    .toBeVisible({ timeout: 10_000 });
+  await expect(page.locator('.map-crumbs')).toContainText(target.stateName, { timeout: 5_000 });
   const zipResult = await zipResponse;
   if (zipResult instanceof Error) throw zipResult;
 }

--- a/frontend/tests/e2e/geo_campaign_prefill.spec.ts
+++ b/frontend/tests/e2e/geo_campaign_prefill.spec.ts
@@ -6,9 +6,12 @@ import { test, expect, type Page, type Route } from '@playwright/test';
  * module0.spec.ts; real_data.spec.ts owns live validation).
  *
  * Flow under test:
- *   home map → drill Illinois → toggle "Unattended leads" → drill Cook
- *   County → ZIP grid shows per-tile unattended counts → "Start campaign"
+ *   home map → toggle "Unattended leads" → drill Illinois straight to its
+ *   ZIP grid → tiles show per-tile unattended counts → "Start campaign"
  *   → Portfolio Builder shows the typed prefilled draft context.
+ *
+ * There is no county rung: the Cotality share carries one county FIPS per
+ * state, so the county level could never render honest data (2026-08-08).
  */
 
 const API_PREFIX = /\/api\/(?:v1\/)?/;
@@ -84,22 +87,14 @@ async function mockGeo(page: Page) {
       snapshot_date: '2026-07-10',
     }),
   );
-  await page.route(apiPattern('geo/county-rollups'), (route) =>
-    json(route, {
-      state: 'IL',
-      rollups: [
-        { fips_5: '17031', state: 'IL', county_name: 'Cook', addressable_borrowers: 620, in_the_money_borrowers: 310, high_opportunity_borrowers: 260, avg_opportunity_score: 86, top_segment_code: 'itm' },
-      ],
-      snapshot_date: '2026-07-10',
-      scope_note: 'Cotality data coverage for IL: 1 county returned',
-    }),
-  );
+  // ZIP rollups are keyed on state; county_fips_5 is NULL on every live row.
   await page.route(apiPattern('geo/zip-rollups'), (route) =>
     json(route, {
-      fips_5: '17031',
+      state: 'IL',
+      fips_5: null,
       rollups: [
-        { zip: '60611', state: 'IL', county_fips_5: '17031', addressable_borrowers: 94, avg_opportunity_score: 94, top_segment_code: 'itm', sample_borrower_id: 'B-0000000000001' },
-        { zip: '60647', state: 'IL', county_fips_5: '17031', addressable_borrowers: 72, avg_opportunity_score: 82, top_segment_code: 'equity', sample_borrower_id: 'B-0000000000002' },
+        { zip: '60611', state: 'IL', county_fips_5: null, addressable_borrowers: 94, avg_opportunity_score: 94, top_segment_code: 'itm', sample_borrower_id: 'B-0000000000001' },
+        { zip: '60647', state: 'IL', county_fips_5: null, addressable_borrowers: 72, avg_opportunity_score: 82, top_segment_code: 'equity', sample_borrower_id: 'B-0000000000002' },
       ],
       snapshot_date: '2026-07-10',
     }),
@@ -123,24 +118,11 @@ async function mockGeo(page: Page) {
         lead_definition: 'Marketing-eligible borrowers in the live lead queue (mip.gold.borrower_360, marketing_eligible = TRUE)',
       });
     }
-    if (level === 'county') {
-      return json(route, {
-        level: 'county',
-        state: url.searchParams.get('state') ?? 'IL',
-        county_fips: null,
-        units: [
-          { unit_id: '17031', lead_count: 410, assigned_count: 96, unattended_count: 314, covering_officer_count: 1, covering_officers: ['Summit LO 01'] },
-        ],
-        total_leads: 410,
-        total_assigned: 96,
-        total_unattended: 314,
-        lead_definition: 'Marketing-eligible borrowers in the live lead queue (mip.gold.borrower_360, marketing_eligible = TRUE)',
-      });
-    }
+    // level=zip is keyed on state now — county_fips stays null.
     return json(route, {
       level: 'zip',
-      state: 'IL',
-      county_fips: url.searchParams.get('county_fips') ?? '17031',
+      state: url.searchParams.get('state') ?? 'IL',
+      county_fips: null,
       units: [
         { unit_id: '60611', lead_count: 64, assigned_count: 21, unattended_count: 43, covering_officer_count: 1, covering_officers: ['Summit LO 01'] },
         { unit_id: '60647', lead_count: 48, assigned_count: 9, unattended_count: 39, covering_officer_count: 1, covering_officers: ['Summit LO 01'] },
@@ -186,24 +168,21 @@ test.describe('S9 — geo overlay + campaign-from-geo prefill', () => {
   test('drill to ZIP grid, toggle unattended overlay, start prefilled campaign draft', async ({ page }) => {
     await page.goto(APP_URL + '/');
 
-    // --- State level: map up, drill into Illinois. ---
+    // --- State level: map up, overlay on, national totals. ---
     const illinois = page.locator('[aria-label="Illinois"]').first();
     await expect(illinois).toBeVisible({ timeout: 45_000 });
-    await illinois.click();
-
-    // --- County level: the drilled state is the selected unit, so the
-    // campaign affordance is already available. Toggle the overlay. ---
-    await expect(page.getByRole('button', { name: 'Start campaign' })).toBeVisible();
     await page.getByRole('button', { name: 'Unattended leads' }).click();
     await expect(page.getByText('Unattended leads in selection')).toBeVisible();
-    await expect(page.locator('.map-legend')).toContainText('314');
-    await expect(page.locator('.map-legend')).toContainText('410 leads · 96 assigned');
+    await expect(page.locator('.map-legend')).toContainText('1,605');
+    await expect(page.locator('.map-legend')).toContainText('1,745 leads · 140 assigned');
     // Overlay evidence affordance present (never removed).
     await expect(page.locator('.map-legend .evidence-chip')).toBeVisible();
 
-    // --- ZIP level: drill Cook County; tiles carry unattended counts. ---
-    await page.locator('[aria-label="Cook County"]').click();
+    // --- ZIP level: one click from the state, no county rung. The drilled
+    // state is the selected unit, so the campaign affordance appears here. ---
+    await illinois.click();
     await expect(page.locator('.zip-tiles')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('button', { name: 'Start campaign' })).toBeVisible();
     const firstTile = page.locator('.zip-tile').first();
     await expect(firstTile).toContainText('60611');
     await expect(firstTile).toContainText('43 unattended');
@@ -216,9 +195,11 @@ test.describe('S9 — geo overlay + campaign-from-geo prefill', () => {
     await expect(page).toHaveURL(/\/portfolio-builder\?/);
     const url = new URL(page.url());
     expect(url.searchParams.get('prefill_source')).toBe('geo-drilldown');
-    expect(url.searchParams.get('prefill_level')).toBe('county');
+    // State is the drilled unit — there is no county to encode.
+    expect(url.searchParams.get('prefill_level')).toBe('state');
     expect(url.searchParams.get('states')).toBe('IL');
-    expect(url.searchParams.get('prefill_county_fips')).toBe('17031');
+    expect(url.searchParams.get('prefill_county_fips')).toBeNull();
+    // The ZIP grid is on screen, so the snapshot is the sum of its tiles.
     expect(url.searchParams.get('prefill_lead_count')).toBe('112');
     expect(url.searchParams.get('prefill_unattended_count')).toBe('82');
 
@@ -227,7 +208,7 @@ test.describe('S9 — geo overlay + campaign-from-geo prefill', () => {
     await expect(banner).toBeVisible();
     await expect(banner).toContainText('Campaign draft from geography drill-down');
     await expect(banner).toContainText('State IL — applied');
-    await expect(banner).toContainText('FIPS 17031');
+    await expect(banner).not.toContainText('FIPS');
     await expect(banner).toContainText('when the campaign builder (S10) ships');
     await expect(banner).toContainText('112 leads · 82 unattended at draft time');
 

--- a/frontend/tests/e2e/live_hardening_regressions.spec.ts
+++ b/frontend/tests/e2e/live_hardening_regressions.spec.ts
@@ -478,7 +478,12 @@ test('segment any/all API counts are de-duplicated and intersection-safe', async
   ).toBe(borrowerIds.length);
 });
 
-test('county drilldown distinguishes loading counties from loaded positive and empty counties', async ({ page, request }) => {
+// Re-keyed 2026-08-08 from a county drilldown. The share carries one county
+// FIPS per state, so county_fips_5 is NULL everywhere and the county level
+// was removed — a test asserting live county fills would assert a fiction.
+// The intent survives at the level that exists: a segment-filtered state
+// drill must land on real ZIP tiles carrying real fill tiers.
+test('state drilldown lands on ZIP tiles with live segment-filtered fills', async ({ page, request }) => {
   const query = 'segment_codes=itm,listed&segment_mode=any';
   const states = await getJson<{ rollups: StateRollup[] }>(request, `/api/geo/state-rollups?${query}`);
   const candidates = states.rollups
@@ -487,24 +492,19 @@ test('county drilldown distinguishes loading counties from loaded positive and e
 
   expect(candidates.length, 'expected at least one live state with borrowers for the selected segments').toBeGreaterThan(0);
 
-  let selected: { state: string; stateName: string; countyName: string } | null = null;
+  let selected: { state: string; stateName: string } | null = null;
   for (const state of candidates) {
-    const counties = await getJson<{ rollups: CountyRollup[] }>(
+    const zips = await getJson<{ rollups: Array<{ zip?: string; addressable_borrowers?: number }> }>(
       request,
-      `/api/geo/county-rollups?state=${state.state}&${query}`,
+      `/api/geo/zip-rollups?state=${state.state}&${query}`,
     );
-    const county = counties.rollups.find((row) => countValue(row) > 0);
-    if (county) {
-      selected = {
-        state: state.state,
-        stateName: STATE_NAMES[state.state],
-        countyName: county.county_name,
-      };
+    if (zips.rollups.some((row) => Number(row.addressable_borrowers ?? 0) > 0)) {
+      selected = { state: state.state, stateName: STATE_NAMES[state.state] };
       break;
     }
   }
 
-  expect(selected, 'expected a live county with borrowers for the selected segments').not.toBeNull();
+  expect(selected, 'expected a live state with ZIP rollups for the selected segments').not.toBeNull();
 
   await gotoApp(page, '/segment-intelligence');
   await clickSegment(page, 'Prime Refi Candidates');
@@ -512,12 +512,14 @@ test('county drilldown distinguishes loading counties from loaded positive and e
   await page.locator('path.map-region', { hasText: '' }).first().waitFor({ state: 'visible', timeout: 45_000 });
   await page.locator(`path[aria-label="${selected!.stateName}"]`).click();
 
-  const countyPath = page.locator(`path[aria-label="${selected!.countyName} County"]`).first();
-  await expect(countyPath, `county path ${selected!.countyName}`).toBeVisible({ timeout: 45_000 });
-  await expect(countyPath).toHaveClass(/(?:is-loading|has-data)/);
-  await expect(countyPath).toHaveClass(/has-data/, { timeout: 45_000 });
-  await expect(countyPath).not.toHaveClass(/is-empty/);
-  await expect(countyPath).toHaveClass(/lvl-[1-4]/);
+  const tiles = page.locator('.zip-tiles');
+  await expect(tiles, `ZIP tiles for ${selected!.stateName}`).toBeVisible({ timeout: 45_000 });
+  await expect(tiles).toHaveAttribute('aria-label', `ZIPs in ${selected!.stateName}`);
+  const firstTile = page.locator('.zip-tile').first();
+  await expect(firstTile).toHaveClass(/zip-tile--lvl-[1-4]/);
+  // A real ZIP with a real count, not an em-dash placeholder.
+  await expect(firstTile.locator('.zip-tile__code')).toHaveText(/^\d{5}$/);
+  await expect(firstTile.locator('.zip-tile__count')).not.toHaveText('—');
 });
 
 test('Genie answers valid recommended and free-form questions without policy-blocking', async ({ page, request }) => {

--- a/frontend/tests/e2e/real_data.spec.ts
+++ b/frontend/tests/e2e/real_data.spec.ts
@@ -250,8 +250,6 @@ async function expectLiveGenieUi(
 type MapDrillTarget = {
   state: string;
   stateName: string;
-  countyFips: string;
-  countyName: string;
 };
 
 function escapeRegExp(value: string): string {
@@ -517,53 +515,32 @@ async function discoverMapDrillTarget(
     footprint.states?.find((row: { state_code?: string }) => row.state_code === stateRollup.state)
       ?.state_name ?? stateRollup.state;
 
-  const countyResp = await request.get(
-    `${API_URL}/api/geo/county-rollups?state=${stateRollup.state}${params.toString() ? `&${params.toString()}` : ''}`,
+  // The drill is state -> ZIP. County discovery is deliberately absent:
+  // the Cotality share carries one county FIPS per state, so
+  // /api/geo/county-rollups is empty for every state and a county-keyed
+  // ZIP request returns []. Asserting otherwise would pin a claim the
+  // data cannot support.
+  const zipResp = await request.get(
+    `${API_URL}/api/geo/zip-rollups?state=${stateRollup.state}${params.toString() ? `&${params.toString()}` : ''}`,
     { headers: AUTH_HEADERS },
   );
-  expect(countyResp.status(), 'county rollups target discovery').toBe(200);
-  const countyPayload = await countyResp.json();
-  let county:
-    | { fips_5?: string; county_name?: string; addressable_borrowers?: number }
-    | undefined;
-  for (const row of countyPayload.rollups as Array<{
-    fips_5?: string;
-    county_name?: string;
-    addressable_borrowers?: number;
-  }>) {
-    if (!row.fips_5 || Number(row.addressable_borrowers ?? 0) <= 0) continue;
-    const zipResp = await request.get(
-      `${API_URL}/api/geo/zip-rollups?county_fips=${row.fips_5}${params.toString() ? `&${params.toString()}` : ''}`,
-      { headers: AUTH_HEADERS },
-    );
-    if (zipResp.status() !== 200) continue;
-    const zipPayload = await zipResp.json();
-    if (Array.isArray(zipPayload.rollups) && zipPayload.rollups.length > 0) {
-      county = row;
-      break;
-    }
-  }
-  expect(county, 'county rollups should expose at least one populated county').toBeTruthy();
-  if (!county) throw new Error('No populated county with ZIP rollups was found');
-  const countyFips = String(county.fips_5 ?? '').trim();
-  expect(countyFips, 'populated county rollup must include a FIPS code').not.toBe('');
-  const rawCountyName = String(county.county_name || countyFips);
-  const countyName = rawCountyName.toLowerCase().endsWith('county')
-    ? rawCountyName
-    : `${rawCountyName} County`;
+  expect(zipResp.status(), 'zip rollups target discovery').toBe(200);
+  const zipPayload = await zipResp.json();
+  expect(
+    Array.isArray(zipPayload.rollups) && zipPayload.rollups.length > 0,
+    `state ${stateRollup.state} should expose at least one populated ZIP rollup`,
+  ).toBe(true);
 
   return {
     state: stateRollup.state,
     stateName,
-    countyFips,
-    countyName,
   };
 }
 
-async function drillStateToCounty(page: Page, target: MapDrillTarget) {
+async function drillStateToZips(page: Page, target: MapDrillTarget) {
   const map = page.locator('.map-wrap').first();
   const state = map.getByRole('button', { name: new RegExp(`^${escapeRegExp(target.stateName)}$`) }).first();
-  const county = map.getByRole('button', { name: new RegExp(escapeRegExp(target.countyName), 'i') }).first();
+  const zipTiles = page.locator('.zip-tiles');
   let lastError: unknown;
   for (let attempt = 0; attempt < 3; attempt += 1) {
     await bringMapIntoViewport(page);
@@ -571,33 +548,10 @@ async function drillStateToCounty(page: Page, target: MapDrillTarget) {
     await clickSvgRegion(page, state, target.stateName);
     try {
       await expect(
-        county,
-        `${target.stateName} pointer click should drill into counties`,
-      ).toBeVisible({ timeout: 5_000 });
-      return;
-    } catch (error) {
-      lastError = error;
-    }
-  }
-  throw lastError;
-}
-
-async function drillCountyToZips(page: Page, target: MapDrillTarget) {
-  const map = page.locator('.map-wrap').first();
-  const county = map.getByRole('button', { name: new RegExp(escapeRegExp(target.countyName), 'i') }).first();
-  const zipTiles = page.locator('.zip-tiles');
-  let lastError: unknown;
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    await bringMapIntoViewport(page);
-    await expectMapIdle(page, 'county');
-    await expect(county).toBeVisible({ timeout: 10_000 });
-    await clickSvgRegion(page, county, target.countyName);
-    try {
-      await expect(
         zipTiles,
-        `${target.countyName} pointer click should drill into ZIPs`,
+        `${target.stateName} pointer click should drill straight into ZIPs`,
       ).toBeVisible({ timeout: 5_000 });
-      await expect(page.locator('.map-crumbs')).toContainText(target.countyName, {
+      await expect(page.locator('.map-crumbs')).toContainText(target.stateName, {
         timeout: 5_000,
       });
       return;
@@ -826,7 +780,7 @@ test.describe('Module 0 — real-UC golden path (nightly only)', () => {
     await expect(page.getByRole('button', { name: /SEGMENT:\s*2 segments selected \(all selected\)/i })).toBeVisible({ timeout: 20_000 });
   });
 
-  test('segment map drill preserves segment filters through county ZIP and Lead Queue', async ({ page, request }) => {
+  test('segment map drill preserves segment filters through state ZIP and Lead Queue', async ({ page, request }) => {
     await gotoApp(page, '/segment-intelligence');
 
     const selectedSegments = ['Prime Refi Candidates', 'Home Equity Candidate'];
@@ -851,18 +805,11 @@ test.describe('Module 0 — real-UC golden path (nightly only)', () => {
     }
     await filteredStateResponse;
 
-    const countyResponse = page.waitForResponse(
-      filteredGeoResponse('/api/geo/county-rollups'),
-      { timeout: 45_000 },
-    );
-    await drillStateToCounty(page, target);
-    await countyResponse;
-
     const zipResponse = page.waitForResponse(
       filteredGeoResponse('/api/geo/zip-rollups'),
       { timeout: 45_000 },
     );
-    await drillCountyToZips(page, target);
+    await drillStateToZips(page, target);
     await zipResponse;
 
     await expect(page.locator('.zip-tiles')).toBeVisible({ timeout: 10_000 });
@@ -896,7 +843,9 @@ test.describe('Module 0 — real-UC golden path (nightly only)', () => {
 	    const url = new URL(page.url());
 	    expect(url.pathname).toBe('/lead-queue');
     expect(url.searchParams.get('state')).toBe(target.state);
-    expect(url.searchParams.get('county')).toBe(target.countyFips);
+    // No county param: the ZIP tile deep-links by state + ZIP, the only
+    // two geography keys the share can actually answer.
+    expect(url.searchParams.get('county')).toBeNull();
     expect(url.searchParams.get('segment_mode')).toBe('any');
     expect(url.searchParams.get('segment_codes')).toContain('equity');
     expect(url.searchParams.get('zip')).toMatch(/^\d{5}$/);
@@ -944,9 +893,7 @@ test.describe('Module 0 — real-UC golden path (nightly only)', () => {
     await expect(map).toBeVisible({ timeout: 30_000 });
     await map.scrollIntoViewIfNeeded();
 
-    await drillStateToCounty(page, target);
-
-    await drillCountyToZips(page, target);
+    await drillStateToZips(page, target);
 
     await expect(page.locator('.zip-tiles')).toBeVisible({ timeout: 10_000 });
 
@@ -977,7 +924,9 @@ test.describe('Module 0 — real-UC golden path (nightly only)', () => {
     const url = new URL(page.url());
     expect(url.pathname).toBe('/lead-queue');
     expect(url.searchParams.get('state')).toBe(target.state);
-    expect(url.searchParams.get('county')).toBe(target.countyFips);
+    // No county param: the ZIP tile deep-links by state + ZIP, the only
+    // two geography keys the share can actually answer.
+    expect(url.searchParams.get('county')).toBeNull();
     expect(url.searchParams.get('zip')).toMatch(/^\d{5}$/);
     await expect(page.locator('table.tbl')).toBeVisible({ timeout: 45_000 });
   });

--- a/tests/fixtures/in_process_repos.py
+++ b/tests/fixtures/in_process_repos.py
@@ -1015,6 +1015,13 @@ _FIXTURE_ZIP_ROLLUPS: dict[str, list[ZipRollup]] = {
     ],
 }
 
+# The live drill is state -> ZIP (the share has no usable county grain), so
+# the fixture mirrors that key too. Same rows as the FIPS entry above so a
+# TestClient drilling IL sees one coherent ZIP story on either key.
+_FIXTURE_ZIP_ROLLUPS_BY_STATE: dict[str, list[ZipRollup]] = {
+    "IL": list(_FIXTURE_ZIP_ROLLUPS["17031"]),
+}
+
 
 class InProcessMockGeoRepository:
     """Test fixture implementing ``GeoRepository`` from the synthetic rollups."""
@@ -1048,15 +1055,26 @@ class InProcessMockGeoRepository:
 
     def zip_rollups(
         self,
-        fips_5: str,
+        fips_5: str | None = None,
         segment_codes: list[str] | None = None,
         segment_mode: str = "any",
         portfolio_criteria: PortfolioCriteria | None = None,
+        *,
+        state: str | None = None,
     ) -> ZipRollupResponse:
         _ = (segment_codes, segment_mode, portfolio_criteria)
+        if state:
+            normalised_state = str(state).upper()[:2]
+            return ZipRollupResponse(
+                fips_5=None,
+                state=normalised_state,
+                rollups=list(_FIXTURE_ZIP_ROLLUPS_BY_STATE.get(normalised_state, [])),
+                snapshot_date="2026-04-22",
+            )
         normalised = str(fips_5 or "")[:5]
         return ZipRollupResponse(
             fips_5=normalised,
+            state=None,
             rollups=list(_FIXTURE_ZIP_ROLLUPS.get(normalised, [])),
             snapshot_date="2026-04-22",
         )
@@ -1081,6 +1099,12 @@ _FIXTURE_OVERLAY_UNITS: dict[tuple[str, str], list[GeoAssignmentOverlayUnit]] = 
         GeoAssignmentOverlayUnit(unit_id="60647", lead_count=48, assigned_count=9, unattended_count=39, covering_officer_count=1, covering_officers=["Summit LO 01"]),
         GeoAssignmentOverlayUnit(unit_id="60613", lead_count=39, assigned_count=0, unattended_count=39, covering_officer_count=1, covering_officers=["Summit LO 01"]),
     ],
+    # State-keyed ZIP overlay — the live drill key.
+    ("zip", "IL"): [
+        GeoAssignmentOverlayUnit(unit_id="60611", lead_count=64, assigned_count=21, unattended_count=43, covering_officer_count=1, covering_officers=["Summit LO 01"]),
+        GeoAssignmentOverlayUnit(unit_id="60647", lead_count=48, assigned_count=9, unattended_count=39, covering_officer_count=1, covering_officers=["Summit LO 01"]),
+        GeoAssignmentOverlayUnit(unit_id="60613", lead_count=39, assigned_count=0, unattended_count=39, covering_officer_count=1, covering_officers=["Summit LO 01"]),
+    ],
 }
 
 
@@ -1097,7 +1121,12 @@ class InProcessMockGeoOverlayService:
         if level == "county":
             key = ("county", str(state or "").upper()[:2])
         elif level == "zip":
-            key = ("zip", str(county_fips or "")[:5])
+            # State is the live ZIP key; FIPS stays for licensed county data.
+            key = (
+                ("zip", str(state).upper()[:2])
+                if state
+                else ("zip", str(county_fips or "")[:5])
+            )
         else:
             key = ("state", "_")
         units = list(_FIXTURE_OVERLAY_UNITS.get(key, []))

--- a/tests/fixtures/openapi_baseline.json
+++ b/tests/fixtures/openapi_baseline.json
@@ -13491,13 +13491,20 @@
         "type": "object"
       },
       "ZipRollupResponse": {
-        "description": "Wire envelope \u2014 list of ZIPs for a given county FIPS + snapshot date.",
+        "description": "Wire envelope \u2014 list of ZIPs for the requested key + snapshot date.\n\nExactly one of ``state`` / ``fips_5`` is populated, echoing whichever\nkey the caller asked with. The state key is the drill the UI uses:\nthe Cotality share carries a single county FIPS per state, so\n``county_fips_5`` is NULL on every ``mip.gold.zip_rollup`` row and a\ncounty-keyed request legitimately returns zero rollups. The FIPS key\nstays on the contract for a future licensed county dataset.",
         "properties": {
           "fips_5": {
-            "maxLength": 5,
-            "minLength": 5,
-            "title": "Fips 5",
-            "type": "string"
+            "anyOf": [
+              {
+                "maxLength": 5,
+                "minLength": 5,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fips 5"
           },
           "rollups": {
             "items": {
@@ -13516,10 +13523,22 @@
               }
             ],
             "title": "Snapshot Date"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "maxLength": 2,
+                "minLength": 2,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
           }
         },
         "required": [
-          "fips_5",
           "rollups"
         ],
         "title": "ZipRollupResponse",
@@ -16916,7 +16935,7 @@
             }
           },
           {
-            "description": "2-char USPS state code. Required when level=county.",
+            "description": "2-char USPS state code. Required when level=county; the live key when level=zip.",
             "in": "query",
             "name": "state",
             "required": false,
@@ -16932,12 +16951,12 @@
                   "type": "null"
                 }
               ],
-              "description": "2-char USPS state code. Required when level=county.",
+              "description": "2-char USPS state code. Required when level=county; the live key when level=zip.",
               "title": "State"
             }
           },
           {
-            "description": "5-char county FIPS. Required when level=zip.",
+            "description": "5-char county FIPS. Alternative key when level=zip, reserved for licensed county data.",
             "in": "query",
             "name": "county_fips",
             "required": false,
@@ -16953,7 +16972,7 @@
                   "type": "null"
                 }
               ],
-              "description": "5-char county FIPS. Required when level=zip.",
+              "description": "5-char county FIPS. Alternative key when level=zip, reserved for licensed county data.",
               "title": "County Fips"
             }
           }
@@ -17509,21 +17528,49 @@
     "/api/geo/zip-rollups": {
       "get": {
         "deprecated": true,
-        "description": "Return per-ZIP rollups for the given county FIPS.\n\nEach ZIP carries a stable-ranked ``sample_borrower_id`` so the UI's\nZIP-tile click-through can deep-link to ``/borrower-360/<id>``.\nEmpty list when the county has no rollup rows (county outside the current\nCotality-backed coverage or CTAS hasn't run).",
+        "description": "Return per-ZIP rollups for the given state, or for a county FIPS.\n\nExactly one key is required \u2014 422 when both or neither are supplied,\nbecause a request that names two geographies has no single honest\nanswer and a request that names none would scan the country.\n\n``state`` is the drill the map uses. ``county_fips`` is kept for a\nfuture licensed county dataset; against the current Cotality share it\nreturns an empty list for every county, since the share carries one\ncounty FIPS per state and ``mip.gold.zip_rollup.county_fips_5`` is\nNULL on every row.\n\nEach ZIP carries a stable-ranked ``sample_borrower_id`` so the UI's\nZIP-tile click-through can deep-link to ``/borrower-360/<id>``.",
         "operationId": "get_api_geo_zip_rollups_zip_rollups",
         "parameters": [
           {
-            "description": "5-char county FIPS (2-char state + 3-char county).",
+            "description": "2-char USPS state code (uppercased server-side). The live ZIP drill key. Mutually exclusive with county_fips.",
+            "in": "query",
+            "name": "state",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 2,
+                  "minLength": 2,
+                  "pattern": "^[A-Za-z]{2}$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "2-char USPS state code (uppercased server-side). The live ZIP drill key. Mutually exclusive with county_fips.",
+              "title": "State"
+            }
+          },
+          {
+            "description": "5-char county FIPS (2-char state + 3-char county). Reserved for licensed county data; returns [] against the current share. Mutually exclusive with state.",
             "in": "query",
             "name": "county_fips",
-            "required": true,
+            "required": false,
             "schema": {
-              "description": "5-char county FIPS (2-char state + 3-char county).",
-              "maxLength": 5,
-              "minLength": 5,
-              "pattern": "^\\d{5}$",
-              "title": "County Fips",
-              "type": "string"
+              "anyOf": [
+                {
+                  "maxLength": 5,
+                  "minLength": 5,
+                  "pattern": "^\\d{5}$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "5-char county FIPS (2-char state + 3-char county). Reserved for licensed county data; returns [] against the current share. Mutually exclusive with state.",
+              "title": "County Fips"
             }
           },
           {
@@ -24323,7 +24370,7 @@
             }
           },
           {
-            "description": "2-char USPS state code. Required when level=county.",
+            "description": "2-char USPS state code. Required when level=county; the live key when level=zip.",
             "in": "query",
             "name": "state",
             "required": false,
@@ -24339,12 +24386,12 @@
                   "type": "null"
                 }
               ],
-              "description": "2-char USPS state code. Required when level=county.",
+              "description": "2-char USPS state code. Required when level=county; the live key when level=zip.",
               "title": "State"
             }
           },
           {
-            "description": "5-char county FIPS. Required when level=zip.",
+            "description": "5-char county FIPS. Alternative key when level=zip, reserved for licensed county data.",
             "in": "query",
             "name": "county_fips",
             "required": false,
@@ -24360,7 +24407,7 @@
                   "type": "null"
                 }
               ],
-              "description": "5-char county FIPS. Required when level=zip.",
+              "description": "5-char county FIPS. Alternative key when level=zip, reserved for licensed county data.",
               "title": "County Fips"
             }
           }
@@ -24913,21 +24960,49 @@
     },
     "/api/v1/geo/zip-rollups": {
       "get": {
-        "description": "Return per-ZIP rollups for the given county FIPS.\n\nEach ZIP carries a stable-ranked ``sample_borrower_id`` so the UI's\nZIP-tile click-through can deep-link to ``/borrower-360/<id>``.\nEmpty list when the county has no rollup rows (county outside the current\nCotality-backed coverage or CTAS hasn't run).",
+        "description": "Return per-ZIP rollups for the given state, or for a county FIPS.\n\nExactly one key is required \u2014 422 when both or neither are supplied,\nbecause a request that names two geographies has no single honest\nanswer and a request that names none would scan the country.\n\n``state`` is the drill the map uses. ``county_fips`` is kept for a\nfuture licensed county dataset; against the current Cotality share it\nreturns an empty list for every county, since the share carries one\ncounty FIPS per state and ``mip.gold.zip_rollup.county_fips_5`` is\nNULL on every row.\n\nEach ZIP carries a stable-ranked ``sample_borrower_id`` so the UI's\nZIP-tile click-through can deep-link to ``/borrower-360/<id>``.",
         "operationId": "get_api_v1_geo_zip_rollups_zip_rollups",
         "parameters": [
           {
-            "description": "5-char county FIPS (2-char state + 3-char county).",
+            "description": "2-char USPS state code (uppercased server-side). The live ZIP drill key. Mutually exclusive with county_fips.",
+            "in": "query",
+            "name": "state",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 2,
+                  "minLength": 2,
+                  "pattern": "^[A-Za-z]{2}$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "2-char USPS state code (uppercased server-side). The live ZIP drill key. Mutually exclusive with county_fips.",
+              "title": "State"
+            }
+          },
+          {
+            "description": "5-char county FIPS (2-char state + 3-char county). Reserved for licensed county data; returns [] against the current share. Mutually exclusive with state.",
             "in": "query",
             "name": "county_fips",
-            "required": true,
+            "required": false,
             "schema": {
-              "description": "5-char county FIPS (2-char state + 3-char county).",
-              "maxLength": 5,
-              "minLength": 5,
-              "pattern": "^\\d{5}$",
-              "title": "County Fips",
-              "type": "string"
+              "anyOf": [
+                {
+                  "maxLength": 5,
+                  "minLength": 5,
+                  "pattern": "^\\d{5}$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "5-char county FIPS (2-char state + 3-char county). Reserved for licensed county data; returns [] against the current share. Mutually exclusive with state.",
+              "title": "County Fips"
             }
           },
           {

--- a/tests/unit/test_geo_assignment_overlay.py
+++ b/tests/unit/test_geo_assignment_overlay.py
@@ -248,6 +248,41 @@ class TestOverlayService:
         # ZIP inherits the parent county's coverage (17031 explicit).
         assert by_id["60611"].covering_officers == ["Summit LO 01"]
 
+    def test_zip_level_by_state_scopes_to_the_state(self) -> None:
+        """State-keyed ZIP overlay: assignments outside the drilled state
+        must not count, and a NULL county_fips_5 (every live row today)
+        must not drop an in-state assignment."""
+        service, sql = _service(
+            sql_rows=[
+                ("GROUP BY zip", [
+                    {"unit_id": "60611", "lead_count": 6, "state": "IL"},
+                    {"unit_id": "60613", "lead_count": 3, "state": "IL"},
+                ]),
+                ("borrower_id IN", [
+                    {"borrower_id": "B-0000000000001", "state": "IL", "county_fips_5": None, "zip": "60611"},
+                    {"borrower_id": "B-0000000000004", "state": "CA", "county_fips_5": None, "zip": "90210"},
+                ]),
+            ],
+            assignments=[
+                {"borrower_id": "B-0000000000001"},
+                {"borrower_id": "B-0000000000004"},
+            ],
+            officers=_OFFICER_ROWS,
+        )
+        result = service.overlay("zip", state="IL")
+        assert result.state == "IL"
+        assert result.county_fips is None
+        by_id = {u.unit_id: u for u in result.units}
+        assert by_id["60611"].assigned_count == 1
+        assert by_id["60611"].unattended_count == 5
+        assert by_id["60613"].assigned_count == 0
+        # The out-of-state ZIP never becomes a unit.
+        assert "90210" not in by_id
+        # State coverage still resolves the officer layer without a county.
+        assert by_id["60611"].covering_officers == ["Summit LO 01"]
+        lead_sql = sql.calls[0][0]
+        assert "state = :state" in lead_sql
+
     def test_no_active_assignments_short_circuits_geo_resolution(self) -> None:
         service, sql = _service(
             sql_rows=[("GROUP BY state", [{"unit_id": "IL", "lead_count": 7}])],
@@ -293,10 +328,28 @@ class TestOverlayEndpoint:
             resp = client.get("/api/geo/assignment-overlay?level=county")
         assert resp.status_code == 422
 
-    def test_zip_overlay_requires_county_fips(self) -> None:
+    def test_zip_overlay_requires_exactly_one_geography_key(self) -> None:
         with TestClient(app) as client:
-            resp = client.get("/api/geo/assignment-overlay?level=zip")
-        assert resp.status_code == 422
+            assert client.get("/api/geo/assignment-overlay?level=zip").status_code == 422
+            assert (
+                client.get(
+                    "/api/geo/assignment-overlay?level=zip&state=IL&county_fips=17031"
+                ).status_code
+                == 422
+            )
+
+    def test_zip_overlay_drills_from_a_state(self) -> None:
+        """The live key: the ZIP tiles are drilled from a state, so the
+        overlay that recolors them must key on the same unit."""
+        with TestClient(app) as client:
+            resp = client.get("/api/geo/assignment-overlay?level=zip&state=IL")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["state"] == "IL"
+        assert body["county_fips"] is None
+        assert body["units"], "expected state-keyed ZIP overlay units"
+        total = sum(u["unattended_count"] for u in body["units"])
+        assert body["total_unattended"] == total
 
     def test_zip_overlay_drill_matches_fixture_math(self) -> None:
         with TestClient(app) as client:

--- a/tests/unit/test_geo_repository.py
+++ b/tests/unit/test_geo_repository.py
@@ -526,6 +526,94 @@ def test_zip_rollups_reads_zip_rollup_table_with_fips_param() -> None:
     assert params == {"fips_5": "17031"}
 
 
+def test_zip_rollups_reads_zip_rollup_table_with_state_param() -> None:
+    """The LIVE drill key. The Cotality share carries one county FIPS per
+    state, so county_fips_5 is NULL across gold.zip_rollup and the state
+    column is the only honest way to scope a ZIP layer."""
+    repo, client = _make_repo()
+    client.responses = [
+        (
+            ".gold.zip_rollup",
+            [
+                {
+                    "zip": "98103",
+                    "state": "WA",
+                    "county_fips_5": None,
+                    "addressable_borrowers": 310,
+                    "avg_opportunity_score": 81,
+                    "top_segment_code": "itm",
+                    "sample_borrower_id": "B-48298",
+                    "snapshot_date": "2026-08-07",
+                },
+            ],
+        ),
+    ]
+    result = repo.zip_rollups(state="WA")
+    assert isinstance(result, ZipRollupResponse)
+    assert result.state == "WA"
+    assert result.fips_5 is None
+    assert result.rollups[0].zip == "98103"
+    # A NULL county on the row must not break the response contract.
+    assert result.rollups[0].county_fips_5 is None
+
+    sql, params = client.calls[0]
+    assert ".gold.zip_rollup" in sql
+    assert "state = :state" in sql
+    assert "county_fips_5 = :fips_5" not in sql
+    assert params == {"state": "WA"}
+
+
+def test_zip_rollups_state_key_is_normalised_and_cached_apart_from_fips() -> None:
+    """`state:WA` and a FIPS grain must never share a cache entry — one
+    returns the whole state, the other a single county."""
+    repo, client = _make_repo()
+    client.responses = [(".gold.zip_rollup", list(_ZIP_ROWS))]
+
+    by_state = repo.zip_rollups(state="wa")
+    assert by_state.state == "WA"
+    repo.zip_rollups("17031")
+    repo.zip_rollups(state="WA")  # cache hit — no fourth call
+
+    assert len(client.calls) == 2
+    assert client.calls[0][1] == {"state": "WA"}
+    assert client.calls[1][1] == {"fips_5": "17031"}
+
+
+def test_zip_rollups_filtered_by_state_reads_borrower_360_with_state() -> None:
+    repo, client = _make_repo()
+    client.responses = [
+        (
+            ".gold.borrower_360",
+            [
+                {
+                    "zip": "98103",
+                    "state": "WA",
+                    "county_fips_5": None,
+                    "addressable_borrowers": 12,
+                    "avg_opportunity_score": 70,
+                    "top_segment_code": "itm",
+                    "sample_borrower_id": "B-98103",
+                    "snapshot_date": None,
+                },
+            ],
+        ),
+    ]
+
+    result = repo.zip_rollups(
+        state="WA",
+        segment_codes=["itm", "equity"],
+        segment_mode="all",
+    )
+
+    assert result.state == "WA"
+    assert result.rollups[0].zip == "98103"
+    sql, params = client.calls[0]
+    assert ".gold.borrower_360" in sql
+    assert "WHERE state = :state" in sql
+    assert "county_fips_5 = :fips_5" not in sql
+    assert params == {"seg_0": "equity", "seg_1": "itm", "state": "WA"}
+
+
 def test_zip_rollups_empty_when_no_rows() -> None:
     repo, client = _make_repo()
     client.responses = []  # no rows match

--- a/tests/unit/test_geo_state_rollups.py
+++ b/tests/unit/test_geo_state_rollups.py
@@ -289,6 +289,34 @@ def test_zip_rollups_returns_zips_for_populated_county():
         assert r["sample_borrower_id"] is None or r["sample_borrower_id"].startswith("B-")
 
 
+def test_zip_rollups_returns_zips_for_state():
+    """The live drill key. `state` echoes back and `fips_5` stays null so a
+    reader can tell which grain answered."""
+    response = client.get("/api/geo/zip-rollups?state=il")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["state"] == "IL"
+    assert payload["fips_5"] is None
+    assert len(payload["rollups"]) >= 1
+    for r in payload["rollups"]:
+        assert len(r["zip"]) == 5
+        assert r["state"] == "IL"
+
+
+def test_zip_rollups_requires_exactly_one_geography_key():
+    """Neither key would scan the country; both name two geographies with
+    no single honest answer. Both are 422."""
+    assert client.get("/api/geo/zip-rollups").status_code == 422
+    assert (
+        client.get("/api/geo/zip-rollups?state=IL&county_fips=17031").status_code == 422
+    )
+
+
+def test_zip_rollups_validates_state_shape():
+    assert client.get("/api/geo/zip-rollups?state=ILL").status_code == 422
+    assert client.get("/api/geo/zip-rollups?state=12").status_code == 422
+
+
 def test_zip_rollups_accepts_segment_filter_params():
     response = client.get(
         "/api/geo/zip-rollups?county_fips=17031&segment_codes=itm,equity&segment_mode=all"
@@ -303,13 +331,17 @@ def test_zip_rollups_passes_secondary_portfolio_criteria_to_repository():
 
         def zip_rollups(
             self,
-            fips,
+            fips=None,
             segment_codes=None,
             segment_mode="any",
             portfolio_criteria=None,
+            *,
+            state=None,
         ):
             self.seen = (fips, segment_codes, segment_mode, portfolio_criteria)
-            return ZipRollupResponse(fips_5=fips, rollups=[], snapshot_date="2026-04-22")
+            return ZipRollupResponse(
+                fips_5=fips, state=state, rollups=[], snapshot_date="2026-04-22"
+            )
 
     spy = SpyGeoRepository()
     previous = app.dependency_overrides.get(get_geo_repository)


### PR DESCRIPTION
- **feat(api): key the ZIP layer on state, not a dead county grain**
- **feat(map): drill state straight to ZIP, not through a dead county**
- **test(e2e): re-key the geo specs to the state -> ZIP drill**
- **fix(home): stop advertising a county rung the map no longer has**
