### PR TITLE
fix(bundle): rebind workspace host to the live dev workspace

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -31,7 +31,7 @@ bundle:
 # anchor and fails if it finds one — a forkability safeguard so an SE
 # cannot ship a customer deploy still pointing at Entrada's workspace.
 workspace:
-  host: &default_host https://dbc-149e560d-e056.cloud.databricks.com
+  host: &default_host https://dbc-3aa503a9-4fa8.cloud.databricks.com
 
 # Sync: explicitly include the built frontend bundle in the uploaded
 # source tree. `frontend/dist/` is in .gitignore (we don't commit built

--- a/tests/unit/test_configuration_files.py
+++ b/tests/unit/test_configuration_files.py
@@ -73,7 +73,7 @@ def test_databricks_yml_contains_required_resource_names():
 def test_bundle_resource_names_are_parameterized_for_isolated_staging():
     content = (REPO / "databricks.yml").read_text(encoding="utf-8")
 
-    assert "host: &default_host https://dbc-149e560d-e056.cloud.databricks.com" in content
+    assert "host: &default_host https://dbc-3aa503a9-4fa8.cloud.databricks.com" in content
     assert "name: ${var.app_name}" in content
     assert "name: ${var.lakebase_instance_name}" in content
     assert "name: ${var.lakebase_catalog_name}" in content


### PR DESCRIPTION
The bundle's host anchor still pointed at the retired staging workspace
while every live resource — the app, warehouse, jobs, Lakebase, Genie
space, secret scopes — lives on the current dev workspace. This is the
documented one-line rebind (see the anchor comment block); it is also
why app roll-forwards have needed out-of-band payload deploys: the
signed-promotion path targeted a workspace the app does not run in.
bundle validate -t dev passes against the rebound host.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
