### PR TITLE
fix(genie+deploy): unblock the space's own deep plan; end the ledger-walk wedge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,17 @@ MIP_DEFAULT_CATALOG=mip
 # plus effective-membership probes executed as every forbidden app-facing M2M
 # and any existing target App identity.
 MIP_UC_APPROVED_OWNER_PRINCIPALS=
+# Required on any metastore that contains ISOLATED catalogs not bound to this
+# workspace. Databricks denies those catalogs at the workspace level, ahead of
+# grants, so they are accepted only against this reviewed, versioned contract:
+# every catalog's owner, catalog type, and complete workspace-binding inventory
+# must match live UC exactly, or the deploy fails rather than assuming denial.
+# Regenerate whenever the metastore's isolated catalogs change (a shared
+# workspace grows them over time); see docs/security/GRANTS.md.
+# Shape: {"version":1,"catalogs":{"<name>":{"owner":"<principal>",
+#   "catalog_type":"MANAGED_CATALOG","bindings":[{"workspace_id":"<id>",
+#   "binding_type":"BINDING_TYPE_READ_WRITE"}]}}}
+MIP_UC_FOREIGN_CATALOG_BINDING_POLICY=
 # Always required for deployment identity/role verification. Use a dedicated
 # account OAuth identity and never reuse the workspace PAT or any app-facing
 # M2M principal. A first install with an approved group owner requires

--- a/backend/schemas/marketing_selection_reviewed_analytics.py
+++ b/backend/schemas/marketing_selection_reviewed_analytics.py
@@ -37,7 +37,63 @@ _REVIEWED_PRODUCT_INTENT = (
     r"purchase|listed(?:[- ]for[- ]sale)?|investor|multi[- ]property|"
     r"retention|recapture|in[- ]the[- ]money|high[- ]equity)"
 )
+# Signal columns a planned sub-analysis may name alongside a ranked cohort.
+# Closed: every entry is a governed gold column or Module 0 domain signal
+# (CLAUDE.md domain rules), never free text.
+_REVIEWED_ANALYTIC_SIGNAL = (
+    r"(?:opportunity\s+scores?|lead\s+scores?|rate\s+spreads?|equity(?:\s+percentage)?|"
+    r"ltv|loan[- ]to[- ]value|key\s+triggers?|triggers?|recommended\s+offers?|"
+    r"next[- ]best\s+offers?|segment\s+memberships?|segments?|listing\s+status|"
+    r"competitor\s+liens?|listed\s+for\s+sale|investor\s+status|"
+    r"retention\s+risk|heloc\s+propensity)"
+)
+_REVIEWED_ANALYTIC_SIGNAL_LIST = (
+    rf"{_REVIEWED_ANALYTIC_SIGNAL}(?:\s*,?\s*(?:and\s+)?{_REVIEWED_ANALYTIC_SIGNAL})*"
+)
+# "the top 20 (eligible) borrowers" — the cohort noun a planned deep analysis
+# names in nearly every sub-question.
+_REVIEWED_TOP_COHORT = (
+    r"(?:the\s+)?top\s+(?:[0-9]{1,3}\s+)?"
+    r"(?:eligible\s+|marketing[- ]eligible\s+|highest[- ]scoring\s+)?"
+    r"(?:borrowers?|leads?|candidates?|opportunities)"
+)
+_REVIEWED_WHOLE_POPULATION = (
+    r"(?:the\s+)?(?:full|entire|whole|overall|broader)\s+"
+    r"(?:eligible\s+)?(?:borrower\s+)?(?:population|pool|universe|portfolio|group)"
+)
+
 _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        # Ranked shortlist plus its governed signal columns ("who are the top
+        # 20 eligible borrowers ranked by opportunity score, and what are
+        # their rate spread, equity percentage, key triggers, and recommended
+        # offer?"). Captured live 2026-08-10 from the governed space's OWN
+        # deep-analysis plan: the criterion machine read it as an unreviewed
+        # criterion, three of seven planned sub-questions were dropped, the
+        # plan fell under the deep floor, and the sweep aborted silently — the
+        # user saw a single-screen answer instead of the deep decomposition.
+        r"^(?:who|what)\s+(?:are|is)\s+"
+        rf"{_REVIEWED_TOP_COHORT}"
+        r"(?:\s+ranked\s+by\s+" + _REVIEWED_ANALYTIC_SIGNAL_LIST + r")?"
+        r"(?:\s*,?\s*and\s+what\s+(?:are|is)\s+(?:their|its)\s+"
+        + _REVIEWED_ANALYTIC_SIGNAL_LIST
+        + r")?\s*\??$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        # Percentile placement of a ranked cohort within the population
+        # ("what is the percentile rank of the top 20 borrowers for
+        # opportunity score, rate spread, and equity percentage within the
+        # entire eligible borrower pool?"). Same live capture.
+        r"^what\s+(?:is|are)\s+the\s+"
+        r"(?:percentile\s+ranks?|percentiles?|rank(?:ings?)?)\s+of\s+"
+        rf"{_REVIEWED_TOP_COHORT}\s+"
+        r"(?:for|on|by|across)\s+"
+        + _REVIEWED_ANALYTIC_SIGNAL_LIST
+        + rf"(?:\s+(?:within|in|against|compared\s+to)\s+{_REVIEWED_WHOLE_POPULATION})?"
+        r"\s*\??$",
+        re.IGNORECASE,
+    ),
     re.compile(
         # Offer strategy by segment ("which offer should we lead with for each
         # segment, and why?"). The audience grammar read the affirmative

--- a/tests/unit/test_oauth_credential_quarantine.py
+++ b/tests/unit/test_oauth_credential_quarantine.py
@@ -1198,7 +1198,7 @@ def test_recovery_without_observation_or_delta_retains_global_quarantine(
     live_ids = ["existing"]
     with pytest.raises(
         CredentialMutationQuarantineError,
-        match="delayed create cannot still commit",
+        match="no attributable credential",
     ):
         recover_oauth_credential_mutation(
             workspace,

--- a/tests/unit/test_oauth_credential_recovery_expiry_proof.py
+++ b/tests/unit/test_oauth_credential_recovery_expiry_proof.py
@@ -1,0 +1,133 @@
+"""Expiry proof for unmaterialized temporary-probe creates.
+
+A phantom create (acknowledged, never listed, observation lost with the
+killed process) must not quarantine forever when the secret was never
+delivered, carried a bounded TTL, and the intent has aged past any commit
+horizon. Every guard failure keeps the fail-closed quarantine.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from tools.databricks.oauth_credential_expiry_proof import (
+    prove_unmaterialized_probe_create_harmless,
+)
+from tools.databricks.oauth_credential_quarantine import (
+    CredentialMutationQuarantineError,
+)
+
+_INTENT_PATH = "/.mip-deployment-leases/app.mutation.mutation.oauth-credential-intent.json"
+
+
+def _intent(**overrides: object) -> dict[str, object]:
+    record: dict[str, object] = {
+        "label": "temporary target identity",
+        "operation_mode": "temporary_probe",
+        "credential_lifetime_seconds": 300,
+    }
+    record.update(overrides)
+    return record
+
+
+def _workspace(age_seconds: float) -> SimpleNamespace:
+    modified_ms = (time.time() - age_seconds) * 1000.0
+    return SimpleNamespace(
+        workspace=SimpleNamespace(
+            get_status=lambda path: SimpleNamespace(modified_at=modified_ms)
+        )
+    )
+
+
+def _prove(
+    *,
+    intent: dict[str, object],
+    age_seconds: float = 22 * 3600.0,
+    sink: dict[str, object] | None = None,
+    delivery_ack: dict[str, object] | None = None,
+    fence_calls: list[str] | None = None,
+) -> None:
+    calls = fence_calls if fence_calls is not None else []
+    prove_unmaterialized_probe_create_harmless(
+        _workspace(age_seconds),
+        intent_path=_INTENT_PATH,
+        intent=intent,
+        sink=sink,
+        delivery_ack=delivery_ack,
+        principal_id="75100133948918",
+        before_ids=frozenset({"a", "b"}),
+        fence=lambda: calls.append("fence"),
+    )
+
+
+def test_expired_undelivered_probe_create_is_proven_harmless() -> None:
+    fence_calls: list[str] = []
+    _prove(intent=_intent(), fence_calls=fence_calls)
+    assert fence_calls == ["fence"]
+
+
+def test_persistent_delivery_intents_always_quarantine() -> None:
+    with pytest.raises(
+        CredentialMutationQuarantineError,
+        match="only temporary-probe creates qualify",
+    ):
+        _prove(intent=_intent(operation_mode="persistent_delivery"))
+
+
+def test_sink_or_acknowledgement_evidence_quarantines() -> None:
+    with pytest.raises(
+        CredentialMutationQuarantineError, match="reached a sink"
+    ):
+        _prove(intent=_intent(), sink={"repository": "gh"})
+    with pytest.raises(
+        CredentialMutationQuarantineError, match="reached a sink"
+    ):
+        _prove(intent=_intent(), delivery_ack={"acknowledged": True})
+
+
+@pytest.mark.parametrize("lifetime", [0, -1, 3601, None, True, "300"])
+def test_unbounded_or_missing_ttl_quarantines(lifetime: object) -> None:
+    with pytest.raises(
+        CredentialMutationQuarantineError, match="no bounded credential TTL"
+    ):
+        _prove(intent=_intent(credential_lifetime_seconds=lifetime))
+
+
+def test_intent_younger_than_ttl_plus_horizon_quarantines() -> None:
+    with pytest.raises(
+        CredentialMutationQuarantineError, match="could still commit"
+    ):
+        _prove(intent=_intent(), age_seconds=1800.0)
+
+
+def test_unavailable_intent_age_quarantines() -> None:
+    def _broken_status(path: str) -> SimpleNamespace:
+        raise RuntimeError("workspace metadata unavailable")
+
+    workspace = SimpleNamespace(
+        workspace=SimpleNamespace(get_status=_broken_status)
+    )
+    with pytest.raises(
+        CredentialMutationQuarantineError, match="intent age is unavailable"
+    ):
+        prove_unmaterialized_probe_create_harmless(
+            workspace,
+            intent_path=_INTENT_PATH,
+            intent=_intent(),
+            sink=None,
+            delivery_ack=None,
+            principal_id="75100133948918",
+            before_ids=frozenset(),
+            fence=lambda: None,
+        )
+
+
+def test_quarantine_message_keeps_the_no_attribution_marker() -> None:
+    with pytest.raises(
+        CredentialMutationQuarantineError,
+        match="no attributable credential",
+    ):
+        _prove(intent=_intent(), age_seconds=60.0)

--- a/tests/unit/test_planned_deep_analysis_guard_capture.py
+++ b/tests/unit/test_planned_deep_analysis_guard_capture.py
@@ -1,0 +1,79 @@
+"""The governed space's own deep-analysis plan must survive the guards.
+
+Captured live 2026-08-10 against the paychex space for the user's question
+("Analyze the full dataset of eligible borrowers ... why each borrower is an
+especially good candidate ... best curated offer"). The space planned seven
+sub-questions; the criterion machine dropped three as ``unreviewed_criterion``
+— none named a protected class — which put the plan under the deep floor of
+five, so ``run_planned_sweep`` returned ``None`` and the user silently got a
+single-turn answer instead of the deep decomposition.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.genie_message_policy import protected_prompt_match
+from backend.services.repositories.databricks_genie_sweep import (
+    _MIN_PLANNED_DEEP,
+    _planned_question_guard_hit,
+)
+
+# Verbatim from the live planning turn.
+LIVE_PLAN = (
+    "Who are the top 20 eligible borrowers ranked by opportunity score, and "
+    "what are their rate spread, equity percentage, key triggers, and "
+    "recommended offer?",
+    "How do the top 20 borrowers compare to the full eligible population in "
+    "terms of average opportunity score, rate spread, and equity percentage?",
+    "What is the distribution of recommended offers among the top 20 "
+    "borrowers, and what key signals (rate spread, equity, listing, investor "
+    "status) drive each offer type?",
+    "What is the geographic concentration (by state and ZIP) of the top 20 "
+    "borrowers compared to the overall eligible population?",
+    "How do segment memberships (e.g., in-the-money, equity, investor, "
+    "retention) and listing status co-occur among the top 20 borrowers versus "
+    "the broader eligible group?",
+    "What proportion of the top 20 borrowers have competitor liens or are "
+    "listed for sale, and how does this compare to the full eligible "
+    "population?",
+    "What is the percentile rank of the top 20 borrowers for opportunity "
+    "score, rate spread, and equity percentage within the entire eligible "
+    "borrower pool?",
+)
+
+NEWLY_REVIEWED = (
+    LIVE_PLAN[0],  # ranked shortlist + its governed signal columns
+    LIVE_PLAN[6],  # percentile placement within the population
+)
+
+
+@pytest.mark.parametrize("question", NEWLY_REVIEWED)
+def test_live_planned_questions_clear_the_guards(question: str) -> None:
+    assert _planned_question_guard_hit(question) is None
+
+
+def test_live_plan_keeps_enough_sections_to_run_the_deep_sweep() -> None:
+    kept = [q for q in LIVE_PLAN if _planned_question_guard_hit(q) is None]
+    assert len(kept) >= _MIN_PLANNED_DEEP
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        # Protected-class terms riding the newly reviewed shapes.
+        "Who are the top 20 hispanic borrowers ranked by opportunity score?",
+        "Who are the top 20 female borrowers ranked by opportunity score, "
+        "and what are their equity percentage?",
+        "Who are the top 20 borrowers ranked by race?",
+        "What is the percentile rank of the top 20 borrowers for religion "
+        "within the entire eligible borrower pool?",
+        # Unknown criteria riding the same shapes.
+        "Who are the top 20 borrowers ranked by zyrplax score, and what are "
+        "their zyrplax percentage?",
+        "What is the percentile rank of the top 20 borrowers for zyrplax "
+        "within the entire eligible borrower pool?",
+    ],
+)
+def test_reviewed_shapes_stay_closed(question: str) -> None:
+    assert protected_prompt_match(question) is not None

--- a/tests/unit/test_probe_deadline_ledger_mirror.py
+++ b/tests/unit/test_probe_deadline_ledger_mirror.py
@@ -39,7 +39,9 @@ def test_immutable_ledger_paths_are_mirrorable():
 
 def test_snapshot_hit_serves_disk_bytes_without_any_transport(tmp_path, monkeypatch):
     path = f"{probe_deadlines._LEASE_ROOT}/mip-app.json.aa11.next"
-    (tmp_path / "mip-app.json.aa11.next").write_bytes(b'{"generation_id": "aa11"}')
+    scoped = tmp_path / "DEFAULT"
+    scoped.mkdir()
+    (scoped / "mip-app.json.aa11.next").write_bytes(b'{"generation_id": "aa11"}')
     monkeypatch.setenv(probe_deadlines._MIRROR_DIR_ENV, str(tmp_path))
     monkeypatch.setattr(probe_deadlines, "_mirror_snapshot", {path})
 
@@ -68,7 +70,23 @@ def test_live_read_success_backfills_the_mirror(tmp_path, monkeypatch):
     class _Workspace:
         workspace = _WorkspaceApi()
 
+    (tmp_path / "DEFAULT").mkdir()
     data = probe_deadlines.bounded_workspace_read(_Workspace(), path, attempts=1)
     assert data == b'{"generation_id": "bb22"}'
-    assert (tmp_path / "mip-app.json.bb22").read_bytes() == data
+    assert (tmp_path / "DEFAULT" / "mip-app.json.bb22").read_bytes() == data
     assert path in probe_deadlines._mirror_snapshot
+
+
+def test_mirror_scope_isolates_workspaces_sharing_a_ledger_path(tmp_path, monkeypatch):
+    path = f"{probe_deadlines._LEASE_ROOT}/mip-app.json.cc33.next"
+    for profile, payload in (("DEFAULT", b"pr105-record"), ("paychex", b"paychex-record")):
+        scoped = tmp_path / profile
+        scoped.mkdir()
+        (scoped / "mip-app.json.cc33.next").write_bytes(payload)
+    monkeypatch.setenv(probe_deadlines._MIRROR_DIR_ENV, str(tmp_path))
+    monkeypatch.setattr(probe_deadlines, "_mirror_snapshot", {path})
+
+    monkeypatch.setenv("MIP_PROBE_CLI_PROFILE", "paychex")
+    assert probe_deadlines.bounded_workspace_read(object(), path) == b"paychex-record"
+    monkeypatch.setenv("MIP_PROBE_CLI_PROFILE", "DEFAULT")
+    assert probe_deadlines.bounded_workspace_read(object(), path) == b"pr105-record"

--- a/tests/unit/test_probe_deadline_ledger_mirror.py
+++ b/tests/unit/test_probe_deadline_ledger_mirror.py
@@ -1,0 +1,74 @@
+"""Ledger-mirror behavior for bounded workspace reads.
+
+The 2026-08-10 hour-long recovery was ~5k sequential CLI reads over the
+grown lease ledger, re-walked per stability round. The mirror serves
+immutable records from disk; mutable head/marker/root records stay live.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.databricks import probe_deadlines
+
+
+@pytest.fixture(autouse=True)
+def _reset_mirror(monkeypatch):
+    monkeypatch.setattr(probe_deadlines, "_mirror_snapshot", None)
+    monkeypatch.delenv("MIP_PROBE_CLI_TRANSPORT", raising=False)
+    monkeypatch.delenv(probe_deadlines._MIRROR_DIR_ENV, raising=False)
+
+
+def test_mutable_ledger_paths_never_mirrored():
+    root = probe_deadlines._LEASE_ROOT
+    assert not probe_deadlines._mirror_immutable(f"{root}/mip-app.json.head")
+    assert not probe_deadlines._mirror_immutable(f"{root}/mip-app.json.protocol-v5")
+    assert not probe_deadlines._mirror_immutable(f"{root}/mip-app.json")
+
+
+def test_immutable_ledger_paths_are_mirrorable():
+    root = probe_deadlines._LEASE_ROOT
+    generation = f"{root}/mip-app.json.2942d267-d1ab-4136-b103-8ba9f7396a57"
+    assert probe_deadlines._mirror_immutable(generation)
+    assert probe_deadlines._mirror_immutable(f"{generation}.next")
+    assert probe_deadlines._mirror_immutable(
+        f"{root}/mip-oauth-credential-mutations.b548be03.b548be03"
+        ".oauth-credential-resolution.json"
+    )
+
+
+def test_snapshot_hit_serves_disk_bytes_without_any_transport(tmp_path, monkeypatch):
+    path = f"{probe_deadlines._LEASE_ROOT}/mip-app.json.aa11.next"
+    (tmp_path / "mip-app.json.aa11.next").write_bytes(b'{"generation_id": "aa11"}')
+    monkeypatch.setenv(probe_deadlines._MIRROR_DIR_ENV, str(tmp_path))
+    monkeypatch.setattr(probe_deadlines, "_mirror_snapshot", {path})
+
+    def _no_transport(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("mirror hit must not touch subprocess or SDK")
+
+    monkeypatch.setattr(probe_deadlines.subprocess, "run", _no_transport)
+    data = probe_deadlines.bounded_workspace_read(object(), path)
+    assert data == b'{"generation_id": "aa11"}'
+
+
+def test_live_read_success_backfills_the_mirror(tmp_path, monkeypatch):
+    path = f"{probe_deadlines._LEASE_ROOT}/mip-app.json.bb22"
+    monkeypatch.setenv(probe_deadlines._MIRROR_DIR_ENV, str(tmp_path))
+    monkeypatch.setattr(probe_deadlines, "_mirror_snapshot", set())
+
+    class _Download:
+        def read(self):
+            return b'{"generation_id": "bb22"}'
+
+    class _WorkspaceApi:
+        def download(self, requested):
+            assert requested == path
+            return _Download()
+
+    class _Workspace:
+        workspace = _WorkspaceApi()
+
+    data = probe_deadlines.bounded_workspace_read(_Workspace(), path, attempts=1)
+    assert data == b'{"generation_id": "bb22"}'
+    assert (tmp_path / "mip-app.json.bb22").read_bytes() == data
+    assert path in probe_deadlines._mirror_snapshot

--- a/tests/unit/test_workspace_users_clone_group.py
+++ b/tests/unit/test_workspace_users_clone_group.py
@@ -1,11 +1,11 @@
-"""Databricks-created ``users`` clone counts as a workspace system group.
+"""Databricks-created ``users`` clone resolves as a reviewed workspace group.
 
 Enabling automatic identity management splits the legacy workspace ``users``
 group: ``users`` becomes entitlement-free and a Databricks-generated clone
-carries the legacy entitlements. Both are the same system identity, so the
+carries the legacy entitlements — and the workspace assignment — forward. The
 runtime inherits the clone without any grant of ours. Acceptance requires
 proof the clone's membership is identical to ``users``; every other shape
-still fails closed.
+still fails closed, and ``users`` itself keeps its exact original contract.
 """
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 import pytest
 
 from tools.databricks.workspace_system_group_evidence import (
+    workspace_users_clone_group_evidence,
     workspace_users_group_evidence,
 )
 
@@ -73,22 +74,30 @@ def _workspace(
 _LEGACY_ENTITLEMENTS = ("workspace-access", "databricks-sql-access")
 
 
-def test_users_alone_still_resolves_as_the_only_system_group() -> None:
+def test_users_alone_resolves_as_the_only_system_group() -> None:
     workspace = _workspace((_group(_USERS_ID, "users", entitlements=_LEGACY_ENTITLEMENTS),))
     assert workspace_users_group_evidence(workspace) == {_USERS_ID: "users"}
+    assert workspace_users_clone_group_evidence(workspace) == {}
 
 
-def test_exact_clone_is_accepted_beside_the_users_group() -> None:
+def test_clone_never_joins_the_system_group_set() -> None:
     workspace = _workspace(
         (
             _group(_USERS_ID, "users"),
             _group(_CLONE_ID, _CLONE_NAME, entitlements=_LEGACY_ENTITLEMENTS),
         )
     )
-    assert workspace_users_group_evidence(workspace) == {
-        _USERS_ID: "users",
-        _CLONE_ID: _CLONE_NAME,
-    }
+    assert workspace_users_group_evidence(workspace) == {_USERS_ID: "users"}
+
+
+def test_exact_clone_resolves_as_a_reviewed_group() -> None:
+    workspace = _workspace(
+        (
+            _group(_USERS_ID, "users"),
+            _group(_CLONE_ID, _CLONE_NAME, entitlements=_LEGACY_ENTITLEMENTS),
+        )
+    )
+    assert workspace_users_clone_group_evidence(workspace) == {_CLONE_ID: _CLONE_NAME}
 
 
 def test_clone_with_different_membership_is_rejected() -> None:
@@ -100,7 +109,7 @@ def test_clone_with_different_membership_is_rejected() -> None:
         members={_USERS_ID: _MEMBERS, _CLONE_ID: _MEMBERS[:2]},
     )
     with pytest.raises(RuntimeError, match="not an exact clone"):
-        workspace_users_group_evidence(workspace)
+        workspace_users_clone_group_evidence(workspace)
 
 
 def test_clone_of_an_empty_users_group_is_rejected() -> None:
@@ -112,7 +121,7 @@ def test_clone_of_an_empty_users_group_is_rejected() -> None:
         members={_USERS_ID: (), _CLONE_ID: ()},
     )
     with pytest.raises(RuntimeError, match="not an exact clone"):
-        workspace_users_group_evidence(workspace)
+        workspace_users_clone_group_evidence(workspace)
 
 
 @pytest.mark.parametrize(
@@ -132,6 +141,7 @@ def test_lookalike_group_names_stay_ordinary_memberships(name: str) -> None:
             _group(_CLONE_ID, name, entitlements=_LEGACY_ENTITLEMENTS),
         )
     )
+    assert workspace_users_clone_group_evidence(workspace) == {}
     assert workspace_users_group_evidence(workspace) == {_USERS_ID: "users"}
 
 
@@ -154,12 +164,12 @@ def test_clone_entitlements_off_the_legacy_pair_are_rejected(
         )
     )
     with pytest.raises(RuntimeError, match="ambiguous"):
-        workspace_users_group_evidence(workspace)
+        workspace_users_clone_group_evidence(workspace)
 
 
 def test_clone_with_roles_or_external_id_is_rejected() -> None:
     with pytest.raises(RuntimeError, match="incomplete or ambiguous"):
-        workspace_users_group_evidence(
+        workspace_users_clone_group_evidence(
             _workspace(
                 (
                     _group(_USERS_ID, "users"),
@@ -168,7 +178,7 @@ def test_clone_with_roles_or_external_id_is_rejected() -> None:
             )
         )
     with pytest.raises(RuntimeError, match="incomplete or ambiguous"):
-        workspace_users_group_evidence(
+        workspace_users_clone_group_evidence(
             _workspace(
                 (
                     _group(_USERS_ID, "users"),
@@ -186,7 +196,7 @@ def test_account_scoped_clone_resource_type_is_rejected() -> None:
         )
     )
     with pytest.raises(RuntimeError, match="incomplete or ambiguous"):
-        workspace_users_group_evidence(workspace)
+        workspace_users_clone_group_evidence(workspace)
 
 
 def test_two_clones_are_ambiguous_and_rejected() -> None:
@@ -202,7 +212,7 @@ def test_two_clones_are_ambiguous_and_rejected() -> None:
         )
     )
     with pytest.raises(RuntimeError, match="incomplete or ambiguous"):
-        workspace_users_group_evidence(workspace)
+        workspace_users_clone_group_evidence(workspace)
 
 
 def test_missing_users_group_still_fails_even_with_a_clone() -> None:
@@ -210,4 +220,4 @@ def test_missing_users_group_still_fails_even_with_a_clone() -> None:
         (_group(_CLONE_ID, _CLONE_NAME, entitlements=_LEGACY_ENTITLEMENTS),)
     )
     with pytest.raises(RuntimeError, match="did not resolve exactly once"):
-        workspace_users_group_evidence(workspace)
+        workspace_users_clone_group_evidence(workspace)

--- a/tests/unit/test_workspace_users_clone_system_group.py
+++ b/tests/unit/test_workspace_users_clone_system_group.py
@@ -1,0 +1,213 @@
+"""Databricks-created ``users`` clone counts as a workspace system group.
+
+Enabling automatic identity management splits the legacy workspace ``users``
+group: ``users`` becomes entitlement-free and a Databricks-generated clone
+carries the legacy entitlements. Both are the same system identity, so the
+runtime inherits the clone without any grant of ours. Acceptance requires
+proof the clone's membership is identical to ``users``; every other shape
+still fails closed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tools.databricks.workspace_system_group_evidence import (
+    workspace_users_group_evidence,
+)
+
+_USERS_ID = "workspace-users-id"
+_CLONE_ID = "workspace-users-clone-id"
+_CLONE_NAME = "users-clone-2026-08-03-2052-UTC (created by Databricks)"
+_MEMBERS = ("5882225431657870", "75100133948918", "78072554043911")
+
+
+def _group(
+    group_id: str,
+    display_name: str,
+    *,
+    entitlements: tuple[str, ...] = (),
+    resource_type: str = "WorkspaceGroup",
+    external_id: object = None,
+    roles: tuple[str, ...] = (),
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=group_id,
+        display_name=display_name,
+        meta=SimpleNamespace(resource_type=resource_type),
+        entitlements=[SimpleNamespace(value=value) for value in entitlements],
+        roles=[SimpleNamespace(value=value) for value in roles],
+        external_id=external_id,
+    )
+
+
+def _workspace(
+    listed: tuple[SimpleNamespace, ...],
+    *,
+    members: dict[str, tuple[str, ...]] | None = None,
+) -> SimpleNamespace:
+    membership = members if members is not None else {
+        _USERS_ID: _MEMBERS,
+        _CLONE_ID: _MEMBERS,
+    }
+
+    def _get(group_id: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=group_id,
+            members=[
+                SimpleNamespace(value=value)
+                for value in membership.get(group_id, ())
+            ],
+        )
+
+    return SimpleNamespace(
+        groups=SimpleNamespace(
+            list=lambda **_kwargs: iter(listed),
+            get=_get,
+        )
+    )
+
+
+_LEGACY_ENTITLEMENTS = ("workspace-access", "databricks-sql-access")
+
+
+def test_users_alone_still_resolves_as_the_only_system_group() -> None:
+    workspace = _workspace((_group(_USERS_ID, "users", entitlements=_LEGACY_ENTITLEMENTS),))
+    assert workspace_users_group_evidence(workspace) == {_USERS_ID: "users"}
+
+
+def test_exact_clone_is_accepted_beside_the_users_group() -> None:
+    workspace = _workspace(
+        (
+            _group(_USERS_ID, "users"),
+            _group(_CLONE_ID, _CLONE_NAME, entitlements=_LEGACY_ENTITLEMENTS),
+        )
+    )
+    assert workspace_users_group_evidence(workspace) == {
+        _USERS_ID: "users",
+        _CLONE_ID: _CLONE_NAME,
+    }
+
+
+def test_clone_with_different_membership_is_rejected() -> None:
+    workspace = _workspace(
+        (
+            _group(_USERS_ID, "users"),
+            _group(_CLONE_ID, _CLONE_NAME, entitlements=_LEGACY_ENTITLEMENTS),
+        ),
+        members={_USERS_ID: _MEMBERS, _CLONE_ID: _MEMBERS[:2]},
+    )
+    with pytest.raises(RuntimeError, match="not an exact clone"):
+        workspace_users_group_evidence(workspace)
+
+
+def test_clone_of_an_empty_users_group_is_rejected() -> None:
+    workspace = _workspace(
+        (
+            _group(_USERS_ID, "users"),
+            _group(_CLONE_ID, _CLONE_NAME, entitlements=_LEGACY_ENTITLEMENTS),
+        ),
+        members={_USERS_ID: (), _CLONE_ID: ()},
+    )
+    with pytest.raises(RuntimeError, match="not an exact clone"):
+        workspace_users_group_evidence(workspace)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "users-clone-2026-08-03-2052-UTC",
+        "users-clone (created by Databricks)",
+        "users-clone-2026-08-03-2052-UTC (created by Databricks) extra",
+        "prod-users-clone-2026-08-03-2052-UTC (created by Databricks)",
+        "users-clone-20260803-2052-UTC (created by Databricks)",
+    ],
+)
+def test_lookalike_group_names_stay_ordinary_memberships(name: str) -> None:
+    workspace = _workspace(
+        (
+            _group(_USERS_ID, "users"),
+            _group(_CLONE_ID, name, entitlements=_LEGACY_ENTITLEMENTS),
+        )
+    )
+    assert workspace_users_group_evidence(workspace) == {_USERS_ID: "users"}
+
+
+@pytest.mark.parametrize(
+    "entitlements",
+    [
+        (*_LEGACY_ENTITLEMENTS, "allow-cluster-create"),
+        ("workspace-access",),
+        ("allow-cluster-create",),
+        ("workspace-access", "workspace-access"),
+    ],
+)
+def test_clone_entitlements_off_the_legacy_pair_are_rejected(
+    entitlements: tuple[str, ...],
+) -> None:
+    workspace = _workspace(
+        (
+            _group(_USERS_ID, "users"),
+            _group(_CLONE_ID, _CLONE_NAME, entitlements=entitlements),
+        )
+    )
+    with pytest.raises(RuntimeError, match="ambiguous"):
+        workspace_users_group_evidence(workspace)
+
+
+def test_clone_with_roles_or_external_id_is_rejected() -> None:
+    with pytest.raises(RuntimeError, match="incomplete or ambiguous"):
+        workspace_users_group_evidence(
+            _workspace(
+                (
+                    _group(_USERS_ID, "users"),
+                    _group(_CLONE_ID, _CLONE_NAME, roles=("arn:aws:iam::role",)),
+                )
+            )
+        )
+    with pytest.raises(RuntimeError, match="incomplete or ambiguous"):
+        workspace_users_group_evidence(
+            _workspace(
+                (
+                    _group(_USERS_ID, "users"),
+                    _group(_CLONE_ID, _CLONE_NAME, external_id="federated"),
+                )
+            )
+        )
+
+
+def test_account_scoped_clone_resource_type_is_rejected() -> None:
+    workspace = _workspace(
+        (
+            _group(_USERS_ID, "users"),
+            _group(_CLONE_ID, _CLONE_NAME, resource_type="Group"),
+        )
+    )
+    with pytest.raises(RuntimeError, match="incomplete or ambiguous"):
+        workspace_users_group_evidence(workspace)
+
+
+def test_two_clones_are_ambiguous_and_rejected() -> None:
+    workspace = _workspace(
+        (
+            _group(_USERS_ID, "users"),
+            _group(_CLONE_ID, _CLONE_NAME, entitlements=_LEGACY_ENTITLEMENTS),
+            _group(
+                "second-clone-id",
+                "users-clone-2026-08-04-0900-UTC (created by Databricks)",
+                entitlements=_LEGACY_ENTITLEMENTS,
+            ),
+        )
+    )
+    with pytest.raises(RuntimeError, match="incomplete or ambiguous"):
+        workspace_users_group_evidence(workspace)
+
+
+def test_missing_users_group_still_fails_even_with_a_clone() -> None:
+    workspace = _workspace(
+        (_group(_CLONE_ID, _CLONE_NAME, entitlements=_LEGACY_ENTITLEMENTS),)
+    )
+    with pytest.raises(RuntimeError, match="did not resolve exactly once"):
+        workspace_users_group_evidence(workspace)

--- a/tools/databricks/app_deployment_lease.py
+++ b/tools/databricks/app_deployment_lease.py
@@ -18,15 +18,14 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey,
 from databricks.sdk import WorkspaceClient  # noqa: F401 - injected into CLI adapter
 from databricks.sdk.errors import (
     AlreadyExists,
-    NotFound,
     ResourceAlreadyExists,
-    ResourceDoesNotExist,
 )
 from databricks.sdk.service.workspace import (
     ImportFormat,
     WorkspaceObjectAccessControlRequest,
     WorkspaceObjectPermissionLevel,
 )
+from tools.databricks import app_deployment_lease_record_io as lease_record_io
 from tools.databricks import app_deployment_lease_recovery_checkpoint as recovery_checkpoint
 from tools.databricks import app_deployment_lease_support as lease_support
 from tools.databricks.app_deployment_lease_cli import (
@@ -35,7 +34,6 @@ from tools.databricks.app_deployment_lease_cli import (
 from tools.databricks.app_deployment_lease_cli import (
     source_sha as _source_sha,
 )
-from tools.databricks.probe_deadlines import bounded_workspace_read
 
 LEGACY_LEASE_VERSION = 4
 LEASE_VERSION = 5
@@ -307,21 +305,12 @@ def _read_record(
     path: str,
     app_name: str,
 ) -> dict[str, Any] | None:
-    try:
-        # Bounded, retried download — the streaming read stalls on held-open
-        # responses (2026-08-10 capture); see probe_deadlines.
-        encoded = bounded_workspace_read(workspace, path)
-    except (NotFound, ResourceDoesNotExist):
-        return None
-    record = _verify(
-        lease_support.json_without_duplicate_keys(
-            encoded,
-            artifact="App deployment lease",
-        )
+    return lease_record_io.read_record(
+        workspace,
+        path=path,
+        app_name=app_name,
+        verify=_verify,
     )
-    if record.get("app_name") != app_name.strip():
-        raise RuntimeError("App deployment lease path binding is invalid")
-    return record
 
 
 def _record_path(app_name: str, record: dict[str, Any]) -> str:

--- a/tools/databricks/app_deployment_lease.py
+++ b/tools/databricks/app_deployment_lease.py
@@ -35,6 +35,7 @@ from tools.databricks.app_deployment_lease_cli import (
 from tools.databricks.app_deployment_lease_cli import (
     source_sha as _source_sha,
 )
+from tools.databricks.probe_deadlines import bounded_workspace_read
 
 LEGACY_LEASE_VERSION = 4
 LEASE_VERSION = 5
@@ -307,12 +308,14 @@ def _read_record(
     app_name: str,
 ) -> dict[str, Any] | None:
     try:
-        stream = workspace.workspace.download(path)
+        # Bounded, retried download — the streaming read stalls on held-open
+        # responses (2026-08-10 capture); see probe_deadlines.
+        encoded = bounded_workspace_read(workspace, path)
     except (NotFound, ResourceDoesNotExist):
         return None
     record = _verify(
         lease_support.json_without_duplicate_keys(
-            stream.read(),
+            encoded,
             artifact="App deployment lease",
         )
     )

--- a/tools/databricks/app_deployment_lease_record_io.py
+++ b/tools/databricks/app_deployment_lease_record_io.py
@@ -1,0 +1,42 @@
+"""Bounded read of one signed App-deployment-lease record.
+
+Split out of ``app_deployment_lease`` when adding the bounded/retried
+transport pushed that module past the size gate (2026-08-10). The verifier
+is injected so the signing-key policy stays in the lease module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from databricks.sdk.errors import NotFound
+from databricks.sdk.errors.platform import ResourceDoesNotExist
+from tools.databricks import app_deployment_lease_support as lease_support
+from tools.databricks.probe_deadlines import bounded_workspace_read
+
+
+def read_record(
+    workspace: Any,
+    *,
+    path: str,
+    app_name: str,
+    verify: Callable[[dict[str, Any]], dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Download, verify, and path-bind one lease record, or None if absent."""
+
+    try:
+        # Bounded, retried download — the streaming read stalls on held-open
+        # responses (2026-08-10 capture); see probe_deadlines.
+        encoded = bounded_workspace_read(workspace, path)
+    except (NotFound, ResourceDoesNotExist):
+        return None
+    record = verify(
+        lease_support.json_without_duplicate_keys(
+            encoded,
+            artifact="App deployment lease",
+        )
+    )
+    if record.get("app_name") != app_name.strip():
+        raise RuntimeError("App deployment lease path binding is invalid")
+    return record

--- a/tools/databricks/audit_agent_runtime_foreign_uc_access.py
+++ b/tools/databricks/audit_agent_runtime_foreign_uc_access.py
@@ -46,6 +46,7 @@ from tools.databricks.uc_target_identity import (
     workspace_target_identity,
 )
 from tools.databricks.workspace_system_group_evidence import (
+    workspace_users_clone_group_evidence,
     workspace_users_group_evidence,
 )
 
@@ -629,8 +630,17 @@ def audit_foreign_uc_access(
             **probe_kwargs,
         )
     )
+    # The identity-management split leaves the legacy ``users`` entitlements —
+    # and its workspace assignment — on a Databricks-created clone the runtime
+    # still belongs to. Evidence, not configuration, admits it: the clone is
+    # proven to have membership identical to ``users`` before it is reviewed,
+    # and the reviewed path below still requires exactly ``USER`` here and
+    # nothing on any other workspace in the metastore.
     normalized_allowed_workspace_groups = _normalized_target_groups(
-        dict(allowed_workspace_groups or {})
+        {
+            **dict(allowed_workspace_groups or {}),
+            **workspace_users_clone_group_evidence(workspace),
+        }
     )
     (
         account_effective_groups,

--- a/tools/databricks/oauth_credential_expiry_proof.py
+++ b/tools/databricks/oauth_credential_expiry_proof.py
@@ -1,0 +1,83 @@
+"""Expiry proof for unmaterialized temporary-probe credential creates.
+
+A create the provider acknowledged but never listed ("phantom create",
+2026-08-09) can strand an intent with no observation and no inventory
+delta. Quarantining forever is wrong for the temporary-probe class: the
+secret was never delivered anywhere, any anomalously late commit
+self-expires after the request's bounded TTL, and every future mutation
+session re-diffs inventory and quarantines on durable drift. The proof
+below enumerates exactly that class; everything else still quarantines.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any, cast
+
+from tools.databricks import oauth_credential_records as records
+from tools.databricks.oauth_credential_quarantine import (
+    raise_credential_quarantine,
+)
+
+_UNMATERIALIZED_CREATE_SETTLE_HORIZON_SECONDS = 3600.0
+_MAX_PROBE_CREDENTIAL_LIFETIME_SECONDS = 3600
+
+
+def prove_unmaterialized_probe_create_harmless(
+    workspace: Any,
+    *,
+    intent_path: str,
+    intent: dict[str, object],
+    sink: dict[str, object] | None,
+    delivery_ack: dict[str, object] | None,
+    principal_id: str,
+    before_ids: frozenset[str],
+    fence: Callable[[], None],
+) -> None:
+    """Allow a restored resolution for an expired, undelivered probe create.
+
+    Callers reach this only when the stabilized inventory equals the intent's
+    prior inventory and no observation exists. Every guard failure keeps the
+    original fail-closed quarantine.
+    """
+
+    def _quarantine(detail: str, cause: BaseException | None = None) -> None:
+        raise_credential_quarantine(
+            message=(
+                "OAuth credential recovery has no attributable credential "
+                f"and no provider proof of harmlessness: {detail}"
+            ),
+            label=records.field(intent, "label"),
+            principal_id=principal_id,
+            before_ids=before_ids,
+            candidate_ids=frozenset(),
+            fence=fence,
+            cause=cause,
+        )
+
+    if records.field(intent, "operation_mode") != "temporary_probe":
+        _quarantine("only temporary-probe creates qualify for expiry proof")
+    if sink is not None or delivery_ack is not None:
+        _quarantine("the credential reached a sink or acknowledgement")
+    lifetime = intent.get("credential_lifetime_seconds")
+    if (
+        not isinstance(lifetime, int)
+        or isinstance(lifetime, bool)
+        or not 0 < lifetime <= _MAX_PROBE_CREDENTIAL_LIFETIME_SECONDS
+    ):
+        _quarantine("the create request carried no bounded credential TTL")
+    try:
+        modified_ms = workspace.workspace.get_status(intent_path).modified_at
+        intent_age_seconds = time.time() - float(modified_ms) / 1000.0
+    except BaseException as status_error:  # noqa: BLE001 - fail closed
+        _quarantine("the intent age is unavailable", cause=status_error)
+        raise  # unreachable; _quarantine always raises
+    if intent_age_seconds <= (
+        float(cast(int, lifetime)) + _UNMATERIALIZED_CREATE_SETTLE_HORIZON_SECONDS
+    ):
+        _quarantine(
+            "a delayed create could still commit inside the TTL plus "
+            "settle horizon"
+        )
+    fence()

--- a/tools/databricks/oauth_credential_records.py
+++ b/tools/databricks/oauth_credential_records.py
@@ -28,6 +28,7 @@ from tools.databricks.app_deployment_lease_support import key_registry
 from tools.databricks.oauth_credential_record_schema import (
     has_exact_string_fields,
 )
+from tools.databricks.probe_deadlines import bounded_workspace_read
 
 INTENT_VERSION = 4
 OBSERVED_VERSION = 1
@@ -206,8 +207,12 @@ def record_paths(workspace: Any) -> tuple[str, ...]:
 
 
 def read_bytes(workspace: Any, path: str) -> bytes:
+    # Bounded, retried download: the SDK's streaming read can stall
+    # indefinitely on a held-open response, and the quarantine inventory
+    # walks every ledger record (2026-08-10 faulthandler capture). See
+    # tools.databricks.probe_deadlines.bounded_workspace_read.
     try:
-        return workspace.workspace.download(path).read()
+        return bounded_workspace_read(workspace, path)
     except (NotFound, ResourceDoesNotExist) as exc:
         raise RuntimeError(
             f"OAuth credential recovery record disappeared: {path}"

--- a/tools/databricks/oauth_credential_recovery.py
+++ b/tools/databricks/oauth_credential_recovery.py
@@ -11,6 +11,9 @@ from typing import Any, cast
 from tools.databricks import app_deployment_lease
 from tools.databricks import oauth_credential_records as records
 from tools.databricks.oauth_credential_creation import prove_stable_credential_ids
+from tools.databricks.oauth_credential_expiry_proof import (
+    prove_unmaterialized_probe_create_harmless,
+)
 from tools.databricks.oauth_credential_quarantine import (
     CREDENTIAL_MUTATION_LEASE_NAME,
     CredentialMutationFence,
@@ -709,16 +712,14 @@ def recover_oauth_credential_mutation(
                     observed_ids=current_ids,
                 )
             if not observed_id:
-                raise_credential_quarantine(
-                    message=(
-                        "OAuth credential recovery has no attributable "
-                        "credential and no provider proof that a delayed "
-                        "create cannot still commit"
-                    ),
-                    label=records.field(intent, "label"),
+                prove_unmaterialized_probe_create_harmless(
+                    workspace,
+                    intent_path=intent_path,
+                    intent=intent,
+                    sink=sink,
+                    delivery_ack=delivery_ack,
                     principal_id=reviewed_principal,
                     before_ids=before_ids,
-                    candidate_ids=frozenset(),
                     fence=fence,
                 )
             restored_ids = current_ids

--- a/tools/databricks/probe_deadlines.py
+++ b/tools/databricks/probe_deadlines.py
@@ -14,6 +14,7 @@ absolutely.
 
 from __future__ import annotations
 
+import faulthandler
 import os
 import socket
 import sys
@@ -56,6 +57,11 @@ def install_probe_deadlines(*, label: str) -> None:
     watchdog = threading.Timer(_WATCHDOG_SECONDS, _watchdog_abort)
     watchdog.daemon = True
     watchdog.start()
+
+    # Periodic thread dumps: every component of the wedging flow passes in
+    # isolation (2026-08-10 discriminators), so when the wedge recurs the
+    # dump names the exact blocked line instead of another theory.
+    faulthandler.dump_traceback_later(180, repeat=True, file=sys.stderr)
 
     # Fresh-credential settle (2026-08-10 discriminator): with user-auth the
     # accounts API answered in ~200-700ms while the SAME calls under a

--- a/tools/databricks/probe_deadlines.py
+++ b/tools/databricks/probe_deadlines.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import faulthandler
 import os
 import socket
+import subprocess
 import sys
 import threading
 
@@ -76,18 +77,48 @@ def bounded_workspace_read(
 ) -> bytes:
     """Download one workspace file with per-attempt deadlines and retries.
 
-    The 2026-08-10 faulthandler capture pinned every deploy wedge to the
-    SDK's streaming workspace download stalling mid-read on a held-open
-    response, with consecutive dumps at different records — stalls clear on
-    a fresh request. Run each read in a worker thread, abandon it at the
-    deadline, retry. ``NotFound``/``ResourceDoesNotExist`` re-raise
-    untouched so callers keep their missing-record contracts.
+    Transport note (2026-08-10): the Python SDK's streaming download stalled
+    on ~every ledger record for hours (faulthandler captures inside
+    ``urllib3.response.stream``) while the Go CLI's ``workspace export``
+    answered the same paths in 1-2 seconds every time. The CLI is therefore
+    the primary transport, authenticated by the same environment the SDK
+    client uses; the bounded SDK thread-read remains as fallback for
+    environments without the CLI. ``NotFound``/``ResourceDoesNotExist``
+    keep their shape so callers keep their missing-record contracts.
     """
 
     from databricks.sdk.errors import NotFound
     from databricks.sdk.errors.platform import ResourceDoesNotExist
 
     last_error: BaseException | None = None
+    # Opt-in via env: the deploy wrappers set this so live runs use the CLI;
+    # unit tests with mocked workspace clients never leak network calls.
+    cli_attempts = 2 if os.environ.get("MIP_PROBE_CLI_TRANSPORT", "").strip() else 0
+    for _attempt in range(cli_attempts):
+        try:
+            completed = subprocess.run(
+                ["databricks", "workspace", "export", path],
+                capture_output=True,
+                timeout=30,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            last_error = exc
+            break
+        except subprocess.TimeoutExpired as exc:
+            last_error = exc
+            continue
+        if completed.returncode == 0:
+            return completed.stdout
+        stderr = completed.stderr.decode(errors="replace")
+        if (
+            "RESOURCE_DOES_NOT_EXIST" in stderr
+            or "does not exist" in stderr
+            or "doesn't exist" in stderr
+        ):
+            raise ResourceDoesNotExist(f"workspace path missing: {path}")
+        last_error = RuntimeError(f"cli export failed ({completed.returncode}): {stderr[:200]}")
+
     for _attempt in range(attempts):
         outcome: list[object] = []
 

--- a/tools/databricks/probe_deadlines.py
+++ b/tools/databricks/probe_deadlines.py
@@ -97,16 +97,29 @@ def _mirror_immutable(path: str) -> bool:
     return ".json." in basename
 
 
-def _mirror_file(mirror_dir: str, path: str) -> str:
-    return os.path.join(mirror_dir, path.rsplit("/", 1)[-1])
+def _mirror_scope(cli_profile: str) -> str:
+    """Directory component isolating one workspace's ledger from another's.
+
+    Ledger paths are identical across workspaces while their contents are
+    not, so a flat mirror would serve one workspace's signed records for
+    another's identical path. Key the cache by the profile actually used to
+    read it (2026-08-10: the same tree exists on pr105-staging and paychex).
+    """
+
+    safe = "".join(c if c.isalnum() or c in "-_." else "_" for c in cli_profile)
+    return safe or "default"
 
 
-def _mirror_store(path: str, data: bytes) -> None:
+def _mirror_file(mirror_dir: str, path: str, *, scope: str) -> str:
+    return os.path.join(mirror_dir, scope, path.rsplit("/", 1)[-1])
+
+
+def _mirror_store(path: str, data: bytes, *, scope: str) -> None:
     mirror_dir = os.environ.get(_MIRROR_DIR_ENV, "").strip()
     if not mirror_dir or _mirror_snapshot is None or not _mirror_immutable(path):
         return
     try:
-        with open(_mirror_file(mirror_dir, path), "wb") as handle:
+        with open(_mirror_file(mirror_dir, path, scope=scope), "wb") as handle:
             handle.write(data)
         with _mirror_lock:
             _mirror_snapshot.add(path)
@@ -114,7 +127,9 @@ def _mirror_store(path: str, data: bytes) -> None:
         return
 
 
-def _ensure_mirror(mirror_dir: str, cli_profile: str, cli_env: dict[str, str]) -> set[str]:
+def _ensure_mirror(
+    mirror_dir: str, cli_profile: str, cli_env: dict[str, str], *, scope: str
+) -> set[str]:
     """List the live ledger once and prefetch immutable records in parallel.
 
     The 2026-08-10 hour-long recovery was 5k sequential ~0.7s reads over the
@@ -147,8 +162,12 @@ def _ensure_mirror(mirror_dir: str, cli_profile: str, cli_env: dict[str, str]) -
         if (path := str(item.get("path", ""))).startswith(f"{_LEASE_ROOT}/")
         and _mirror_immutable(path)
     ]
-    os.makedirs(mirror_dir, exist_ok=True)
-    reused = {p for p in live_paths if os.path.exists(_mirror_file(mirror_dir, p))}
+    os.makedirs(os.path.join(mirror_dir, scope), exist_ok=True)
+    reused = {
+        p
+        for p in live_paths
+        if os.path.exists(_mirror_file(mirror_dir, p, scope=scope))
+    }
 
     def _fetch(path: str) -> str | None:
         try:
@@ -164,7 +183,7 @@ def _ensure_mirror(mirror_dir: str, cli_profile: str, cli_env: dict[str, str]) -
         if completed.returncode != 0:
             return None
         try:
-            with open(_mirror_file(mirror_dir, path), "wb") as handle:
+            with open(_mirror_file(mirror_dir, path, scope=scope), "wb") as handle:
                 handle.write(completed.stdout)
         except OSError:
             return None
@@ -227,11 +246,14 @@ def bounded_workspace_read(
         "HOME": os.environ.get("HOME", ""),
     }
     mirror_dir = os.environ.get(_MIRROR_DIR_ENV, "").strip()
+    mirror_scope = _mirror_scope(cli_profile)
     if mirror_dir and _mirror_immutable(path):
-        snapshot = _ensure_mirror(mirror_dir, cli_profile, cli_env)
+        snapshot = _ensure_mirror(mirror_dir, cli_profile, cli_env, scope=mirror_scope)
         if path in snapshot:
             try:
-                with open(_mirror_file(mirror_dir, path), "rb") as handle:
+                with open(
+                    _mirror_file(mirror_dir, path, scope=mirror_scope), "rb"
+                ) as handle:
                     return handle.read()
             except OSError:
                 pass
@@ -251,7 +273,7 @@ def bounded_workspace_read(
             last_error = exc
             continue
         if completed.returncode == 0:
-            _mirror_store(path, completed.stdout)
+            _mirror_store(path, completed.stdout, scope=mirror_scope)
             return completed.stdout
         stderr = completed.stderr.decode(errors="replace")
         if (
@@ -283,7 +305,7 @@ def bounded_workspace_read(
         if isinstance(result, BaseException):
             last_error = result
             continue
-        _mirror_store(path, result)  # type: ignore[arg-type]
+        _mirror_store(path, result, scope=mirror_scope)  # type: ignore[arg-type]
         return result  # type: ignore[return-value]
     raise RuntimeError(
         f"workspace read failed after {attempts} bounded attempts: {path}"

--- a/tools/databricks/probe_deadlines.py
+++ b/tools/databricks/probe_deadlines.py
@@ -18,9 +18,11 @@ import os
 import socket
 import sys
 import threading
+import time
 
 _DEADLINE_SECONDS = 120.0
 _WATCHDOG_SECONDS = 900.0
+_STARTUP_SETTLE_ENV = "MIP_PROBE_STARTUP_SETTLE_S"
 
 
 def install_probe_deadlines(*, label: str) -> None:
@@ -54,3 +56,25 @@ def install_probe_deadlines(*, label: str) -> None:
     watchdog = threading.Timer(_WATCHDOG_SECONDS, _watchdog_abort)
     watchdog.daemon = True
     watchdog.start()
+
+    # Fresh-credential settle (2026-08-10 discriminator): with user-auth the
+    # accounts API answered in ~200-700ms while the SAME calls under a
+    # just-minted bounded temp credential stalled indefinitely and its
+    # creates never became visible. Deployment wrappers mint the bounded
+    # credential immediately before exec'ing this process, so a startup
+    # sleep here separates mint from first use, giving the credential time
+    # to propagate. Opt-in via env so ordinary invocations pay nothing.
+    settle_raw = os.environ.get(_STARTUP_SETTLE_ENV, "").strip()
+    if settle_raw:
+        try:
+            settle = min(300.0, max(0.0, float(settle_raw)))
+        except ValueError:
+            settle = 0.0
+        if settle:
+            print(
+                f"[{label}] settling {int(settle)}s before first use of the "
+                "freshly minted bounded credential",
+                file=sys.stderr,
+                flush=True,
+            )
+            time.sleep(settle)

--- a/tools/databricks/probe_deadlines.py
+++ b/tools/databricks/probe_deadlines.py
@@ -14,7 +14,9 @@ absolutely.
 
 from __future__ import annotations
 
+import concurrent.futures
 import faulthandler
+import json
 import os
 import socket
 import subprocess
@@ -68,6 +70,123 @@ def install_probe_deadlines(*, label: str) -> None:
     faulthandler.dump_traceback_later(180, repeat=True, file=sys.stderr)
 
 
+_LEASE_ROOT = "/.mip-deployment-leases"
+_MIRROR_DIR_ENV = "MIP_PROBE_LEDGER_MIRROR_DIR"
+# Rewritten in place (overwrite=True) or delete-then-recreated during
+# repairs — never served from the mirror.
+_MUTABLE_BASENAME_SUFFIXES = (".head", ".protocol-v5")
+_mirror_lock = threading.Lock()
+_mirror_snapshot: set[str] | None = None
+
+
+def _mirror_immutable(path: str) -> bool:
+    """True for ledger records the writers create exactly once.
+
+    Every ledger write except the head hint and protocol marker uses
+    ``overwrite=False``; chain roots (bare ``<app>.json``) are additionally
+    delete-then-recreated by re-root repairs, so only basenames with content
+    after ``.json`` (generations, ``.next`` pointers, mutation records,
+    delete-with-backup copies) are safe to serve from disk forever.
+    """
+
+    basename = path.rsplit("/", 1)[-1]
+    if basename.endswith(_MUTABLE_BASENAME_SUFFIXES):
+        return False
+    if ".oauth-credential-" in basename and basename.endswith(".json"):
+        return True
+    return ".json." in basename
+
+
+def _mirror_file(mirror_dir: str, path: str) -> str:
+    return os.path.join(mirror_dir, path.rsplit("/", 1)[-1])
+
+
+def _mirror_store(path: str, data: bytes) -> None:
+    mirror_dir = os.environ.get(_MIRROR_DIR_ENV, "").strip()
+    if not mirror_dir or _mirror_snapshot is None or not _mirror_immutable(path):
+        return
+    try:
+        with open(_mirror_file(mirror_dir, path), "wb") as handle:
+            handle.write(data)
+        with _mirror_lock:
+            _mirror_snapshot.add(path)
+    except OSError:
+        return
+
+
+def _ensure_mirror(mirror_dir: str, cli_profile: str, cli_env: dict[str, str]) -> set[str]:
+    """List the live ledger once and prefetch immutable records in parallel.
+
+    The 2026-08-10 hour-long recovery was 5k sequential ~0.7s reads over the
+    grown ledger (4.8k lease-chain records), repeated per stability round —
+    not a network stall at all. One parallel prefetch makes every later walk
+    a local read. Only paths present in the live listing are ever served, so
+    a record deleted by an operator repair can never be resurrected from a
+    stale mirror file; failures just fall back to live reads.
+    """
+
+    global _mirror_snapshot
+    with _mirror_lock:
+        if _mirror_snapshot is not None:
+            return _mirror_snapshot
+    listing = subprocess.run(
+        ["databricks", "workspace", "list", _LEASE_ROOT,
+         "--output", "json", "--profile", cli_profile],
+        capture_output=True,
+        timeout=60,
+        check=False,
+        env=cli_env,
+    )
+    if listing.returncode != 0:
+        with _mirror_lock:
+            _mirror_snapshot = set()
+        return _mirror_snapshot
+    live_paths = [
+        path
+        for item in json.loads(listing.stdout or b"[]")
+        if (path := str(item.get("path", ""))).startswith(f"{_LEASE_ROOT}/")
+        and _mirror_immutable(path)
+    ]
+    os.makedirs(mirror_dir, exist_ok=True)
+    reused = {p for p in live_paths if os.path.exists(_mirror_file(mirror_dir, p))}
+
+    def _fetch(path: str) -> str | None:
+        try:
+            completed = subprocess.run(
+                ["databricks", "workspace", "export", path, "--profile", cli_profile],
+                capture_output=True,
+                timeout=30,
+                check=False,
+                env=cli_env,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if completed.returncode != 0:
+            return None
+        try:
+            with open(_mirror_file(mirror_dir, path), "wb") as handle:
+                handle.write(completed.stdout)
+        except OSError:
+            return None
+        return path
+
+    missing = [p for p in live_paths if p not in reused]
+    fetched: set[str] = set()
+    if missing:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+            fetched = {p for p in pool.map(_fetch, missing) if p}
+    snapshot = reused | fetched
+    print(
+        f"[probe-deadlines] ledger mirror ready: {len(reused)} reused, "
+        f"{len(fetched)} fetched, {len(missing) - len(fetched)} left to live reads",
+        file=sys.stderr,
+        flush=True,
+    )
+    with _mirror_lock:
+        _mirror_snapshot = snapshot
+    return snapshot
+
+
 def bounded_workspace_read(
     workspace: object,
     path: str,
@@ -107,6 +226,15 @@ def bounded_workspace_read(
         "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
         "HOME": os.environ.get("HOME", ""),
     }
+    mirror_dir = os.environ.get(_MIRROR_DIR_ENV, "").strip()
+    if mirror_dir and _mirror_immutable(path):
+        snapshot = _ensure_mirror(mirror_dir, cli_profile, cli_env)
+        if path in snapshot:
+            try:
+                with open(_mirror_file(mirror_dir, path), "rb") as handle:
+                    return handle.read()
+            except OSError:
+                pass
     for _attempt in range(cli_attempts):
         try:
             completed = subprocess.run(
@@ -123,6 +251,7 @@ def bounded_workspace_read(
             last_error = exc
             continue
         if completed.returncode == 0:
+            _mirror_store(path, completed.stdout)
             return completed.stdout
         stderr = completed.stderr.decode(errors="replace")
         if (
@@ -149,11 +278,12 @@ def bounded_workspace_read(
             last_error = RuntimeError(f"workspace read stalled: {path}")
             continue
         result = outcome[0] if outcome else RuntimeError("workspace read returned nothing")
-        if isinstance(result, (NotFound, ResourceDoesNotExist)):
+        if isinstance(result, NotFound | ResourceDoesNotExist):
             raise result
         if isinstance(result, BaseException):
             last_error = result
             continue
+        _mirror_store(path, result)  # type: ignore[arg-type]
         return result  # type: ignore[return-value]
     raise RuntimeError(
         f"workspace read failed after {attempts} bounded attempts: {path}"

--- a/tools/databricks/probe_deadlines.py
+++ b/tools/databricks/probe_deadlines.py
@@ -63,6 +63,54 @@ def install_probe_deadlines(*, label: str) -> None:
     # dump names the exact blocked line instead of another theory.
     faulthandler.dump_traceback_later(180, repeat=True, file=sys.stderr)
 
+
+def bounded_workspace_read(
+    workspace: object,
+    path: str,
+    *,
+    attempts: int = 3,
+    deadline_seconds: float = 60.0,
+) -> bytes:
+    """Download one workspace file with per-attempt deadlines and retries.
+
+    The 2026-08-10 faulthandler capture pinned every deploy wedge to the
+    SDK's streaming workspace download stalling mid-read on a held-open
+    response, with consecutive dumps at different records — stalls clear on
+    a fresh request. Run each read in a worker thread, abandon it at the
+    deadline, retry. ``NotFound``/``ResourceDoesNotExist`` re-raise
+    untouched so callers keep their missing-record contracts.
+    """
+
+    from databricks.sdk.errors import NotFound
+    from databricks.sdk.errors.platform import ResourceDoesNotExist
+
+    last_error: BaseException | None = None
+    for _attempt in range(attempts):
+        outcome: list[object] = []
+
+        def _download(target: list[object] = outcome) -> None:
+            try:
+                target.append(workspace.workspace.download(path).read())  # type: ignore[attr-defined]
+            except BaseException as exc:  # noqa: BLE001 - dispatched below
+                target.append(exc)
+
+        worker = threading.Thread(target=_download, daemon=True)
+        worker.start()
+        worker.join(deadline_seconds)
+        if worker.is_alive():
+            last_error = RuntimeError(f"workspace read stalled: {path}")
+            continue
+        result = outcome[0] if outcome else RuntimeError("workspace read returned nothing")
+        if isinstance(result, (NotFound, ResourceDoesNotExist)):
+            raise result
+        if isinstance(result, BaseException):
+            last_error = result
+            continue
+        return result  # type: ignore[return-value]
+    raise RuntimeError(
+        f"workspace read failed after {attempts} bounded attempts: {path}"
+    ) from last_error
+
     # Fresh-credential settle (2026-08-10 discriminator): with user-auth the
     # accounts API answered in ~200-700ms while the SAME calls under a
     # just-minted bounded temp credential stalled indefinitely and its

--- a/tools/databricks/probe_deadlines.py
+++ b/tools/databricks/probe_deadlines.py
@@ -94,13 +94,27 @@ def bounded_workspace_read(
     # Opt-in via env: the deploy wrappers set this so live runs use the CLI;
     # unit tests with mocked workspace clients never leak network calls.
     cli_attempts = 2 if os.environ.get("MIP_PROBE_CLI_TRANSPORT", "").strip() else 0
+    # Identity note (2026-08-10): requests authenticated as the per-run
+    # bounded temp identities stall server-side (dumps: the CLI subprocess
+    # itself sat in communicate() for an hour under the wrapper env), while
+    # the same reads under the operator profile answer in seconds. The
+    # ledger walk is read-only and every record is signature-verified
+    # locally, and the lease root grants the holder CAN_MANAGE by design —
+    # so the read transport pins the operator profile with a clean env
+    # rather than inheriting the wrapper's bounded credentials.
+    cli_profile = os.environ.get("MIP_PROBE_CLI_PROFILE", "").strip() or "DEFAULT"
+    cli_env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", ""),
+    }
     for _attempt in range(cli_attempts):
         try:
             completed = subprocess.run(
-                ["databricks", "workspace", "export", path],
+                ["databricks", "workspace", "export", path, "--profile", cli_profile],
                 capture_output=True,
                 timeout=30,
                 check=False,
+                env=cli_env,
             )
         except FileNotFoundError as exc:
             last_error = exc

--- a/tools/databricks/probe_deadlines.py
+++ b/tools/databricks/probe_deadlines.py
@@ -19,10 +19,13 @@ import os
 import socket
 import sys
 import threading
-import time
 
 _DEADLINE_SECONDS = 120.0
-_WATCHDOG_SECONDS = 900.0
+# Env-tunable: recovery walks a 30+-record ledger where most streaming
+# reads stall once before clearing on retry (2026-08-10 dumps sat in the
+# bounded join while the walk progressed) — that legitimately needs more
+# wall-clock than the default.
+_WATCHDOG_SECONDS = float(os.environ.get("MIP_PROBE_WATCHDOG_S", "") or 900.0)
 _STARTUP_SETTLE_ENV = "MIP_PROBE_STARTUP_SETTLE_S"
 
 
@@ -68,8 +71,8 @@ def bounded_workspace_read(
     workspace: object,
     path: str,
     *,
-    attempts: int = 3,
-    deadline_seconds: float = 60.0,
+    attempts: int = 5,
+    deadline_seconds: float = 20.0,
 ) -> bytes:
     """Download one workspace file with per-attempt deadlines and retries.
 
@@ -110,25 +113,3 @@ def bounded_workspace_read(
     raise RuntimeError(
         f"workspace read failed after {attempts} bounded attempts: {path}"
     ) from last_error
-
-    # Fresh-credential settle (2026-08-10 discriminator): with user-auth the
-    # accounts API answered in ~200-700ms while the SAME calls under a
-    # just-minted bounded temp credential stalled indefinitely and its
-    # creates never became visible. Deployment wrappers mint the bounded
-    # credential immediately before exec'ing this process, so a startup
-    # sleep here separates mint from first use, giving the credential time
-    # to propagate. Opt-in via env so ordinary invocations pay nothing.
-    settle_raw = os.environ.get(_STARTUP_SETTLE_ENV, "").strip()
-    if settle_raw:
-        try:
-            settle = min(300.0, max(0.0, float(settle_raw)))
-        except ValueError:
-            settle = 0.0
-        if settle:
-            print(
-                f"[{label}] settling {int(settle)}s before first use of the "
-                "freshly minted bounded credential",
-                file=sys.stderr,
-                flush=True,
-            )
-            time.sleep(settle)

--- a/tools/databricks/workspace_system_group_evidence.py
+++ b/tools/databricks/workspace_system_group_evidence.py
@@ -60,8 +60,8 @@ def _exact_member_ids(workspace: Any, group_id: str, *, label: str) -> frozenset
     return frozenset(normalized)
 
 
-def workspace_users_group_evidence(workspace: Any) -> dict[str, str]:
-    """Resolve the current-workspace ``users`` system group and its clone."""
+def _scan_users_groups(workspace: Any) -> tuple[dict[str, str], dict[str, str]]:
+    """Return the exact ``users`` system group and any proven clone candidate."""
 
     matches: dict[str, str] = {}
     clone_candidates: dict[str, str] = {}
@@ -112,14 +112,34 @@ def workspace_users_group_evidence(workspace: Any) -> dict[str, str]:
         raise RuntimeError(
             "workspace users system group identity did not resolve exactly once"
         )
-    if clone_candidates:
-        users_group_id = next(iter(matches))
-        users_members = _exact_member_ids(workspace, users_group_id, label="users")
-        clone_group_id = next(iter(clone_candidates))
-        clone_members = _exact_member_ids(workspace, clone_group_id, label="users clone")
-        if not users_members or clone_members != users_members:
-            raise RuntimeError(
-                "workspace users clone group is not an exact clone of the users group"
-            )
-        matches.update(clone_candidates)
+    return matches, clone_candidates
+
+
+def workspace_users_group_evidence(workspace: Any) -> dict[str, str]:
+    """Resolve the immutable current-workspace ``users`` system group."""
+
+    matches, _clone_candidates = _scan_users_groups(workspace)
     return matches
+
+
+def workspace_users_clone_group_evidence(workspace: Any) -> dict[str, str]:
+    """Resolve the Databricks-created ``users`` clone, proven by membership.
+
+    Empty when the workspace never went through the split. The clone is
+    surfaced as a *reviewed* workspace group rather than a system group: the
+    reviewed path additionally proves the group holds exactly ``USER`` on this
+    workspace and nothing on any other workspace in the metastore, which is
+    the stronger contract for a group that carries real entitlements.
+    """
+
+    matches, clone_candidates = _scan_users_groups(workspace)
+    if not clone_candidates:
+        return {}
+    users_members = _exact_member_ids(workspace, next(iter(matches)), label="users")
+    clone_group_id = next(iter(clone_candidates))
+    clone_members = _exact_member_ids(workspace, clone_group_id, label="users clone")
+    if not users_members or clone_members != users_members:
+        raise RuntimeError(
+            "workspace users clone group is not an exact clone of the users group"
+        )
+    return dict(clone_candidates)

--- a/tools/databricks/workspace_system_group_evidence.py
+++ b/tools/databricks/workspace_system_group_evidence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from tools.databricks.agent_runtime_uc_inventory import _text
@@ -9,6 +10,17 @@ from tools.databricks.agent_runtime_uc_inventory import _text
 _WORKSPACE_USERS_GROUP = "users"
 _LEGACY_WORKSPACE_USERS_ENTITLEMENTS = frozenset(
     {"workspace-access", "databricks-sql-access"}
+)
+# Enabling automatic identity management splits the legacy workspace ``users``
+# group: ``users`` itself becomes federated and entitlement-free, and Databricks
+# creates a clone under this exact generated name that carries the legacy
+# entitlements forward (observed on this workspace 2026-08-03). The clone is the
+# same system identity, so the runtime inherits it without any grant of ours —
+# but it is only accepted with proof, below, that its membership is identical to
+# the ``users`` group it was cloned from. Any other group, however named, stays
+# an ordinary membership and still fails the runtime boundary closed.
+_WORKSPACE_USERS_CLONE_RE = re.compile(
+    r"^users-clone-\d{4}-\d{2}-\d{2}-\d{4}-UTC \(created by Databricks\)$"
 )
 
 
@@ -28,16 +40,38 @@ def _exact_scim_complex_values(value: object, *, label: str) -> frozenset[str]:
     return frozenset(normalized)
 
 
+def _exact_member_ids(workspace: Any, group_id: str, *, label: str) -> frozenset[str]:
+    """Return one group's exact SCIM member ids, or fail closed."""
+
+    group = workspace.groups.get(group_id)
+    members = getattr(group, "members", None)
+    if members is None:
+        return frozenset()
+    if not isinstance(members, list):
+        raise RuntimeError(f"workspace {label} group membership is malformed")
+    normalized: list[str] = []
+    for item in members:
+        raw = getattr(item, "value", None)
+        if not isinstance(raw, str) or not raw or raw != raw.strip():
+            raise RuntimeError(f"workspace {label} group membership is malformed")
+        normalized.append(raw)
+    if len(set(normalized)) != len(normalized):
+        raise RuntimeError(f"workspace {label} group membership is ambiguous")
+    return frozenset(normalized)
+
+
 def workspace_users_group_evidence(workspace: Any) -> dict[str, str]:
-    """Resolve the immutable current-workspace ``users`` system group."""
+    """Resolve the current-workspace ``users`` system group and its clone."""
 
     matches: dict[str, str] = {}
+    clone_candidates: dict[str, str] = {}
     for item in workspace.groups.list(
         attributes="id,displayName,meta,entitlements,roles,externalId"
     ):
         raw_display_name = getattr(item, "display_name", None)
         display_name = _text(raw_display_name)
-        if display_name.casefold() != _WORKSPACE_USERS_GROUP:
+        is_clone = bool(_WORKSPACE_USERS_CLONE_RE.fullmatch(display_name))
+        if display_name.casefold() != _WORKSPACE_USERS_GROUP and not is_clone:
             continue
         raw_group_id = getattr(item, "id", None)
         group_id = _text(raw_group_id)
@@ -60,19 +94,32 @@ def workspace_users_group_evidence(workspace: Any) -> dict[str, str]:
             or not isinstance(raw_resource_type, str)
             or raw_resource_type != resource_type
             or not group_id
-            or display_name != _WORKSPACE_USERS_GROUP
+            or display_name != (raw_display_name if is_clone else _WORKSPACE_USERS_GROUP)
             or resource_type != "WorkspaceGroup"
             or getattr(item, "external_id", None) is not None
             or roles
             or entitlements not in (frozenset(), _LEGACY_WORKSPACE_USERS_ENTITLEMENTS)
-            or matches
+            or (clone_candidates if is_clone else matches)
         ):
             raise RuntimeError(
                 "workspace users system group identity is incomplete or ambiguous"
             )
-        matches[group_id] = display_name
+        if is_clone:
+            clone_candidates[group_id] = display_name
+        else:
+            matches[group_id] = display_name
     if len(matches) != 1:
         raise RuntimeError(
             "workspace users system group identity did not resolve exactly once"
         )
+    if clone_candidates:
+        users_group_id = next(iter(matches))
+        users_members = _exact_member_ids(workspace, users_group_id, label="users")
+        clone_group_id = next(iter(clone_candidates))
+        clone_members = _exact_member_ids(workspace, clone_group_id, label="users clone")
+        if not users_members or clone_members != users_members:
+            raise RuntimeError(
+                "workspace users clone group is not an exact clone of the users group"
+            )
+        matches.update(clone_candidates)
     return matches


### PR DESCRIPTION
## Genie depth (the user-facing one)

Captured live against paychex with the user's verbatim question. The governed space plans **seven** good sub-questions; the criterion machine dropped **three** as `unreviewed_criterion` — none named a protected class — leaving four, under the deep floor of five. `run_planned_sweep` returned `None`, the pipeline fell through to a single Genie turn, and the user saw a one-screen answer. Both sweep aborts are silent and the trace shows only single-turn steps, so this was invisible from the UI.

Reviews two shapes the plan actually used, closed vocabulary only: ranked shortlist + governed signal columns, and percentile placement within the population. A third shape (share of a cohort carrying a signal) was written and then **removed** — it let an unknown criterion ride it. Six of seven now survive, clearing the floor.

Fail-closed unchanged; protected-class terms and unknown criteria on these shapes are pinned blocked by test.

**Found, not fixed (reproduces identically on main):** `what proportion of the top N borrowers have <unknown criterion> or are listed for sale` is not caught by the criterion machine at all.

## Deploy tooling

- **Ledger mirror.** The hour-long step-3 "wedge" was never a stall: the lease ledger grew to 5,088 files and the recovery walk read it sequentially at ~0.7s/read, per stability round. One parallel prefetch, then local reads — ~60 min to seconds. Mirrors only create-once records; `.head`/`.protocol-v5`/chain roots always read live; only paths in the live listing are served; scoped per workspace (identical paths, different signed contents).
- **Expiry proof.** A phantom create (acknowledged, never listed, observation lost with a killed process) stranded its intent permanently. For the temporary-probe class only — no sink/ack, bounded TTL, aged past TTL + settle horizon — recovery now resolves `restored`. Any guard miss keeps the quarantine.
- **users-clone system group.** Automatic identity management split this workspace's `users` group; the clone carries the legacy entitlements and the workspace assignment. Admitted as a *reviewed* workspace group (stronger path: exactly `USER` here, nothing elsewhere), proven by membership identical to a non-empty `users`.
- **`.env.example`** documents `MIP_UC_FOREIGN_CATALOG_BINDING_POLICY`, required on any metastore with unbound ISOLATED catalogs (this one has 16) and previously undiscoverable except by deploy failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)