### PR TITLE
fix(genie): make the deep sweep actually ship — deadline, margin, and gateway budget

### DIFF
--- a/backend/schemas/marketing_selection_reviewed_analytics.py
+++ b/backend/schemas/marketing_selection_reviewed_analytics.py
@@ -119,7 +119,14 @@ _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS: tuple[re.Pattern[str], ...] = (
         # mortgage") — still drawn from the same closed vocabulary, so an
         # unknown criterion cannot ride the second slot. Live persona audit
         # 2026-08-07 (co-pilot flagship objective).
-        rf"{_REVIEWED_PRODUCT_INTENT}(?:[\s-]+(?:{_REVIEWED_PRODUCT_INTENT}|mortgage|loan))?\s+"
+        # The intent token is OPTIONAL: "rank the top opportunities" names no
+        # criterion at all, so there is no unreviewed criterion to smuggle —
+        # it ranks by the governed score. An unknown word in this slot still
+        # fails to match (it is neither an intent token nor a cohort noun),
+        # so "rank the top zyrplax borrowers" keeps falling through to the
+        # strict criterion machine. Live persona probe 2026-08-10
+        # (sales-manager): the whole question was refused because of it.
+        rf"(?:{_REVIEWED_PRODUCT_INTENT}(?:[\s-]+(?:{_REVIEWED_PRODUCT_INTENT}|mortgage|loan))?\s+)?"
         r"(?:candidates?|borrowers?|leads?|opportunities)"
         rf"{_REVIEWED_ANALYTIC_LOCATION}"
         r"(?:\s*,?\s*and\s+(?:explain|tell\s+me|describe|show)\s+"

--- a/backend/services/genie_client.py
+++ b/backend/services/genie_client.py
@@ -183,8 +183,15 @@ class GenieClient:
         self,
         question: str,
         conversation_id: str | None = None,
+        poll_timeout_s: int | None = None,
     ) -> GenieResponse:
         """Ask Genie one question; poll to completion; return the answer.
+
+        ``poll_timeout_s`` overrides the interactive polling deadline for
+        callers that are deliberately slower than a single screen — the
+        planned deep sweep runs cross-population scans that legitimately
+        take 80-120s (measured live 2026-08-10), where the default 45s
+        deadline silently dropped exactly the deepest sections.
 
         If ``conversation_id`` is ``None``, starts a new conversation
         (``POST /conversations``) whose initial message IS the question.
@@ -209,7 +216,13 @@ class GenieClient:
             else:
                 conv_id = conversation_id
                 msg_id = self._append_message(conv_id, question)
-            return self._finish_message(conv_id, msg_id, q_hash=q_hash, start=start)
+            return self._finish_message(
+                conv_id,
+                msg_id,
+                q_hash=q_hash,
+                start=start,
+                poll_timeout_s=poll_timeout_s,
+            )
         except BaseException as exc:
             emit(
                 log,
@@ -314,8 +327,9 @@ class GenieClient:
         q_hash: str,
         start: float,
         operation: str = "ask",
+        poll_timeout_s: int | None = None,
     ) -> GenieResponse:
-        message = self._poll_message(conv_id, msg_id)
+        message = self._poll_message(conv_id, msg_id, timeout_s=poll_timeout_s)
         genie_status = str(message.get("status") or message.get("state") or "") or None
         extracted = self._extract_message_payload(message)
         sql_rows: list[dict[str, Any]] | None = None
@@ -494,13 +508,20 @@ class GenieClient:
             )
         return msg_id
 
-    def _poll_message(self, conversation_id: str, message_id: str) -> dict[str, Any]:
+    def _poll_message(
+        self,
+        conversation_id: str,
+        message_id: str,
+        *,
+        timeout_s: int | None = None,
+    ) -> dict[str, Any]:
         """Poll the message until terminal state or timeout."""
         url = (
             f"{self._host}/api/2.0/genie/spaces/{self._space_id}"
             f"/conversations/{conversation_id}/messages/{message_id}"
         )
-        deadline = time.monotonic() + self._timeout_s
+        budget = self._timeout_s if timeout_s is None else timeout_s
+        deadline = time.monotonic() + budget
         sleep_s = self._POLL_INITIAL_S
         last_state: str | None = None
         while True:
@@ -520,7 +541,7 @@ class GenieClient:
                 )
             if time.monotonic() >= deadline:
                 raise GenieClientError(
-                    f"Genie message polling timed out after {self._timeout_s}s "
+                    f"Genie message polling timed out after {budget}s "
                     f"(last_state={last_state!r})",
                     space_id=self._space_id,
                     conversation_id=conversation_id,
@@ -756,6 +777,7 @@ class ResilientGenieClient:
         self,
         question: str,
         conversation_id: str | None = None,
+        poll_timeout_s: int | None = None,
     ) -> GenieResponse:
         # R6-18: when the breaker was force-opened at boot because
         # GENIE_SPACE_ID was a placeholder string, we give ourselves a
@@ -769,7 +791,11 @@ class ResilientGenieClient:
             lambda: not is_placeholder_space_id(self._client.space_id)
         )
         return self._resilient.call(
-            lambda: self._client.ask(question, conversation_id=conversation_id)
+            lambda: self._client.ask(
+                question,
+                conversation_id=conversation_id,
+                poll_timeout_s=poll_timeout_s,
+            )
         )
 
     def submit_message(

--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -241,6 +241,7 @@ class DatabricksGenieRepository:
         conversation_id: str | None = None,
         *,
         allow_sweep: bool = True,
+        poll_timeout_s: int | None = None,
     ) -> GenieMessageResponse:
         # Product posture (mip_genie_live_first=True): LIVE Genie is the primary
         # answer path for every guardrail-passing question so the answer is
@@ -271,7 +272,13 @@ class DatabricksGenieRepository:
                 return sweep
         repaired = False
         try:
-            result = self._genie.ask(question, conversation_id=conversation_id)
+            # Only the deep sweep sets a deadline; the interactive path
+            # keeps the historical call shape so every client implementation
+            # (and test double) of ask() stays valid.
+            ask_kwargs: dict[str, object] = {"conversation_id": conversation_id}
+            if poll_timeout_s is not None:
+                ask_kwargs["poll_timeout_s"] = poll_timeout_s
+            result = self._genie.ask(question, **ask_kwargs)
             if _needs_genie_sql_repair(question, result):
                 regenerated = self._repair_text_only_genie_answer(
                     question=question,

--- a/backend/services/repositories/databricks_genie_sweep.py
+++ b/backend/services/repositories/databricks_genie_sweep.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import re
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from typing import TYPE_CHECKING
 
 from backend.api import genie_guardrails as prompt_guardrails
@@ -61,10 +61,30 @@ def _has_rendered_prose(response: GenieMessageResponse) -> bool:
 
 # Fan-out cap: polite to the Conversation API while keeping wall time near the
 # slowest single turn.
-_SWEEP_MAX_WORKERS = 4
+_SWEEP_MAX_WORKERS = 8
+# Sub-analyses are deliberately deeper than one screen: measured live
+# 2026-08-10, the cross-population scans took 82s, 94s and 120s while the
+# shallow ones took ~40s. The interactive 45s poll deadline therefore
+# dropped precisely the deepest sections, leaving too few to ship and
+# aborting the sweep — the user saw a single-screen answer instead.
+_SWEEP_POLL_TIMEOUT_S = 180
+# Databricks Apps returns 504 at ~300s, so the sweep must finish INSIDE
+# that or the user gets a gateway error instead of an answer (live persona
+# probe 2026-08-10 timed out at 300.7s once deep routing widened). Ship
+# whatever sections completed within the budget and disclose the rest as
+# gaps — the floor still decides whether the sweep is worth shipping.
+_SWEEP_WALL_BUDGET_S = 200.0
 
 _MIN_PLANNED = 3
 _MAX_PLANNED = 7
+# Deep plans ask for MORE candidates than the floor needs. The planner
+# rewords every run, so a phrasing that clears the plan-time guard on one
+# run can trip it on the next; live runs 2026-08-10 lost 2-3 of 7 and
+# landed exactly ON the floor of 5, where one more drop aborts the sweep.
+# Over-planning buys margin without touching the guard — which cannot be
+# relaxed here, since the sweep calls respond() directly and so bypasses
+# the router's guard battery.
+_MAX_PLANNED_DEEP = 10
 # Deep-analysis asks get the larger plan floor: a shortlist + per-item why +
 # offer call cannot be told in three queries.
 _MIN_PLANNED_DEEP = 5
@@ -78,7 +98,9 @@ _PLAN_LINE_RE = re.compile(r"^\s*(?:\d{1,2}[.)]|[-*•])\s+(.{10,240})\s*$")
 # analytic parts (or an explicit depth request) route to the planner first.
 _DEPTH_EXPLICIT_RE = re.compile(
     r"\b(?:deep|comprehensive|complete|thorough|full|in[- ]depth|end[- ]to[- ]end)\b"
-    r".{0,40}\b(?:analysis|analyz|analys|review|dive|assessment|picture|study)",
+    r".{0,40}\b(?:analysis|analyz|analys|review|dive|assessment|picture|study|"
+    r"read|breakdown|rundown|overview|look|investigation|investigat|"
+    r"examination|examin|audit|exploration|explor|teardown|interrogat)",
     re.IGNORECASE,
 )
 _DEPTH_PART_RES: tuple[re.Pattern[str], ...] = (
@@ -134,7 +156,8 @@ def _planning_prompt(question: str, *, deep: bool = False) -> str:
             "concentration or co-occurrence angle (geography, segments, "
             "competitor liens, listing status) that a single screen would "
             "not show. "
-            f"Plan between {_MIN_PLANNED_DEEP} and {_MAX_PLANNED} questions.\n\n"
+            f"Plan between {_MIN_PLANNED_DEEP + 2} and {_MAX_PLANNED_DEEP} "
+            "questions.\n\n"
         )
         count_line = ""
     else:
@@ -162,7 +185,7 @@ def _planning_prompt(question: str, *, deep: bool = False) -> str:
     )
 
 
-def _parse_planned_questions(text: str | None) -> list[str]:
+def _parse_planned_questions(text: str | None, *, deep: bool = False) -> list[str]:
     if not text:
         return []
     # The planner's own "this is not an analytics request" verdict. Nothing
@@ -183,7 +206,7 @@ def _parse_planned_questions(text: str | None) -> list[str]:
             candidate = f"{candidate}?"
         if candidate not in planned:
             planned.append(candidate)
-    return planned[:_MAX_PLANNED]
+    return planned[: (_MAX_PLANNED_DEEP if deep else _MAX_PLANNED)]
 
 
 def _planned_question_guard_hit(question: str) -> str | None:
@@ -224,7 +247,7 @@ def plan_sub_questions(
         planning_turn = repo.ask_raw(_planning_prompt(question, deep=deep))
     except Exception:  # noqa: BLE001 - planner failure falls through honestly
         return [], []
-    planned_raw = _parse_planned_questions(planning_turn)
+    planned_raw = _parse_planned_questions(planning_turn, deep=deep)
     planned: list[str] = []
     dropped: list[str] = []
     for candidate in planned_raw:
@@ -365,12 +388,34 @@ def run_planned_sweep(
 
     def _one(sub_question: str) -> GenieMessageResponse | None:
         try:
-            return repo.respond(sub_question, allow_sweep=False)
+            return repo.respond(
+                sub_question,
+                allow_sweep=False,
+                poll_timeout_s=_SWEEP_POLL_TIMEOUT_S,
+            )
         except Exception:  # noqa: BLE001 - a failed theme becomes a disclosed gap
             return None
 
+    results: list[GenieMessageResponse | None] = [None] * len(planned)
     with ThreadPoolExecutor(max_workers=_SWEEP_MAX_WORKERS) as pool:
-        results = list(pool.map(_one, planned))
+        futures = {
+            pool.submit(_one, sub_question): index
+            for index, sub_question in enumerate(planned)
+        }
+        pending = set(futures)
+        budget_end = started + _SWEEP_WALL_BUDGET_S
+        while pending:
+            remaining = budget_end - time.monotonic()
+            if remaining <= 0:
+                break
+            done, pending = wait(pending, timeout=remaining, return_when=FIRST_COMPLETED)
+            for future in done:
+                try:
+                    results[futures[future]] = future.result()
+                except Exception:  # noqa: BLE001 - becomes a disclosed gap
+                    results[futures[future]] = None
+        for future in pending:
+            future.cancel()
 
     sections: list[tuple[str, GenieMessageResponse]] = []
     gaps: list[str] = list(dropped)

--- a/tests/unit/test_genie_full_analysis_sweep.py
+++ b/tests/unit/test_genie_full_analysis_sweep.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from backend.services.genie_answers import GenieMessageResponse, GenieProof
 from backend.services.repositories.databricks_genie_sweep import (
+    _SWEEP_POLL_TIMEOUT_S,
     _parse_planned_questions,
     _planned_question_guard_hit,
     is_deep_analysis_request,
@@ -66,6 +67,7 @@ class _StubRepo:
     ) -> None:
         self.plan_text = plan_text
         self.calls: list[tuple[str, bool]] = []
+        self.poll_timeouts: list[int | None] = []
         self.raw_prompts: list[str] = []
         self._failures = failures
 
@@ -81,8 +83,10 @@ class _StubRepo:
         conversation_id: str | None = None,
         *,
         allow_sweep: bool = True,
+        poll_timeout_s: int | None = None,
     ) -> GenieMessageResponse:
         self.calls.append((question, allow_sweep))
+        self.poll_timeouts.append(poll_timeout_s)
         if any(marker in question for marker in self._failures):
             return GenieMessageResponse(
                 conversation_id="",
@@ -197,7 +201,10 @@ def test_deep_sweep_uses_deep_plan_floor_and_synthesis() -> None:
     # The deep planning prompt demands the comparison/offer/concentration
     # coverage and the wider plan floor.
     assert "deep-analysis request" in repo.raw_prompts[0]
-    assert "between 5 and 7" in repo.raw_prompts[0]
+    # Deep plans deliberately over-ask (7-10 against a floor of 5): the
+    # planner rewords every run, so plan-time guard drops vary and a plan
+    # sized to the floor aborts the sweep the moment one is dropped.
+    assert "between 7 and 10" in repo.raw_prompts[0]
     # The deep synthesis contract replaces the generic one.
     assert "deep executive synthesis" in repo.raw_prompts[1]
     assert len(repo.calls) == 5
@@ -208,3 +215,19 @@ def test_deep_sweep_requires_the_deeper_plan() -> None:
     # A three-line plan is enough for a rescue sweep but not for a deep ask.
     repo = _StubRepo()
     assert run_planned_sweep(repo, _DEEP_QUESTION, deep=True) is None  # type: ignore[arg-type]
+
+
+def test_sub_analyses_carry_the_sweep_poll_deadline() -> None:
+    """Deep sections legitimately outrun the interactive 45s deadline.
+
+    Measured live 2026-08-10: cross-population scans took 82-120s, so the
+    interactive deadline timed out exactly the deepest sections and starved
+    the sweep below its section floor.
+    """
+
+    repo = _StubRepo(plan_text=_DEEP_PLAN_TEXT)
+    result = run_planned_sweep(repo, "Do a deep analysis of the portfolio.", deep=True)
+
+    assert result is not None
+    assert repo.poll_timeouts
+    assert all(value == _SWEEP_POLL_TIMEOUT_S for value in repo.poll_timeouts)

--- a/tests/unit/test_genie_sweep_poll_deadline.py
+++ b/tests/unit/test_genie_sweep_poll_deadline.py
@@ -1,0 +1,65 @@
+"""Deep-sweep sub-analyses get a deadline sized for their real latency.
+
+Live measurement 2026-08-10: the planned cross-population scans took 82s,
+94s and 120s while the shallow sections took ~40s. The interactive 45s
+polling deadline therefore timed out exactly the deepest sections, leaving
+fewer than ``_MIN_PLANNED`` usable ones, so ``run_planned_sweep`` aborted and
+the user got a single-turn answer.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from backend.services.repositories import databricks_genie_sweep as sweep
+
+
+def test_sweep_deadline_exceeds_the_measured_deep_section_latency() -> None:
+    # The slowest measured section was 120s; the per-section deadline must
+    # clear it with headroom.
+    assert sweep._SWEEP_POLL_TIMEOUT_S >= 150
+
+
+def test_sweep_finishes_inside_the_apps_gateway_timeout() -> None:
+    """Databricks Apps returns 504 at ~300s (live probe 2026-08-10: 300.7s).
+
+    The whole sweep — fan-out plus synthesis plus the surrounding turn — has
+    to land inside that or the user gets a gateway error instead of an answer.
+    """
+
+    assert sweep._SWEEP_WALL_BUDGET_S <= 240
+    # A section that outruns the whole budget could never contribute.
+    assert sweep._SWEEP_POLL_TIMEOUT_S <= sweep._SWEEP_WALL_BUDGET_S
+
+
+def test_fan_out_covers_a_full_deep_plan_in_one_wave() -> None:
+    # Deep plans ask for up to _MAX_PLANNED_DEEP; running them in one wave is
+    # what keeps the wall budget achievable.
+    assert sweep._SWEEP_MAX_WORKERS >= 8
+
+
+def test_sub_analyses_are_asked_with_the_sweep_deadline() -> None:
+    source = inspect.getsource(sweep.run_planned_sweep)
+    assert "poll_timeout_s=_SWEEP_POLL_TIMEOUT_S" in source
+    assert "allow_sweep=False" in source
+
+
+def test_repository_and_clients_accept_the_override() -> None:
+    from backend.services.genie_client import GenieClient, ResilientGenieClient
+    from backend.services.repositories.databricks_genie import (
+        DatabricksGenieRepository,
+    )
+
+    for func in (
+        GenieClient.ask,
+        ResilientGenieClient.ask,
+        DatabricksGenieRepository.respond,
+    ):
+        assert "poll_timeout_s" in inspect.signature(func).parameters
+
+
+def test_interactive_default_is_unchanged_when_no_override_is_given() -> None:
+    from backend.services.genie_client import GenieClient
+
+    assert inspect.signature(GenieClient.ask).parameters["poll_timeout_s"].default is None
+    assert inspect.signature(GenieClient.__init__).parameters["timeout_s"].default == 45

--- a/tests/unit/test_planned_deep_analysis_guard_capture.py
+++ b/tests/unit/test_planned_deep_analysis_guard_capture.py
@@ -77,3 +77,89 @@ def test_live_plan_keeps_enough_sections_to_run_the_deep_sweep() -> None:
 )
 def test_reviewed_shapes_stay_closed(question: str) -> None:
     assert protected_prompt_match(question) is not None
+
+
+LIVE_PERSONA_PROBES = (
+    # Marketing leader: "a deep, comprehensive read" is the same ask as "a deep
+    # analysis"; the depth nouns had no business phrasings, so this ran as a
+    # single turn. Live persona probe 2026-08-10.
+    "Give me a deep, comprehensive read on our offer mix. For every recommended "
+    "offer, what signals drive it, how large is the addressable cohort, how do "
+    "those cohorts differ on equity and rate spread, and where should we "
+    "concentrate spend geographically and why?",
+)
+
+
+@pytest.mark.parametrize("question", LIVE_PERSONA_PROBES)
+def test_persona_depth_phrasings_route_to_the_deep_sweep(question: str) -> None:
+    from backend.services.repositories.databricks_genie_sweep import (
+        is_deep_analysis_request,
+    )
+
+    assert is_deep_analysis_request(question)
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        # The plainest sales ask: a ranked cohort with NO criterion at all.
+        "Rank the top opportunities",
+        "Rank the top borrowers",
+        "Show the top leads",
+    ],
+)
+def test_bare_ranked_cohort_is_reviewed(question: str) -> None:
+    assert protected_prompt_match(question) is None
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        "Rank the top zyrplax borrowers",
+        "Rank the top hispanic borrowers",
+        "Rank the top borrowers with eczema",
+        "Show me the top christian leads",
+        "list the top female candidates",
+    ],
+)
+def test_bare_ranked_cohort_shape_stays_closed(question: str) -> None:
+    assert protected_prompt_match(question) is not None
+
+
+@pytest.mark.parametrize(
+    "phrasing",
+    [
+        # Investigative asks — live persona probe 2026-08-10 ran an "in-depth
+        # investigation" question as a single 26s turn because the depth nouns
+        # covered analysis/review/dive/study but no investigative vocabulary.
+        "Do an in-depth investigation of the portfolio",
+        "Do a deep investigation of the portfolio",
+        "Do a thorough investigation of the portfolio",
+        "Give me a comprehensive examination of the portfolio",
+        "Run a full audit of the portfolio",
+        "Do a deep exploration of the portfolio",
+    ],
+)
+def test_investigative_phrasings_route_to_the_deep_sweep(phrasing: str) -> None:
+    from backend.services.repositories.databricks_genie_sweep import (
+        is_deep_analysis_request,
+    )
+
+    assert is_deep_analysis_request(phrasing)
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        "How many in-the-money borrowers are in TX?",
+        "Show borrowers by state.",
+        "What is the average equity percentage?",
+        "How many leads do we have?",
+    ],
+)
+def test_single_part_asks_stay_on_the_single_turn_path(question: str) -> None:
+    from backend.services.repositories.databricks_genie_sweep import (
+        is_deep_analysis_request,
+    )
+
+    assert not is_deep_analysis_request(question)


### PR DESCRIPTION
Found by running the deep-analysis path against the **live app** and measuring, not by reading code.

## The sweep was silently discarding its best work

Each planned sub-analysis was run individually through the app: all five returned governed, data-bearing sections — in 82s, 120s, 42s, 40s and 94s. The Genie client polls with `databricks_timeout_s + 15 = 45s`, sized so "a cold-start Genie doesn't hang the FastAPI handler". That interactive deadline timed out precisely the deepest sections (cross-population scans over 500+ rows) and kept only the shallow ones, leaving two — under `_MIN_PLANNED` — so `run_planned_sweep` returned `None` and fell through to a single turn. Observed wall time 119.7s fits exactly: timeouts, abort, one more turn.

Sub-analyses now carry an explicit deadline threaded `respond()` → `ResilientGenieClient.ask` → `GenieClient.ask` → `_poll_message`. The interactive default is untouched and the kwarg is only passed when set, so every existing client implementation and test double stays valid.

**Result on the live app:** the user's question went from 1,521 chars / 1 turn to **11,728 chars / 9 sub-analyses** with an `orchestrate` trace step — 100% of the top cohort in-the-money vs 1.49% of the population, ZIP concentration against base rates, per-borrower offer calls.

## Plan margin

The planner rewords every run, so plan-time guard drops vary (2-3 of 7 across live runs) and a plan sized to the floor lands exactly ON 5, where one more drop aborts the sweep. Deep plans now ask for 7-10.

The guard itself is **not** relaxed: the sweep calls `respond()` directly and so bypasses the router's guard battery, which makes that screen the only thing between a model-authored question and Genie.

## Gateway budget (regression caught by persona probes)

Widening deep routing sent one persona question into a sweep that ran past Databricks Apps' ~300s limit and returned **HTTP 504 at 300.7s** — worse than the shallow answer it replaced. The fan-out now runs under a 200s wall budget: finished sections are kept, the rest cancelled and disclosed as gaps via the existing mechanism, floor still decides shipping. Per-section 240s → 180s so no one section eats the budget; pool 4 → 8 so a full deep plan runs in one wave.

## Persona findings

- "a deep, comprehensive **read**" ran as a single turn — depth nouns lacked ordinary business phrasings (read/breakdown/rundown/overview/look). They still require a depth adjective within 40 chars.
- "Rank the top opportunities" was **refused** as an unreviewed criterion: the reviewed ranked-cohort shape required a product-intent token, so the plainest ask in the product fell through to the strict machine. The token is now optional; an unknown word in that slot matches neither an intent token nor a cohort noun, so `rank the top zyrplax borrowers` keeps failing closed. Six adversarial phrasings pinned blocked.

## Known remaining (not fixed here)

- Multi-clause conversational questions can't match the `^…$`-anchored reviewed shapes, so a two-sentence sales question is still refused even when every clause passes individually. Structural; needs a considered fix, not another regex.
- `what proportion of the top N borrowers have <unknown criterion> or are listed for sale` is not caught by the criterion machine at all — reproduces on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)