### PR TITLE
refactor(api): split the lead queue's query params and cohort replay out of the router

### DIFF
--- a/backend/api/leads.py
+++ b/backend/api/leads.py
@@ -9,23 +9,56 @@ already masked before API egress.
 """
 from __future__ import annotations
 
-import json
 import logging
-from typing import Annotated, Literal
+from typing import Annotated
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 
 from backend.schemas._validators_tenant import normalize_public_lender_ref
 from backend.schemas.common import validate_internal_staff_email
 from backend.schemas.lead import SEGMENT_CODE_VALUES, LeadSummary
-from backend.schemas.portfolio import PortfolioCriteria
-from backend.services.audit_store import AuditStore, get_audit_store, resolve_actor
-from backend.services.lakebase import LakebaseError, get_lakebase_client
-from backend.services.lead_query_helpers import (
-    cohort_list as _cohort_list,
+from backend.schemas.lead_query import (
+    DEFAULT_LEAD_LIMIT,
+    MAX_LEAD_LIMIT,
+    AgedDaysParam,
+    ApprovalStatusParam,
+    AssignedToParam,
+    BorrowerIdsParam,
+    CohortIdParam,
+    ConsentStatusParam,
+    CountiesParam,
+    CountyParam,
+    FunnelStageParam,
+    GeographyParam,
+    IncludeIdentityProofParam,
+    IncludeSuppressedForAnalyticsParam,
+    LenderRelationshipParam,
+    LienStatusParam,
+    LimitParam,
+    LoanProductParam,
+    MarketingEligibilityParam,
+    MinEquityPctLabelParam,
+    MinEquityPctParam,
+    OccupancyParam,
+    OriginationChannelParam,
+    OutreachStatusParam,
+    OwnerLinkParam,
+    ProductParam,
+    PurchaseIntentParam,
+    RecencyParam,
+    SegmentCodesParam,
+    SegmentModeParam,
+    StateParam,
+    StatesParam,
+    TargetLenderRefParam,
+    ZipParam,
+    ZipsParam,
 )
-from backend.services.lead_query_helpers import (
-    cohort_segment_mode as _cohort_segment_mode,
+from backend.services.audit_store import AuditStore, get_audit_store, resolve_actor
+from backend.services.lakebase import LakebaseError
+from backend.services.lead_cohort_replay import (
+    cohort_portfolio_criteria,
+    resolve_cohort_replay,
 )
 from backend.services.lead_query_helpers import (
     parse_borrower_ids as _parse_borrower_ids,
@@ -67,11 +100,11 @@ log = logging.getLogger(__name__)
 
 router = APIRouter(tags=["leads"])
 
-# Kept in sync with DatabricksLeadRepository.{DEFAULT_LIMIT, MAX_LIMIT}.
-# Exposed as module-level constants so the router's Query() annotations
-# and the unit tests can both read one source of truth.
-DEFAULT_LEAD_LIMIT: int = 500
-MAX_LEAD_LIMIT: int = 5000
+# Re-exported: the limit bounds are declared next to the Query() annotation
+# that enforces them, and callers (backend.services.lead_warm, the unit
+# tests) have always read them from here.
+__all__ = ["DEFAULT_LEAD_LIMIT", "MAX_LEAD_LIMIT", "router"]
+
 _ALLOWED_SEGMENT_CODES: frozenset[str] = frozenset(SEGMENT_CODE_VALUES)
 _ALLOWED_FUNNEL_STAGES: frozenset[str] = frozenset(
     {
@@ -83,14 +116,6 @@ _ALLOWED_FUNNEL_STAGES: frozenset[str] = frozenset(
         "actioned",
     }
 )
-
-_COHORT_FILTER_SELECT_SQL = """
-SELECT route_filters, row_count
-FROM mip_app.genie_cohorts
-WHERE cohort_id = %(cohort_id)s
-  AND actor_email = %(actor_email)s
-LIMIT 1
-"""
 
 RepoDep = Annotated[LeadRepository, Depends(get_lead_repository)]
 StoreDep = Annotated[AuditStore, Depends(get_audit_store)]
@@ -119,44 +144,6 @@ def _safe_audit_write(store: AuditStore, **kwargs: object) -> None:
         )
 
 
-def _load_cohort_filters(
-    cohort_id: str, *, actor: str
-) -> tuple[dict[str, object], int | None]:
-    """Return the replayable filters and the count the Genie answer stated.
-
-    The stated count is what the user just read on screen. The queue below
-    replays only the reviewed geography/segment subset, so the two can
-    diverge by orders of magnitude (live 2026-08-10: an answer of 32
-    borrowers replays to 1,766). Carrying it here is what lets the response
-    say so instead of quietly showing a different population.
-    """
-
-    try:
-        row = get_lakebase_client().fetchone(
-            _COHORT_FILTER_SELECT_SQL,
-            {"cohort_id": cohort_id, "actor_email": actor},
-        )
-    except LakebaseError as exc:
-        raise HTTPException(status_code=503, detail="Lakebase temporarily unavailable") from exc
-    if row is None:
-        raise HTTPException(status_code=404, detail="cohort not found")
-    filters_raw = row.get("route_filters") or {}
-    if isinstance(filters_raw, str):
-        try:
-            filters_raw = json.loads(filters_raw)
-        except json.JSONDecodeError as exc:
-            raise HTTPException(status_code=422, detail="cohort route filters are invalid") from exc
-    if not isinstance(filters_raw, dict):
-        raise HTTPException(status_code=422, detail="cohort route filters are invalid")
-    stated_raw = row.get("row_count")
-    stated_count: int | None
-    try:
-        stated_count = int(stated_raw) if stated_raw is not None else None
-    except (TypeError, ValueError):
-        stated_count = None
-    return filters_raw, stated_count
-
-
 @router.get("/leads", response_model=list[LeadSummary])
 def list_leads(
     request: Request,
@@ -166,298 +153,40 @@ def list_leads(
     audit: StoreDep,
     sales_state: SalesStateDep,
     segment: str | None = None,
-    segment_codes: Annotated[
-        str | None,
-        Query(
-            alias="segment_codes",
-            description=(
-                "Optional comma-separated SegmentCode list for multi-card "
-                "filters. Use when more than one segment card is active."
-            ),
-        ),
-    ] = None,
-    segment_mode: Annotated[
-        str,
-        Query(
-            description=(
-                "any = segment arrays overlap; all = borrower contains every "
-                "selected segment code."
-            ),
-        ),
-    ] = "any",
+    segment_codes: SegmentCodesParam = None,
+    segment_mode: SegmentModeParam = "any",
     portfolio_id: str | None = None,
-    state: Annotated[
-        str | None,
-        Query(
-            min_length=2,
-            max_length=2,
-            pattern=r"^[A-Za-z]{2}$",
-            description=(
-                "Optional 2-char USPS state code. When present, the repo "
-                "queries borrower_360 directly (no score floor) so the "
-                "returned rows match the per-state map count."
-            ),
-        ),
-    ] = None,
-    zip_code: Annotated[
-        str | None,
-        Query(
-            alias="zip",
-            min_length=5,
-            max_length=5,
-            pattern=r"^\d{5}$",
-            description=(
-                "Optional 5-char ZIP. Same borrower_360 query path as state. "
-                "Use with state for the most narrow filter."
-            ),
-        ),
-    ] = None,
-    county: Annotated[
-        str | None,
-        Query(
-            alias="county",
-            min_length=5,
-            max_length=5,
-            pattern=r"^\d{5}$",
-            description=(
-                "Optional 5-char county FIPS. Same borrower_360 query path "
-                "as state/zip so map drill-downs preserve the counted cohort."
-            ),
-        ),
-    ] = None,
-    states: Annotated[
-        str | None,
-        Query(
-            alias="states",
-            max_length=256,
-            description=(
-                "Optional comma-separated USPS states for Genie-generated "
-                "cohort actions."
-            ),
-        ),
-    ] = None,
-    zips: Annotated[
-        str | None,
-        Query(
-            alias="zips",
-            max_length=4096,
-            description=(
-                "Optional comma-separated 5-digit ZIP list for Genie-generated "
-                "cohort actions."
-            ),
-        ),
-    ] = None,
-    counties: Annotated[
-        str | None,
-        Query(
-            alias="counties",
-            max_length=4096,
-            description=(
-                "Optional comma-separated 5-digit county FIPS list for "
-                "Genie-generated cohort actions."
-            ),
-        ),
-    ] = None,
-    borrower_ids: Annotated[
-        str | None,
-        Query(
-            alias="borrower_ids",
-            max_length=8192,
-            description=(
-                "Optional comma-separated synthetic borrower IDs for Genie "
-                "borrower-list cohort actions."
-            ),
-        ),
-    ] = None,
-    target_lender_ref: Annotated[
-        str | None,
-        Query(
-            alias="target_lender_ref",
-            max_length=64,
-            description="Optional public-demo-safe current-lender ref such as the configured tenant lender or Competitor A.",
-        ),
-    ] = None,
-    geography: Annotated[
-        str | None,
-        Query(
-            alias="geography",
-            max_length=64,
-            description="Optional Portfolio Builder geography label to replay the built population.",
-        ),
-    ] = None,
-    occupancy: Annotated[
-        str | None,
-        Query(
-            alias="occupancy",
-            max_length=64,
-            description="Optional Portfolio Builder occupancy filter.",
-        ),
-    ] = None,
-    lien_status: Annotated[
-        str | None,
-        Query(
-            alias="lien_status",
-            max_length=64,
-            description="Optional Portfolio Builder lien-status filter.",
-        ),
-    ] = None,
-    lender_relationship: Annotated[
-        str | None,
-        Query(
-            alias="lender_relationship",
-            max_length=64,
-            description="Optional Portfolio Builder lender-relationship filter.",
-        ),
-    ] = None,
-    product: Annotated[
-        str | None,
-        Query(
-            alias="product",
-            max_length=64,
-            description="Optional Portfolio Builder product filter.",
-        ),
-    ] = None,
-    loan_product: Annotated[
-        str | None,
-        Query(alias="loan_product", max_length=64, description="Optional loan product-type filter."),
-    ] = None,
-    origination_channel: Annotated[
-        str | None,
-        Query(alias="origination_channel", max_length=64, description="Optional origination-channel filter."),
-    ] = None,
-    min_equity_pct_label: Annotated[
-        str | None,
-        Query(
-            alias="min_equity_pct_label",
-            max_length=32,
-            description="Optional Portfolio Builder display equity threshold.",
-        ),
-    ] = None,
-    min_equity_pct: Annotated[
-        float | None,
-        Query(
-            alias="min_equity_pct",
-            ge=0,
-            le=100,
-            description="Optional numeric Portfolio Builder equity threshold.",
-        ),
-    ] = None,
-    owner_link: Annotated[
-        str | None,
-        Query(
-            alias="owner_link",
-            max_length=64,
-            description="Optional owner-link bucket from Segment Intelligence.",
-        ),
-    ] = None,
-    purchase_intent: Annotated[
-        str | None,
-        Query(
-            alias="purchase_intent",
-            max_length=64,
-            description="Optional purchase-intent bucket from Segment Intelligence.",
-        ),
-    ] = None,
-    marketing_eligibility: Annotated[
-        str,
-        Query(
-            alias="marketing_eligibility",
-            max_length=32,
-            description="Contactability gate. Defaults to Eligible only for fail-closed campaign/export use.",
-        ),
-    ] = "Eligible only",
-    consent_status: Annotated[
-        str | None,
-        Query(
-            alias="consent_status",
-            max_length=32,
-            description="Optional consent filter: Opt-in, Opt-out, Unknown, Any.",
-        ),
-    ] = None,
-    recency: Annotated[
-        str | None,
-        Query(
-            alias="recency",
-            max_length=32,
-            description="Optional touch-recency filter: Untouched 30d/60d/90d or Any.",
-        ),
-    ] = None,
-    include_suppressed_for_analytics: Annotated[
-        bool,
-        Query(
-            alias="include_suppressed_for_analytics",
-            description=(
-                "Admin-only analytics override. When true, clears the default "
-                "Eligible only marketing gate so suppressed/non-opt-in rows can "
-                "be counted or inspected without making them campaign-actionable."
-            ),
-        ),
-    ] = False,
-    include_identity_proof: Annotated[
-        bool,
-        Query(
-            alias="include_identity_proof",
-            description=(
-                "Admin/evaluation-only complete-cohort digest and snapshot headers. "
-                "Disabled by default because it performs an aggregate proof query."
-            ),
-        ),
-    ] = False,
-    approval_status: Annotated[
-        Literal["pending", "approved", "rejected", "hold", "any"],
-        Query(alias="approval_status", description="Sales workflow approval state filter."),
-    ] = "any",
-    outreach_status: Annotated[
-        Literal["none", "queued", "actioned", "sent", "bounced", "replied", "any"],
-        Query(alias="outreach_status", description="Sales workflow outreach state filter."),
-    ] = "any",
-    assigned_to: Annotated[
-        str | None,
-        Query(alias="assigned_to", max_length=256, description="Internal LO email assigned to the lead."),
-    ] = None,
-    aged_days: Annotated[
-        int | None,
-        Query(alias="aged_days", ge=1, le=90, description="Only approved leads aged at least this many days with no outreach."),
-    ] = None,
-    cohort_id: Annotated[
-        str | None,
-        Query(
-            alias="cohort_id",
-            max_length=64,
-            description="Optional Lakebase persisted cohort id produced by a governed Genie action.",
-        ),
-    ] = None,
-    funnel_stage: Annotated[
-        Literal[
-            "addressable",
-            "in_the_money",
-            "high_opportunity",
-            "offer_recommended",
-            "approved",
-            "actioned",
-        ] | None,
-        Query(
-            alias="funnel_stage",
-            description=(
-                "Exact native-analytics Lead Funnel drilldown. When present, "
-                "the repository applies the same gold.borrower_360 predicate "
-                "used by the funnel snapshot so X-Total-Matching equals the "
-                "clicked stage count."
-            ),
-        ),
-    ] = None,
-    limit: Annotated[
-        int,
-        Query(
-            ge=1,
-            le=MAX_LEAD_LIMIT,
-            description=(
-                "Maximum leads to return. Defaults to 500; max 5000. When the "
-                "resultset hits this cap the response sets `X-Truncated-At` "
-                "so the UI can render 'Showing N — refine filters'."
-            ),
-        ),
-    ] = DEFAULT_LEAD_LIMIT,
+    state: StateParam = None,
+    zip_code: ZipParam = None,
+    county: CountyParam = None,
+    states: StatesParam = None,
+    zips: ZipsParam = None,
+    counties: CountiesParam = None,
+    borrower_ids: BorrowerIdsParam = None,
+    target_lender_ref: TargetLenderRefParam = None,
+    geography: GeographyParam = None,
+    occupancy: OccupancyParam = None,
+    lien_status: LienStatusParam = None,
+    lender_relationship: LenderRelationshipParam = None,
+    product: ProductParam = None,
+    loan_product: LoanProductParam = None,
+    origination_channel: OriginationChannelParam = None,
+    min_equity_pct_label: MinEquityPctLabelParam = None,
+    min_equity_pct: MinEquityPctParam = None,
+    owner_link: OwnerLinkParam = None,
+    purchase_intent: PurchaseIntentParam = None,
+    marketing_eligibility: MarketingEligibilityParam = "Eligible only",
+    consent_status: ConsentStatusParam = None,
+    recency: RecencyParam = None,
+    include_suppressed_for_analytics: IncludeSuppressedForAnalyticsParam = False,
+    include_identity_proof: IncludeIdentityProofParam = False,
+    approval_status: ApprovalStatusParam = "any",
+    outreach_status: OutreachStatusParam = "any",
+    assigned_to: AssignedToParam = None,
+    aged_days: AgedDaysParam = None,
+    cohort_id: CohortIdParam = None,
+    funnel_stage: FunnelStageParam = None,
+    limit: LimitParam = DEFAULT_LEAD_LIMIT,
 ) -> list[LeadSummary]:
     # 2026-05-04 FIX β: plumb optional state/zip filters through to the
     # repo. The repo's geo-filtered path bypasses lead_population (which
@@ -542,11 +271,13 @@ def list_leads(
         # Cohort id is the governed source of truth. Query params are
         # useful for shareable URLs and visual chips, but they must not
         # widen a confirmed Genie cohort if the URL is edited by hand.
-        cohort_filters, cohort_stated_count = _load_cohort_filters(cohort_id, actor=actor)
+        replay = resolve_cohort_replay(cohort_id, actor=actor)
+        cohort_filters = replay.filters
+        cohort_stated_count = replay.stated_count
+        cohort_unreplayable = replay.unreplayable_filters
         segment = None
         state = None
         zip_code = None
-        county = None
         portfolio_id = None
         geography = None
         occupancy = None
@@ -564,27 +295,14 @@ def list_leads(
         outreach_status = "any"
         assigned_to = None
         aged_days = None
-        target_lender_ref = None
-        parsed_segments = None
-        segment_mode = _cohort_segment_mode(cohort_filters)
-        parsed_states = _cohort_list(cohort_filters, "states", width=2)
-        parsed_zips = _cohort_list(cohort_filters, "zips", width=5, numeric=True)
-        parsed_counties = _cohort_list(cohort_filters, "counties", width=5, numeric=True)
-        parsed_borrower_ids = _cohort_list(cohort_filters, "borrower_ids", borrower_ids=True)
-        cohort_county = str(cohort_filters.get("county") or "").strip()
-        if cohort_county:
-            if not cohort_county.isdigit() or len(cohort_county) != 5:
-                raise HTTPException(status_code=422, detail="cohort county filter is invalid")
-            county = cohort_county
-        cohort_segments = _cohort_list(cohort_filters, "segment_codes")
-        if cohort_segments is not None:
-            parsed_segments = _parse_segment_codes(",".join(cohort_segments))
-        unreplayable_raw = cohort_filters.get("unreplayable_filters")
-        if isinstance(unreplayable_raw, list):
-            cohort_unreplayable = [str(key) for key in unreplayable_raw if str(key).strip()]
-        cohort_target = str(cohort_filters.get("target_lender_ref") or "").strip()
-        if cohort_target:
-            target_lender_ref = cohort_target
+        county = replay.county_fips
+        target_lender_ref = replay.target_lender_ref
+        segment_mode = replay.segment_mode
+        parsed_segments = replay.segment_codes
+        parsed_states = replay.state_codes
+        parsed_zips = replay.zip_codes
+        parsed_counties = replay.county_fipses
+        parsed_borrower_ids = replay.borrower_ids
     try:
         target_lender_ref = normalize_public_lender_ref(target_lender_ref, allow_all=True)
     except ValueError as exc:
@@ -596,43 +314,20 @@ def list_leads(
         target_lender_ref = None
 
     if cohort_id:
-        portfolio_raw = cohort_filters.get("portfolio_criteria")
-        cohort_has_replay_filter = any(
-            (
-                parsed_states,
-                parsed_zips,
-                parsed_counties,
-                parsed_borrower_ids,
-                county,
-                parsed_segments,
-                target_lender_ref,
-            )
-        )
-        if isinstance(portfolio_raw, dict):
-            try:
-                original_criteria = PortfolioCriteria(**portfolio_raw)
-            except ValueError as exc:
-                raise HTTPException(
-                    status_code=422,
-                    detail="cohort portfolio criteria are invalid",
-                ) from exc
-            if not original_criteria.has_effective_predicate(count_default_marketing=False):
-                raise HTTPException(
-                    status_code=422,
-                    detail="cohort portfolio criteria are invalid",
+        portfolio_criteria, cohort_has_replay_filter = cohort_portfolio_criteria(
+            cohort_filters,
+            has_replay_filter=any(
+                (
+                    parsed_states,
+                    parsed_zips,
+                    parsed_counties,
+                    parsed_borrower_ids,
+                    county,
+                    parsed_segments,
+                    target_lender_ref,
                 )
-            cohort_has_replay_filter = True
-            safe_portfolio_raw = dict(portfolio_raw)
-            safe_portfolio_raw["marketing_eligibility"] = "Eligible only"
-            safe_portfolio_raw.pop("consent_status", None)
-            portfolio_criteria = PortfolioCriteria(**safe_portfolio_raw)
-        elif portfolio_raw is not None:
-            raise HTTPException(
-                status_code=422,
-                detail="cohort portfolio criteria are invalid",
-            )
-        else:
-            portfolio_criteria = PortfolioCriteria(marketing_eligibility="Eligible only")
+            ),
+        )
     else:
         try:
             portfolio_criteria = _portfolio_criteria_from_query(

--- a/backend/schemas/lead_query.py
+++ b/backend/schemas/lead_query.py
@@ -1,0 +1,352 @@
+"""Query-parameter contract for ``GET /api/leads``.
+
+The Lead Queue accepts 35 query parameters -- geography drill-downs,
+Portfolio Builder replays, sales-workflow state, and the governed Genie
+cohort handoff. Declaring them inline left the router's signature ~290
+lines long, which buried the ten lines of logic underneath it.
+
+Each parameter is exported as an ``Annotated`` alias so the router reads
+as a list of names and the FastAPI ``Query()`` metadata -- alias,
+pattern, bounds, description -- lives in one reviewable place. FastAPI
+resolves an aliased ``Annotated`` identically to an inline one, so the
+generated OpenAPI surface is byte-identical; ``tests/fixtures/
+openapi_baseline.json`` pins that.
+
+Defaults stay in the router signature: they are part of the endpoint's
+behaviour, not of the parameter's type.
+"""
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from fastapi import Query
+
+# Kept in sync with DatabricksLeadRepository.{DEFAULT_LIMIT, MAX_LIMIT}.
+# Module-level so the router's Query() annotation, backend.api.leads
+# (which re-exports them), and the unit tests all read one source of truth.
+DEFAULT_LEAD_LIMIT: int = 500
+MAX_LEAD_LIMIT: int = 5000
+
+SegmentCodesParam = Annotated[
+    str | None,
+    Query(
+        alias="segment_codes",
+        description=(
+            "Optional comma-separated SegmentCode list for multi-card "
+            "filters. Use when more than one segment card is active."
+        ),
+    ),
+]
+
+SegmentModeParam = Annotated[
+    str,
+    Query(
+        description=(
+            "any = segment arrays overlap; all = borrower contains every "
+            "selected segment code."
+        ),
+    ),
+]
+
+StateParam = Annotated[
+    str | None,
+    Query(
+        min_length=2,
+        max_length=2,
+        pattern=r"^[A-Za-z]{2}$",
+        description=(
+            "Optional 2-char USPS state code. When present, the repo "
+            "queries borrower_360 directly (no score floor) so the "
+            "returned rows match the per-state map count."
+        ),
+    ),
+]
+
+ZipParam = Annotated[
+    str | None,
+    Query(
+        alias="zip",
+        min_length=5,
+        max_length=5,
+        pattern=r"^\d{5}$",
+        description=(
+            "Optional 5-char ZIP. Same borrower_360 query path as state. "
+            "Use with state for the most narrow filter."
+        ),
+    ),
+]
+
+CountyParam = Annotated[
+    str | None,
+    Query(
+        alias="county",
+        min_length=5,
+        max_length=5,
+        pattern=r"^\d{5}$",
+        description=(
+            "Optional 5-char county FIPS. Same borrower_360 query path "
+            "as state/zip so map drill-downs preserve the counted cohort."
+        ),
+    ),
+]
+
+StatesParam = Annotated[
+    str | None,
+    Query(
+        alias="states",
+        max_length=256,
+        description=(
+            "Optional comma-separated USPS states for Genie-generated "
+            "cohort actions."
+        ),
+    ),
+]
+
+ZipsParam = Annotated[
+    str | None,
+    Query(
+        alias="zips",
+        max_length=4096,
+        description=(
+            "Optional comma-separated 5-digit ZIP list for Genie-generated "
+            "cohort actions."
+        ),
+    ),
+]
+
+CountiesParam = Annotated[
+    str | None,
+    Query(
+        alias="counties",
+        max_length=4096,
+        description=(
+            "Optional comma-separated 5-digit county FIPS list for "
+            "Genie-generated cohort actions."
+        ),
+    ),
+]
+
+BorrowerIdsParam = Annotated[
+    str | None,
+    Query(
+        alias="borrower_ids",
+        max_length=8192,
+        description=(
+            "Optional comma-separated synthetic borrower IDs for Genie "
+            "borrower-list cohort actions."
+        ),
+    ),
+]
+
+TargetLenderRefParam = Annotated[
+    str | None,
+    Query(
+        alias="target_lender_ref",
+        max_length=64,
+        description="Optional public-demo-safe current-lender ref such as the configured tenant lender or Competitor A.",
+    ),
+]
+
+GeographyParam = Annotated[
+    str | None,
+    Query(
+        alias="geography",
+        max_length=64,
+        description="Optional Portfolio Builder geography label to replay the built population.",
+    ),
+]
+
+OccupancyParam = Annotated[
+    str | None,
+    Query(
+        alias="occupancy",
+        max_length=64,
+        description="Optional Portfolio Builder occupancy filter.",
+    ),
+]
+
+LienStatusParam = Annotated[
+    str | None,
+    Query(
+        alias="lien_status",
+        max_length=64,
+        description="Optional Portfolio Builder lien-status filter.",
+    ),
+]
+
+LenderRelationshipParam = Annotated[
+    str | None,
+    Query(
+        alias="lender_relationship",
+        max_length=64,
+        description="Optional Portfolio Builder lender-relationship filter.",
+    ),
+]
+
+ProductParam = Annotated[
+    str | None,
+    Query(
+        alias="product",
+        max_length=64,
+        description="Optional Portfolio Builder product filter.",
+    ),
+]
+
+LoanProductParam = Annotated[
+    str | None,
+    Query(alias="loan_product", max_length=64, description="Optional loan product-type filter."),
+]
+
+OriginationChannelParam = Annotated[
+    str | None,
+    Query(alias="origination_channel", max_length=64, description="Optional origination-channel filter."),
+]
+
+MinEquityPctLabelParam = Annotated[
+    str | None,
+    Query(
+        alias="min_equity_pct_label",
+        max_length=32,
+        description="Optional Portfolio Builder display equity threshold.",
+    ),
+]
+
+MinEquityPctParam = Annotated[
+    float | None,
+    Query(
+        alias="min_equity_pct",
+        ge=0,
+        le=100,
+        description="Optional numeric Portfolio Builder equity threshold.",
+    ),
+]
+
+OwnerLinkParam = Annotated[
+    str | None,
+    Query(
+        alias="owner_link",
+        max_length=64,
+        description="Optional owner-link bucket from Segment Intelligence.",
+    ),
+]
+
+PurchaseIntentParam = Annotated[
+    str | None,
+    Query(
+        alias="purchase_intent",
+        max_length=64,
+        description="Optional purchase-intent bucket from Segment Intelligence.",
+    ),
+]
+
+MarketingEligibilityParam = Annotated[
+    str,
+    Query(
+        alias="marketing_eligibility",
+        max_length=32,
+        description="Contactability gate. Defaults to Eligible only for fail-closed campaign/export use.",
+    ),
+]
+
+ConsentStatusParam = Annotated[
+    str | None,
+    Query(
+        alias="consent_status",
+        max_length=32,
+        description="Optional consent filter: Opt-in, Opt-out, Unknown, Any.",
+    ),
+]
+
+RecencyParam = Annotated[
+    str | None,
+    Query(
+        alias="recency",
+        max_length=32,
+        description="Optional touch-recency filter: Untouched 30d/60d/90d or Any.",
+    ),
+]
+
+IncludeSuppressedForAnalyticsParam = Annotated[
+    bool,
+    Query(
+        alias="include_suppressed_for_analytics",
+        description=(
+            "Admin-only analytics override. When true, clears the default "
+            "Eligible only marketing gate so suppressed/non-opt-in rows can "
+            "be counted or inspected without making them campaign-actionable."
+        ),
+    ),
+]
+
+IncludeIdentityProofParam = Annotated[
+    bool,
+    Query(
+        alias="include_identity_proof",
+        description=(
+            "Admin/evaluation-only complete-cohort digest and snapshot headers. "
+            "Disabled by default because it performs an aggregate proof query."
+        ),
+    ),
+]
+
+ApprovalStatusParam = Annotated[
+    Literal["pending", "approved", "rejected", "hold", "any"],
+    Query(alias="approval_status", description="Sales workflow approval state filter."),
+]
+
+OutreachStatusParam = Annotated[
+    Literal["none", "queued", "actioned", "sent", "bounced", "replied", "any"],
+    Query(alias="outreach_status", description="Sales workflow outreach state filter."),
+]
+
+AssignedToParam = Annotated[
+    str | None,
+    Query(alias="assigned_to", max_length=256, description="Internal LO email assigned to the lead."),
+]
+
+AgedDaysParam = Annotated[
+    int | None,
+    Query(alias="aged_days", ge=1, le=90, description="Only approved leads aged at least this many days with no outreach."),
+]
+
+CohortIdParam = Annotated[
+    str | None,
+    Query(
+        alias="cohort_id",
+        max_length=64,
+        description="Optional Lakebase persisted cohort id produced by a governed Genie action.",
+    ),
+]
+
+FunnelStageParam = Annotated[
+    Literal[
+        "addressable",
+        "in_the_money",
+        "high_opportunity",
+        "offer_recommended",
+        "approved",
+        "actioned",
+    ] | None,
+    Query(
+        alias="funnel_stage",
+        description=(
+            "Exact native-analytics Lead Funnel drilldown. When present, "
+            "the repository applies the same gold.borrower_360 predicate "
+            "used by the funnel snapshot so X-Total-Matching equals the "
+            "clicked stage count."
+        ),
+    ),
+]
+
+LimitParam = Annotated[
+    int,
+    Query(
+        ge=1,
+        le=MAX_LEAD_LIMIT,
+        description=(
+            "Maximum leads to return. Defaults to 500; max 5000. When the "
+            "resultset hits this cap the response sets `X-Truncated-At` "
+            "so the UI can render 'Showing N — refine filters'."
+        ),
+    ),
+]

--- a/backend/services/lead_cohort_replay.py
+++ b/backend/services/lead_cohort_replay.py
@@ -1,0 +1,176 @@
+"""Replay a governed Genie cohort as Lead Queue filters.
+
+When a Genie answer produces a cohort, the confirmed filters are
+persisted to ``mip_app.genie_cohorts`` and the user is handed a
+``cohort_id``. The Lead Queue then replays *that* row rather than the
+URL: query params are useful for shareable links and visual chips, but
+they must not widen a confirmed cohort if the URL is edited by hand.
+
+Two things leave this module together on purpose:
+
+* the replayable filters, which are what the queue actually queries; and
+* the count the Genie answer stated, which is what the user just read on
+  screen. The queue replays only the reviewed geography/segment subset,
+  so an answer narrowed by any numeric threshold replays broader --
+  measured live 2026-08-10 at 55x (32 borrowers -> 1,766). Carrying the
+  stated count here is what lets the response say so instead of quietly
+  showing a different population under the same question.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import HTTPException
+
+from backend.schemas.portfolio import PortfolioCriteria
+from backend.services.lakebase import LakebaseError, get_lakebase_client
+from backend.services.lead_query_helpers import (
+    cohort_list,
+    cohort_segment_mode,
+    parse_segment_codes,
+)
+
+_COHORT_FILTER_SELECT_SQL = """
+SELECT route_filters, row_count
+FROM mip_app.genie_cohorts
+WHERE cohort_id = %(cohort_id)s
+  AND actor_email = %(actor_email)s
+LIMIT 1
+"""
+
+
+@dataclass(frozen=True)
+class CohortReplay:
+    """The persisted cohort, normalized into Lead Queue filter values."""
+
+    filters: dict[str, object]
+    stated_count: int | None
+    segment_mode: str
+    state_codes: list[str] | None
+    zip_codes: list[str] | None
+    county_fipses: list[str] | None
+    borrower_ids: list[str] | None
+    segment_codes: list[str] | None
+    county_fips: str | None
+    target_lender_ref: str | None
+    unreplayable_filters: list[str]
+
+
+def load_cohort_filters(cohort_id: str, *, actor: str) -> tuple[dict[str, object], int | None]:
+    """Return the replayable filters and the count the Genie answer stated."""
+
+    try:
+        row = get_lakebase_client().fetchone(
+            _COHORT_FILTER_SELECT_SQL,
+            {"cohort_id": cohort_id, "actor_email": actor},
+        )
+    except LakebaseError as exc:
+        raise HTTPException(status_code=503, detail="Lakebase temporarily unavailable") from exc
+    if row is None:
+        raise HTTPException(status_code=404, detail="cohort not found")
+    filters_raw = row.get("route_filters") or {}
+    if isinstance(filters_raw, str):
+        try:
+            filters_raw = json.loads(filters_raw)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=422, detail="cohort route filters are invalid") from exc
+    if not isinstance(filters_raw, dict):
+        raise HTTPException(status_code=422, detail="cohort route filters are invalid")
+    stated_raw = row.get("row_count")
+    stated_count: int | None
+    try:
+        stated_count = int(stated_raw) if stated_raw is not None else None
+    except (TypeError, ValueError):
+        stated_count = None
+    return filters_raw, stated_count
+
+
+def resolve_cohort_replay(cohort_id: str, *, actor: str) -> CohortReplay:
+    """Load the persisted cohort and normalize every filter it can replay.
+
+    Raises 404 when the cohort is not the actor's, and 422 when any
+    persisted filter fails the same validation the URL path applies --
+    a stored cohort gets no more trust than a hand-typed one.
+    """
+
+    filters, stated_count = load_cohort_filters(cohort_id, actor=actor)
+
+    # Validation order is load-bearing: a cohort with more than one bad
+    # filter must report the same 422 detail the inline router did.
+    segment_mode = cohort_segment_mode(filters)
+    state_codes = cohort_list(filters, "states", width=2)
+    zip_codes = cohort_list(filters, "zips", width=5, numeric=True)
+    county_fipses = cohort_list(filters, "counties", width=5, numeric=True)
+    borrower_ids = cohort_list(filters, "borrower_ids", borrower_ids=True)
+
+    county_fips: str | None = None
+    cohort_county = str(filters.get("county") or "").strip()
+    if cohort_county:
+        if not cohort_county.isdigit() or len(cohort_county) != 5:
+            raise HTTPException(status_code=422, detail="cohort county filter is invalid")
+        county_fips = cohort_county
+
+    segment_codes: list[str] | None = None
+    cohort_segments = cohort_list(filters, "segment_codes")
+    if cohort_segments is not None:
+        segment_codes = parse_segment_codes(",".join(cohort_segments))
+
+    unreplayable: list[str] = []
+    unreplayable_raw = filters.get("unreplayable_filters")
+    if isinstance(unreplayable_raw, list):
+        unreplayable = [str(key) for key in unreplayable_raw if str(key).strip()]
+
+    return CohortReplay(
+        filters=filters,
+        stated_count=stated_count,
+        segment_mode=segment_mode,
+        state_codes=state_codes,
+        zip_codes=zip_codes,
+        county_fipses=county_fipses,
+        borrower_ids=borrower_ids,
+        segment_codes=segment_codes,
+        county_fips=county_fips,
+        target_lender_ref=str(filters.get("target_lender_ref") or "").strip() or None,
+        unreplayable_filters=unreplayable,
+    )
+
+
+def cohort_portfolio_criteria(
+    filters: dict[str, object],
+    *,
+    has_replay_filter: bool,
+) -> tuple[PortfolioCriteria, bool]:
+    """Return the cohort's portfolio criteria and whether anything is replayable.
+
+    The persisted criteria are re-validated and then re-gated: the
+    contactability filter is forced back to ``Eligible only`` and any
+    stored consent override is dropped, so a cohort can never replay into
+    a wider marketing population than the queue's own fail-closed default.
+    """
+
+    portfolio_raw = filters.get("portfolio_criteria")
+    if isinstance(portfolio_raw, dict):
+        fields: dict[str, Any] = dict(portfolio_raw)
+        try:
+            original_criteria = PortfolioCriteria(**fields)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail="cohort portfolio criteria are invalid",
+            ) from exc
+        if not original_criteria.has_effective_predicate(count_default_marketing=False):
+            raise HTTPException(
+                status_code=422,
+                detail="cohort portfolio criteria are invalid",
+            )
+        fields["marketing_eligibility"] = "Eligible only"
+        fields.pop("consent_status", None)
+        return PortfolioCriteria(**fields), True
+    if portfolio_raw is not None:
+        raise HTTPException(
+            status_code=422,
+            detail="cohort portfolio criteria are invalid",
+        )
+    return PortfolioCriteria(marketing_eligibility="Eligible only"), has_replay_filter

--- a/tests/unit/test_genie_cohort_lead_queue.py
+++ b/tests/unit/test_genie_cohort_lead_queue.py
@@ -4,7 +4,7 @@ import json
 
 from fastapi.testclient import TestClient
 
-import backend.api.leads as leads_api
+import backend.services.lead_cohort_replay as cohort_replay
 from backend.main import app
 from backend.services.repositories import get_lead_repository
 
@@ -66,7 +66,7 @@ def test_lead_queue_replays_lakebase_cohort_filters_and_ignores_widening_url(
     repo = _CaptureLeadRepo()
     prior = app.dependency_overrides.get(get_lead_repository)
     app.dependency_overrides[get_lead_repository] = lambda: repo
-    monkeypatch.setattr(leads_api, "get_lakebase_client", lambda: _CohortLakebase())
+    monkeypatch.setattr(cohort_replay, "get_lakebase_client", lambda: _CohortLakebase())
     try:
         response = TestClient(app).get(
             "/api/leads?cohort_id=11111111-1111-1111-1111-111111111111"
@@ -102,7 +102,7 @@ def test_lead_queue_cohort_without_target_ignores_url_target_lender(
     repo = _CaptureLeadRepo()
     prior = app.dependency_overrides.get(get_lead_repository)
     app.dependency_overrides[get_lead_repository] = lambda: repo
-    monkeypatch.setattr(leads_api, "get_lakebase_client", lambda: _CohortLakebaseNoTarget())
+    monkeypatch.setattr(cohort_replay, "get_lakebase_client", lambda: _CohortLakebaseNoTarget())
     try:
         response = TestClient(app).get(
             "/api/leads?cohort_id=22222222-2222-2222-2222-222222222222"
@@ -162,7 +162,7 @@ def test_lead_queue_cohort_rejects_invalid_lakebase_route_filters(
         prior = app.dependency_overrides.get(get_lead_repository)
         app.dependency_overrides[get_lead_repository] = lambda repo=repo: repo
         monkeypatch.setattr(
-            leads_api,
+            cohort_replay,
             "get_lakebase_client",
             lambda route_filters=route_filters: _MalformedCohortLakebase(route_filters),
         )


### PR DESCRIPTION
`backend/api/leads.py` was **855 lines against a 900-line CI fail threshold** — 8 lines of headroom on a route that changes often, and no allowlist entry. The project rule is split, never allowlist.

## Two seams, both pure moves

**`backend/schemas/lead_query.py`** — the 35 `Query()` parameter declarations that made up ~290 lines of the endpoint signature, each re-exported as an `Annotated` alias. The endpoint signature drops from ~300 lines to 35 names.

**`backend/services/lead_cohort_replay.py`** — the `mip_app.genie_cohorts` read plus the ~90-line block that normalizes a persisted Genie cohort into queue filters, returning a `CohortReplay` dataclass. Filter validation order is preserved deliberately (and commented): a cohort with more than one bad filter must still report the same 422 detail.

The router keeps its shape — validate → resolve → call repo → headers → audit.

## Why the OpenAPI surface is safe

FastAPI resolves an aliased `Annotated` identically to an inline one. The full `app.openapi()` output hashes **byte-identical** before and after:

```
before: ad6845378845b7b734f384202c1d0469ae9ad222697bea847b9e7fedf46f775e
after:  ad6845378845b7b734f384202c1d0469ae9ad222697bea847b9e7fedf46f775e
```

That is a stronger check than the `openapi_baseline.json` fixture alone — it covers every route, not just `/api/leads`. All 35 query parameters and all 11 response headers are untouched.

## Constraints honored

- `test_routers_do_not_import_other_routers` forbids `backend.api.*` → `backend.api.*` imports, so neither new module could live under `backend/api/`.
- `DEFAULT_LEAD_LIMIT` / `MAX_LEAD_LIMIT` move next to the `Query()` bounds they feed and are re-exported via `__all__`, so `backend.services.lead_warm` and the tests importing them from `backend.api.leads` still resolve.
- Neither new module is on the mypy exemption list, so both are type-checked — the ratchet only shrinks.
- `tests/unit/test_genie_cohort_lead_queue.py` monkeypatched `leads_api.get_lakebase_client`; retargeted to the module the call now lives in.

## Validation

| Gate | Result |
|---|---|
| `pytest tests/unit -k "lead or cohort or genie"` | 1047 passed, 0 failed |
| `test_architecture_boundaries` / `test_openapi_contract` / `test_typecheck_ratchet` / `test_documentation_contract` | pass |
| `ruff check backend tests tools` | clean |
| `mypy backend` | no issues in 246 files |
| `tools/check_file_sizes.py` | exit 0 |

`leads.py`: **855 → 550 lines** (WARN only; 350 lines of headroom under the fail gate). New modules are 352 and 176 lines, both under the 500-line warn threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)