### PR TITLE
fix(genie): read the cohort's segments from the answer's SQL, never its wording

### DIFF
--- a/backend/schemas/campaign_json_projection.py
+++ b/backend/schemas/campaign_json_projection.py
@@ -26,6 +26,7 @@ from backend.schemas.genie_numeric_filters import (
     GENIE_NUMERIC_FILTER_KEYS,
     is_reviewed_numeric_floor,
 )
+from backend.schemas.lead import GENIE_REPLAY_SEGMENT_CODES
 from backend.schemas.portfolio_campaign import (
     assert_public_campaign_text,
 )
@@ -96,7 +97,7 @@ _GENIE_REPLAY_FILTER_KEYS = frozenset(
         "unreplayable_filters",
     }
 )
-_GENIE_SEGMENT_CODES = frozenset({"itm", "listed", "permit", "investor", "equity", "retention"})
+_GENIE_SEGMENT_CODES = GENIE_REPLAY_SEGMENT_CODES
 _GENIE_VISUALIZATION_KINDS = frozenset({"bar", "line", "metric", "pie", "scatter", "table"})
 _GENIE_OPAQUE_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
 _PUBLIC_CAMPAIGN_NAME_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9 &(),./:+\-\u2014]{0,79}")

--- a/backend/schemas/lead.py
+++ b/backend/schemas/lead.py
@@ -34,6 +34,18 @@ SegmentCode = Literal[
 # Canonical runtime vocabulary derived from the Literal so API allowlists,
 # audit validation, and repositories share exactly one registry.
 SEGMENT_CODE_VALUES: tuple[str, ...] = get_args(SegmentCode)
+# The subset a GENIE ANSWER may hand to a governed action. The Lead Queue can
+# filter on all of SEGMENT_CODE_VALUES, but a cohort a Genie answer opens also
+# becomes a Lakebase cohort row, draft-campaign criteria and an approval
+# record, and only these six are reviewed for that. Three readers enforced it
+# with three private copies -- the Genie cohort writer's regex, the campaign
+# JSON projection's frozenset, and the answer's own segment reader -- so a
+# code the reader emitted could be rejected two layers later, which is exactly
+# how the S1.3 overlay codes came to 400 every governed action on an answer
+# that filtered on one (adversarial review 2026-08-11). One definition now.
+GENIE_REPLAY_SEGMENT_CODES: frozenset[str] = frozenset(
+    {"itm", "listed", "permit", "investor", "equity", "retention"}
+)
 # S1.3 three-state source gating for segments whose driving source can be
 # disconnected or unlicensed: connected / not_connected / not_licensed.
 # Derived from gold.source_readiness; the full entitlement matrix ships in

--- a/backend/services/genie_actions.py
+++ b/backend/services/genie_actions.py
@@ -25,6 +25,7 @@ from backend.config.settings import settings
 from backend.schemas._validators_tenant import normalize_public_lender_ref
 from backend.schemas.common import validate_public_borrower_id
 from backend.schemas.genie_numeric_filters import GENIE_NUMERIC_FILTER_BOUNDS
+from backend.schemas.lead import GENIE_REPLAY_SEGMENT_CODES
 from backend.schemas.portfolio import PortfolioCriteria
 from backend.services.audit_store import (
     _assert_allowlisted,
@@ -96,6 +97,10 @@ _REPLAYABLE_FILTER_KEYS = frozenset(
         "source",
         *_REPLAYABLE_NUMERIC_FILTERS,
     }
+)
+# Built from the one canonical replay vocabulary, not spelled out again.
+_GENIE_SEGMENT_CODE_RE = re.compile(
+    r"^(" + "|".join(sorted(GENIE_REPLAY_SEGMENT_CODES)) + r")$", re.IGNORECASE
 )
 _MAX_UNREPLAYABLE_FILTER_KEYS = 12
 _MAX_UNREPLAYABLE_FILTER_KEY_LEN = 64
@@ -1066,7 +1071,7 @@ def _cohort_route_filters(
         filters.get("segment_codes"),
         field="segment_codes",
         max_items=6,
-        pattern=re.compile(r"^(itm|listed|permit|investor|equity|retention)$", re.IGNORECASE),
+        pattern=_GENIE_SEGMENT_CODE_RE,
     )
     if segment_codes:
         out["segment_codes"] = [s.lower() for s in segment_codes]

--- a/backend/services/genie_sql_predicates.py
+++ b/backend/services/genie_sql_predicates.py
@@ -154,6 +154,12 @@ _PLAIN_LITERAL_RE = re.compile(r"[A-Za-z0-9_]*")
 
 _MAX_SQL_CHARS = 200_000
 
+# Words that are BOTH a clause keyword and a scalar builtin. Only these get the
+# "followed by `(` means function call" treatment -- `WHERE (`, `ON (` and
+# `QUALIFY (` are all ordinary parenthesised predicates, so a blanket rule
+# would stop opening filter regions at all.
+_CLAUSE_WORDS_THAT_ARE_ALSO_FUNCTIONS = frozenset({"left", "right"})
+
 
 @dataclass(frozen=True)
 class SqlFilterReading:
@@ -169,6 +175,33 @@ class SqlFilterReading:
     floors: dict[str, int]
     unreplayable: tuple[str, ...] = ()
     predicates: tuple[str, ...] = ()
+    unread_predicates: tuple[str, ...] = ()
+    """Normalized text of every filter-region conjunct this reader refused.
+
+    READ THE WHOLE SPAN OR NOTHING. These are the shapes the floor reader will
+    not reason about -- ORs, negations, bounds over a re-aggregating CTE -- so
+    a consumer may only accept one by proving the ENTIRE span reduces to a
+    predicate it can replay exactly, the way
+    ``_segment_selection_from_sql`` proves a span is nothing but a disjunction
+    of segment membership tests. Lifting a value out of a span whose remainder
+    you have not accounted for is the truncation bug this module exists to
+    prevent: in ``a OR b`` the ``a`` alone is narrower than the answer, and in
+    ``NOT a`` it is the complement.
+    """
+    unread_filter_words: frozenset[str] = frozenset()
+    """Word tokens of every filter-region conjunct this reader refused.
+
+    A refused conjunct -- an OR, a negation, a bound over a re-aggregating CTE
+    -- is simply not replayed, so the queue opens a cohort BROADER than the
+    answer's. This field exists so a caller can name that on the way past
+    instead of diverging in silence.
+
+    It carries word tokens only. String literals and numbers tokenize as their
+    own kinds and never appear here, so this can answer "was this column
+    filtered in a shape you could not read?" and structurally cannot answer
+    "what value did it filter on?" -- the narrowing question that every
+    deleted text-matching reader got wrong.
+    """
 
 
 _EMPTY_READING = SqlFilterReading(floors={})
@@ -211,6 +244,22 @@ def _filter_regions(tokens: list[Token]) -> tuple[tuple[Token, ...], ...] | None
         if depth != 0 or token.kind != "word":
             continue
         word = token.text
+        if word in _CLAUSE_WORDS_THAT_ARE_ALSO_FUNCTIONS and (
+            index + 1 < len(tokens)
+            and tokens[index + 1].kind == "punct"
+            and tokens[index + 1].text == "("
+        ):
+            # `LEFT(` / `RIGHT(` is a string builtin, not a join keyword. Both
+            # words live in CLAUSE_WORDS for LEFT/RIGHT JOIN, so a call closed
+            # the region mid-predicate: `WHERE array_contains(segment_codes,
+            # 'itm') OR LEFT(zip,3)='606'` handed the caller the fragment
+            # `array_contains(segment_codes,'itm') or`, which reads as a pure
+            # membership test. The queue replayed `itm` alone against an answer
+            # asking for `itm OR zip-prefix` -- a strict subset disclosed to
+            # nobody (adversarial review 2026-08-11). A join keyword is never
+            # followed by `(`, and this runs before the join bookkeeping so a
+            # call cannot mark a later JOIN as non-filtering either.
+            continue
         if word in SET_OPERATOR_WORDS:
             return None
         if word in NON_FILTERING_JOIN_WORDS:
@@ -265,11 +314,30 @@ def _split_conjunction(
     return parts
 
 
-def _conjuncts(tokens: tuple[Token, ...]) -> list[tuple[Token, ...]]:
-    """Leaf predicates that must ALL hold for a row to survive."""
+def _conjuncts(
+    tokens: tuple[Token, ...],
+    dropped: list[tuple[Token, ...]] | None = None,
+    disjunctions: list[tuple[Token, ...]] | None = None,
+) -> list[tuple[Token, ...]]:
+    """Leaf predicates that must ALL hold for a row to survive.
+
+    Spans this refuses are appended to ``dropped`` when a caller passes one.
+    Dropping is always the BROADENING direction — the queue replays fewer
+    filters than the answer applied — but a caller that wants to say so out
+    loud needs to know a filter was there at all.
+
+    ``disjunctions`` collects the subset a caller may legitimately try to
+    re-read: whole spans refused ONLY because they are a top-level OR. A
+    NEGATED span is deliberately not among them -- its population is the
+    complement, so any part of it read as membership is inverted.
+    """
 
     parts = _split_conjunction(tokens)
     if parts is None:
+        if dropped is not None:
+            dropped.append(tokens)
+        if disjunctions is not None:
+            disjunctions.append(tokens)
         return []
     leaves: list[tuple[Token, ...]] = []
     for part in parts:
@@ -278,13 +346,15 @@ def _conjuncts(tokens: tuple[Token, ...]) -> list[tuple[Token, ...]]:
         if part[0].kind == "word" and part[0].text == "not":
             # Negated: the surviving population is the complement, which no
             # cohort floor can express. Drop it rather than invert it.
+            if dropped is not None:
+                dropped.append(part)
             continue
         if (
             part[0].kind == "punct"
             and part[0].text == "("
             and matching_paren(part, 0) == len(part) - 1
         ):
-            leaves.extend(_conjuncts(part[1:-1]))
+            leaves.extend(_conjuncts(part[1:-1], dropped, disjunctions))
             continue
         leaves.append(part)
     return leaves
@@ -445,15 +515,41 @@ def read_sql_filters(sql_query: str | None) -> SqlFilterReading:
         return _EMPTY_READING
 
     leaves: list[tuple[Token, ...]] = []
+    dropped: list[tuple[Token, ...]] = []
+    disjunctions: list[tuple[Token, ...]] = []
     for region in regions:
-        leaves.extend(_conjuncts(region))
-    if not leaves:
-        return _EMPTY_READING
+        leaves.extend(_conjuncts(region, dropped, disjunctions))
 
     # A conjunct only means what it says when the outermost FROM still binds
     # its names to the base columns: an outer bound over a re-aggregating CTE
     # filters GROUPS, and replaying it per borrower silently truncates.
     rebound = rebound_columns(tokens)
+    # Only a whole span refused for SHAPE, at base grain, may be re-read.
+    # Publishing every refused span let a caller re-admit exactly what the
+    # grain gate had just thrown out: `WITH pool AS (SELECT (in_the_money OR
+    # listed_for_sale) AS in_the_money ...) SELECT ... WHERE in_the_money`
+    # was replayed as the `itm` segment alone (adversarial review
+    # 2026-08-11). The floor reader discloses that refusal; re-reading it
+    # silently is strictly worse than never publishing it.
+    readable = [span for span in disjunctions if is_base_grain(span, rebound)]
+    readable_texts = tuple(_leaf_text(sql_query, span) for span in readable)
+    accounted = {id(span) for span in readable}
+
+    def _unread_words() -> frozenset[str]:
+        return frozenset(
+            token.text
+            for span in dropped
+            if id(span) not in accounted
+            for token in span
+            if token.kind == "word"
+        )
+
+    if not leaves:
+        return SqlFilterReading(
+            floors={},
+            unread_predicates=readable_texts,
+            unread_filter_words=_unread_words(),
+        )
     bounds: dict[str, set[int | None]] = {}
     unreplayable: list[str] = []
     accepted: list[tuple[Token, ...]] = []
@@ -462,6 +558,7 @@ def read_sql_filters(sql_query: str | None) -> SqlFilterReading:
         if not is_base_grain(leaf, rebound):
             if bound is not None:
                 unreplayable.append(_disclosure_name(bound[0]))
+            dropped.append(leaf)
             continue
         accepted.append(leaf)
         if bound is None:
@@ -486,4 +583,6 @@ def read_sql_filters(sql_query: str | None) -> SqlFilterReading:
         floors=floors,
         unreplayable=tuple(sorted(set(unreplayable))),
         predicates=tuple(_leaf_text(sql_query, leaf) for leaf in accepted),
+        unread_predicates=readable_texts,
+        unread_filter_words=_unread_words(),
     )

--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -24,7 +24,6 @@ from backend.services.repositories.databricks_genie_actions import (
     _portfolio_criteria_from_sql,  # noqa: F401 - compatibility re-export
     _route_from_answer_rows,  # noqa: F401 - compatibility re-export
     _row_values,  # noqa: F401 - compatibility re-export
-    _segment_codes_from_question,  # noqa: F401 - compatibility re-export
     _sql_hash,  # noqa: F401 - compatibility re-export
     _suggest_genie_actions,
     _total_matching_from_rows,

--- a/backend/services/repositories/databricks_genie_actions.py
+++ b/backend/services/repositories/databricks_genie_actions.py
@@ -13,6 +13,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 from backend.schemas.common import validate_public_borrower_id
+from backend.schemas.lead import GENIE_REPLAY_SEGMENT_CODES
 from backend.services.genie_answers import GenieActionSuggestion, GenieVisualizationSpec
 from backend.services.genie_sql_predicates import SqlFilterReading, read_sql_filters
 
@@ -49,6 +50,60 @@ _PRODUCT_LABEL_CODES: dict[str, frozenset[str]] = {
     "Purchase": frozenset({"purchase"}),
     "Retention": frozenset({"retention"}),
 }
+
+# `array_contains(segment_codes, 'itm')`, with or without a table alias. The
+# code is anchored on its own quotes so a match cannot run past its literal.
+_SEGMENT_CONTAINS_RE = re.compile(
+    r"array_contains\(\s*(?:\w+\.)?segment_codes\s*,\s*['\"]([a-z0-9_]+)['\"]\s*\)"
+)
+# Gold boolean column -> the segment it EXACTLY defines. `segment_codes` is
+# built by a CASE ladder in sql/transformations/gold_borrower_360.sql
+# (`with_segments`), and for these entries the arm is nothing but this one
+# column, so `WHERE <column>` and `array_contains(segment_codes,'<code>')`
+# select the identical population. Genie writes the flag at least as often as
+# the array -- borrower_360 exposes both and the flag is shorter -- and
+# without this map "how many borrowers are in the money?" answered over
+# `WHERE in_the_money` produced NO replayable filter and therefore no cohort
+# action at all.
+#
+# Only arms that are ONE BARE COLUMN belong here. `permit`, `equity`,
+# `retention` and `refi_propensity` are compound (an OR across two columns, a
+# two-sided comparison, a threshold), so no single column stands in for them:
+# filtering on one part of a compound arm is not the segment, and replaying it
+# as the segment would open a population the answer never described. Those
+# columns already reach the queue as reviewed portfolio criteria instead.
+# `itm_on_related_property` is left out for the same reason even though it is
+# exact today -- its arm is a COALESCE, and admitting a wrapper here is how a
+# pin stops being a pin.
+# ``test_segment_flag_columns_match_the_gold_case_ladder`` parses the SQL and
+# fails if an arm here stops being one bare column, or if a compound arm
+# becomes one and is missing.
+_SEGMENT_FLAG_COLUMNS: dict[str, str] = {
+    "in_the_money": "itm",
+    "listed_for_sale": "listed",
+    "is_investor": "investor",
+    "second_lien_itm": "second_lien_itm",
+    "has_heloc_draw_ending": "heloc_draw_to_payback",
+    "has_home_equity_history": "home_equity_history",
+    "is_payoff_loss": "payoff_loss_leads",
+    "has_permit": "permit_activity",
+}
+# `flag`, `flag = TRUE`, `t.flag = 1`. The `= FALSE` form deliberately does NOT
+# match: the optional tail is left in the residue, the span fails the purity
+# check, and the complement is disclosed instead of inverted into membership.
+_SEGMENT_FLAG_TERM_RE = re.compile(
+    r"(?:\w+\.)?(" + "|".join(sorted(_SEGMENT_FLAG_COLUMNS, key=len, reverse=True)) + r")\b"
+    r"(?:\s*=\s*(?:true|1)\b)?"
+)
+# Any mention of a segment-defining name at all. Separates "this conjunct
+# filters segments in a shape we could not read" from "this conjunct is about
+# something else".
+_SEGMENT_COLUMN_RE = re.compile(
+    r"\b(?:segment_codes?|" + "|".join(_SEGMENT_FLAG_COLUMNS) + r")\b"
+)
+# Disclosure name for the former. Identifier-shaped and bounded, like the
+# threshold disclosures it rides alongside in `unreplayable_filters`.
+_SEGMENT_PREDICATE_DISCLOSURE = "segment_codes_predicate"
 
 # `recommended_offer_code = 'x'` or `recommended_offer_code IN ('x', 'y')`.
 # The alternation is anchored on the quotes so the list branch cannot run past
@@ -149,31 +204,99 @@ def _row_values(
     return values
 
 
-def _segment_codes_from_question(question: str) -> list[str]:
-    q = question.lower()
-    codes: list[str] = []
-    if re.search(r"\b(in[-\s]?the[-\s]?money|itm|refi|refinance)\b", q):
-        codes.append("itm")
-    if re.search(r"\b(heloc|equity[-\s]line|equity-credit)\b", q):
-        codes.append("permit")
-    elif "home equity" in q:
-        codes.append("equity")
-    if "investor" in q or "multi-property" in q or "multi property" in q:
-        codes.append("investor")
-    if (
-        "retention" in q
-        or "competitor lien" in q
-        or "current customer" in q
-        or "recapture" in q
-        or "at risk" in q
-        or "going to a competitor" in q
-    ):
-        codes.append("retention")
-    if "listed" in q or "for sale" in q or "purchase" in q:
-        codes.append("listed")
-    if "permit" in q:
-        codes.append("permit")
-    return list(dict.fromkeys(codes))
+def _segment_selection_from_sql(
+    reading: SqlFilterReading,
+) -> tuple[list[str], str, bool]:
+    """Read the segments the ANSWER filtered on out of its own conjuncts.
+
+    Returns ``(codes, mode, unreadable)``.
+
+    This replaces a reader that inferred segments from the QUESTION'S WORDING
+    (deleted 2026-08-11), the last of that family. It failed the same way its
+    siblings did — prose has no position to gate on, so a segment the answer
+    merely *mentioned* was indistinguishable from one it *filtered on*, and the
+    mismatch always narrowed. Live: "Which segment converts best: HELOC,
+    cash-out, or retention?" is answered over all 5,156,184 borrowers (segment
+    is a GROUP BY, not a filter) while the queue opened 468,703 — a comparison
+    read as a cohort. The wording reader also mapped "refi" to ``itm`` and
+    "purchase" to ``listed``, so questions that never named a segment at all
+    still narrowed.
+
+    Segments are read the way the numeric floors are: only from the accepted
+    top-level AND-conjuncts of the outermost statement. A conjunct counts when
+    it is a pure disjunction of ``array_contains(segment_codes, '<code>')``
+    tests, which is exactly the shape the Lead Queue's ``segment_mode="any"``
+    compiles back to. Anything else that names the column — a mixed
+    ``OR`` across two columns, a negation, an equality on the array itself, an
+    unreviewed code — is reported as unreadable rather than guessed at, because
+    every possible guess is a narrowing one. ``(a OR b) AND c`` is a
+    conjunction of disjunctions that the queue's single any/all switch cannot
+    express, so it is unreadable too.
+
+    Reading nothing is safe in a way that reading wrong is not: the queue then
+    opens the population the answer actually described. An answer with no
+    replayable filter at all simply offers no cohort action.
+    """
+
+    # A segment name the reader refused for a reason no re-read can recover --
+    # a negation, a bound over a re-aggregating CTE, a span it could not prove
+    # complete. `unread_predicates` deliberately excludes these.
+    unreadable = bool(_SEGMENT_COLUMN_RE.search(" ".join(reading.unread_filter_words)))
+    disjunctions: list[list[str]] = []
+    # Accepted conjuncts, then the ones the floor reader refused. A refused
+    # span is where a real segment filter usually lives -- "itm OR equity" is
+    # one conjunct, and the splitter will not break an OR apart -- so skipping
+    # them would open every segment for a question that named two. Each span
+    # is accepted ONLY if the WHOLE of it reduces to segment membership tests
+    # joined by OR, which is exactly what ``segment_mode="any"`` replays. A
+    # span that mentions the column in any other shape is disclosed, never
+    # partially read: half of an OR is narrower than the answer, and a
+    # negation is its complement.
+    for predicate in (*reading.predicates, *reading.unread_predicates):
+        if not _SEGMENT_COLUMN_RE.search(predicate):
+            continue
+        codes = list(
+            dict.fromkeys(
+                [
+                    *_SEGMENT_CONTAINS_RE.findall(predicate),
+                    *(
+                        _SEGMENT_FLAG_COLUMNS[flag]
+                        for flag in _SEGMENT_FLAG_TERM_RE.findall(predicate)
+                    ),
+                ]
+            )
+        )
+        residue = _SEGMENT_FLAG_TERM_RE.sub(
+            " ", _SEGMENT_CONTAINS_RE.sub(" ", predicate)
+        )
+        residue = residue.replace("(", " ").replace(")", " ")
+        leftover = residue.split()
+        # Every OR must sit BETWEEN two membership tests. Counting matches
+        # rather than deduped codes matters: `array_contains(...,'itm') OR
+        # in_the_money` is two tests for one code. A span with a dangling `or`
+        # is a fragment of a longer disjunction whose other branches were cut
+        # off, and reading it would replay a strict subset of the answer.
+        matches = len(_SEGMENT_CONTAINS_RE.findall(predicate)) + len(
+            _SEGMENT_FLAG_TERM_RE.findall(predicate)
+        )
+        if (
+            not codes
+            or any(token != "or" for token in leftover)
+            or len(leftover) != matches - 1
+            or any(code not in GENIE_REPLAY_SEGMENT_CODES for code in codes)
+        ):
+            unreadable = True
+            continue
+        disjunctions.append(codes)
+
+    if not disjunctions:
+        return [], "any", unreadable
+    if len(disjunctions) == 1:
+        return disjunctions[0], "any", unreadable
+    if all(len(codes) == 1 for codes in disjunctions):
+        flattened = list(dict.fromkeys(code for codes in disjunctions for code in codes))
+        return flattened, "all", unreadable
+    return [], "any", True
 
 
 def _product_label_from_offer_codes(sql: str) -> str | None:
@@ -338,44 +461,13 @@ def _numeric_floors_from_sql(sql_query: str | None) -> dict[str, int]:
     return read_sql_filters(sql_query).floors
 
 
-def _segment_mode_from_sql(sql_query: str | None, segment_codes: list[str]) -> str:
-    """Return "all" only when every segment is a top-level AND-conjunct.
-
-    Position-gated for the same reason the numeric floors are (adversarial
-    review 2026-08-11): the previous reader regexed the WHOLE statement and
-    called it an intersection whenever the text between two
-    ``array_contains`` calls contained "and" and no "or". Two such calls in
-    different CTEs, or inside a ``COUNT_IF(...)`` breakdown, therefore yielded
-    ``mode="all"`` for an answer that used a union — and "all" is the
-    NARROWING direction, so the Lead Queue silently opened a smaller cohort
-    than the answer described.
-
-    Reading the accepted conjuncts instead makes the select list, HAVING,
-    CASE arms, aggregate filters and CTE bodies structurally unreachable.
-    """
-
-    if not sql_query or len(segment_codes) <= 1:
-        return "any"
-    predicates = read_sql_filters(sql_query).predicates
-    if not predicates:
-        return "any"
-    for code in segment_codes:
-        pattern = re.compile(
-            rf"array_contains\(\s*(?:\w+\.)?segment_codes\s*,\s*['\"]{re.escape(code)}['\"]\s*\)"
-        )
-        # Each code must stand alone as its own conjunct. A conjunct holding
-        # two codes is an OR the splitter refused to break apart.
-        if not any(pattern.search(predicate) for predicate in predicates):
-            return "any"
-    return "all"
-
-
 def _route_from_answer_rows(
     *,
     question: str,
     rows: list[dict[str, Any]] | None,
     borrower_ids: list[str],
     sql_query: str | None = None,
+    declared_segments: tuple[str, ...] = (),
 ) -> tuple[str, dict[str, Any]]:
     params: dict[str, str] = {}
     filter_criteria: dict[str, Any] = {}
@@ -388,8 +480,23 @@ def _route_from_answer_rows(
         and _actionable_total_from_rows(rows) is None
     ):
         states = states[:1]
-    segment_codes = _segment_codes_from_question(question)
     reading = read_sql_filters(sql_query)
+    # Segments come from the ANSWER'S OWN conjuncts, never from the question's
+    # wording: see ``_segment_selection_from_sql``.
+    segment_codes, segment_mode, segments_unreadable = _segment_selection_from_sql(reading)
+    if declared_segments:
+        # A canonical statement this repo AUTHORED, whose segment filter sits
+        # where the position gate cannot see it -- inside a CTE body, or in a
+        # statement whose sources the reader will not resolve. The cohort is
+        # then declared next to the SQL and reviewed with it, which is the one
+        # honest alternative to inference: we are not guessing what someone
+        # else's SQL meant, we are stating what ours does. Never reachable
+        # from a live Genie answer -- ``respond()`` has no declaration to make.
+        segment_codes = [
+            code for code in declared_segments if code in GENIE_REPLAY_SEGMENT_CODES
+        ]
+        segment_mode = "all" if len(segment_codes) > 1 else "any"
+        segments_unreadable = False
     # Portfolio criteria come from the ANSWER'S OWN SQL only. They used to be
     # merged with criteria inferred from the question's wording, which is
     # removed: see ``_portfolio_criteria_from_sql`` for why every criterion
@@ -414,7 +521,6 @@ def _route_from_answer_rows(
         filter_criteria["states"] = states
 
     if segment_codes:
-        segment_mode = _segment_mode_from_sql(sql_query, segment_codes)
         if len(segment_codes) == 1:
             params["segment"] = segment_codes[0]
         else:
@@ -445,7 +551,16 @@ def _route_from_answer_rows(
         filter_criteria[floor_key] = floor
         params[floor_key] = str(floor)
 
-    if reading.unreplayable and _REPLAYABLE_ROUTE_FILTER_KEYS & set(filter_criteria):
+    disclosures = list(reading.unreplayable)
+    if segments_unreadable:
+        # A segment predicate the queue cannot express. Named for the same
+        # reason a threshold is: the queue's count will be broader than the
+        # answer's, and a named reason beats a silent divergence. This fires
+        # even when other conjuncts DID set the cohort's segments -- in
+        # `itm AND (listed OR score >= 80)` the queue replays `itm` and is
+        # still broader on the very axis it filtered.
+        disclosures.append(_SEGMENT_PREDICATE_DISCLOSURE)
+    if disclosures and _REPLAYABLE_ROUTE_FILTER_KEYS & set(filter_criteria):
         # A threshold that really filters the answer but cannot be replayed —
         # a bound parameter whose value never reaches us, a bound outside the
         # reviewed cohort domain, or several disagreeing bounds on one column.
@@ -456,7 +571,7 @@ def _route_from_answer_rows(
         # never added to the URL, and never stand alone — a cohort with no
         # replayable filter is rejected, so a disclosure-only cohort would
         # offer an action that 400s.
-        for disclosure in reading.unreplayable:
+        for disclosure in disclosures:
             filter_criteria[disclosure] = True
 
     if params:
@@ -475,6 +590,7 @@ def _suggest_genie_actions(
     question_hash: str | None,
     sql_query: str | None,
     source: str = "genie",
+    declared_segments: tuple[str, ...] = (),
 ) -> list[GenieActionSuggestion]:
     actions: list[GenieActionSuggestion] = []
     borrower_ids = _borrower_ids_from_rows(rows)
@@ -494,6 +610,7 @@ def _suggest_genie_actions(
         rows=rows,
         borrower_ids=borrower_ids,
         sql_query=sql_query,
+        declared_segments=declared_segments,
     )
     if result_filters:
         base_criteria["result_filters"] = result_filters

--- a/backend/services/repositories/databricks_genie_direct.py
+++ b/backend/services/repositories/databricks_genie_direct.py
@@ -167,6 +167,7 @@ def _trusted_sql_response(
     metric_value: str | None = None,
     started_at: float | None = None,
     suppress_actions: bool = False,
+    cohort_segments: tuple[str, ...] = (),
 ) -> GenieMessageResponse:
     question_hash = _genie_question_hash(question)
     message_id = f"trusted-sql-{question_hash}"
@@ -191,6 +192,7 @@ def _trusted_sql_response(
         question_hash=question_hash,
         sql_query=sql_query,
         source="trusted_sql",
+        declared_segments=cohort_segments,
     )
     return GenieMessageResponse(
         conversation_id="",
@@ -1843,6 +1845,13 @@ def direct_canonical_response(
             rows=rows,
             answer=answer,
             metric_value=f"{total_matching:,}",
+            # `array_contains(b.segment_codes,'retention')` is a real
+            # conjunct, but it sits in a subquery this statement selects from
+            # rather than in the outermost statement's own filter position, so
+            # the reader sees no filters at all. Every returned row satisfies
+            # it and `borrower_ids` already pins the cohort, so declaring
+            # `retention` restates the answer instead of narrowing it.
+            cohort_segments=("retention",),
         )
 
     if _retention_risk_question(question):
@@ -1956,6 +1965,16 @@ def direct_canonical_response(
             trusted_assets=trusted_assets,
             rows=rows,
             answer=answer,
+            # The outermost statement joins two CTEs and has no WHERE,
+            # QUALIFY or inner-join ON of its own, so there is no filter
+            # position to read: `broad` restricts on `in_the_money = TRUE` and
+            # `lead_queue` on `array_contains(segment_codes,'itm')`, both
+            # inside CTE bodies the position gate never visits. Per the gold
+            # CASE ladder those two are the same population, so `itm` is exact.
+            # Declared rather than inferred: without it the queue opens every
+            # borrower in those states while the button still promises the
+            # eligible in-the-money subset.
+            cohort_segments=("itm",),
         )
 
     scope = _canonical_in_the_money_count_scope(question)

--- a/backend/services/repositories/databricks_repo.py
+++ b/backend/services/repositories/databricks_repo.py
@@ -77,7 +77,6 @@ from backend.services.repositories.databricks_genie import (  # noqa: F401
     _route_from_answer_rows,
     _row_columns,
     _row_values,
-    _segment_codes_from_question,
     _source_readiness_only_assets,
     _sql_hash,
     _sql_uses_impossible_retention_conjunction,

--- a/tests/unit/test_genie_actions_api.py
+++ b/tests/unit/test_genie_actions_api.py
@@ -44,6 +44,7 @@ from backend.services.repositories import get_genie_answer_repository
 from backend.services.repositories.databricks_genie_actions import (
     _numeric_floors_from_sql,
     _route_from_answer_rows,
+    _suggest_genie_actions,
 )
 from backend.services.scoring import HIGH_OPPORTUNITY_THRESHOLD
 from backend.services.state_footprint import (

--- a/tests/unit/test_genie_actions_api.py
+++ b/tests/unit/test_genie_actions_api.py
@@ -1872,7 +1872,6 @@ def test_heloc_genie_action_routes_to_heloc_intent_segment() -> None:
     )
 
     params = parse_qs(urlsplit(route).query)
-    assert params["segment"] == ["permit"]
     assert params["states"] == ["CA"]
     # From the SQL: `has_heloc_propensity_trigger = TRUE` is the answer's own
     # top-level conjunct.
@@ -1882,8 +1881,17 @@ def test_heloc_genie_action_routes_to_heloc_intent_segment() -> None:
     # Live paychex gold 2026-08-11: the answer covers 102,063 CA borrowers and
     # `product=HELOC` would have opened 86,454 — 15,609 dropped in silence.
     assert "product" not in params
-    assert filters["segment_codes"] == ["permit"]
-    assert filters["segment_mode"] == "any"
+    # No `segment` either, and this one is subtle: `permit` IS exactly this
+    # column's population today, because its CASE arm is
+    # `has_permit OR has_heloc_propensity_trigger` and `has_permit` is a
+    # literal FALSE until a filed-permit source lands. But the old value came
+    # from the word "HELOC" in the question, not from that reasoning -- the
+    # same question over `WHERE state = 'CA'` emitted it too. A compound arm
+    # gets no single-column stand-in (see `_SEGMENT_FLAG_COLUMNS`); the answer
+    # already reaches the queue exactly, through `purchase_intent`.
+    assert "segment" not in params
+    assert "segment_codes" not in filters
+    assert "segment_mode" not in filters
 
 
 def test_genie_action_carries_the_answers_score_floor_into_the_cohort() -> None:
@@ -2933,3 +2941,156 @@ def test_request_validation_error_never_echoes_submitted_body() -> None:
         assert "ctx" not in item, item
         assert item.get("loc"), item
         assert item.get("msg"), item
+
+
+# --- Segment predicates the queue cannot replay reach the STORED cohort ------
+#
+# These drive real SQL through `_route_from_answer_rows` into POST
+# /api/genie/actions and assert on the row Lakebase actually received. Testing
+# `_route_from_answer_rows` alone would have passed while both defects below
+# were live (adversarial review 2026-08-11):
+#   * the disclosure was appended to a local list and then never read, so an
+#     answer over `NOT in_the_money` opened all of IL with an EMPTY
+#     `X-Cohort-Unreplayable-Filters` -- the silent divergence this whole
+#     workstream exists to remove;
+#   * the segment reader validated against all 13 SegmentCode values while the
+#     cohort writer and the campaign projection accept 6, so an answer
+#     filtering on an S1.3 overlay segment 400'd all four governed actions.
+
+
+class _SqlDrivenCohortRepo:
+    """Builds its action from `SQL_UNDER_TEST` the way the live path does."""
+
+    SQL_UNDER_TEST = ""
+
+    def respond(
+        self,
+        question: str,
+        conversation_id: str | None = None,
+    ) -> GenieMessageResponse:
+        _ = question
+        rows = [{"state": "IL", "borrowers": 1503}]
+        actions = _suggest_genie_actions(
+            question="How many borrowers does that leave in Illinois?",
+            rows=rows,
+            trusted_assets=["mip.gold.borrower_360"],
+            visualization=None,
+            conversation_id=conversation_id or "conv-sql",
+            message_id="msg-sql",
+            question_hash="hash-sql",
+            sql_query=self.SQL_UNDER_TEST,
+        )
+        return GenieMessageResponse(
+            conversation_id=conversation_id or "conv-sql",
+            message_id="msg-sql",
+            question="How many borrowers does that leave in Illinois?",
+            question_hash="hash-sql",
+            answer="Illinois returned.",
+            source="genie",
+            trusted_assets=["mip.gold.borrower_360"],
+            row_count=len(rows),
+            table_rows=rows,
+            actions=actions,
+        )
+
+
+def _stored_cohort_route_filters(sql: str) -> tuple[int, dict[str, object] | None]:
+    """POST the open_cohort action built from `sql`; return (status, stored row)."""
+
+    repo = type("_Repo", (_SqlDrivenCohortRepo,), {"SQL_UNDER_TEST": sql})
+    lakebase = _RecordingLakebase()
+    prior_repo = app.dependency_overrides.get(get_genie_answer_repository)
+    prior_lakebase = app.dependency_overrides.get(get_lakebase_client)
+    app.dependency_overrides[get_genie_answer_repository] = repo
+    app.dependency_overrides[get_lakebase_client] = lambda: lakebase
+    try:
+        payload = _confirmed_payload_for_action("open_cohort")
+        res = client.post("/api/genie/actions", json=payload, headers=ACTOR_HEADERS)
+    finally:
+        if prior_repo is None:
+            app.dependency_overrides.pop(get_genie_answer_repository, None)
+        else:
+            app.dependency_overrides[get_genie_answer_repository] = prior_repo
+        if prior_lakebase is None:
+            app.dependency_overrides.pop(get_lakebase_client, None)
+        else:
+            app.dependency_overrides[get_lakebase_client] = prior_lakebase
+    stored = next(
+        (
+            json.loads(str(params["route_filters"]))
+            for sql_text, params in lakebase.fetchones
+            if "INSERT INTO mip_app.genie_cohorts" in sql_text
+        ),
+        None,
+    )
+    return res.status_code, stored
+
+
+@pytest.mark.parametrize(
+    ("sql", "why"),
+    [
+        (
+            "SELECT * FROM mip.gold.borrower_360 WHERE NOT in_the_money AND state = 'IL'",
+            "a negation is the complement, which no cohort filter can express",
+        ),
+        (
+            "SELECT * FROM mip.gold.borrower_360 WHERE "
+            "(array_contains(segment_codes,'retention') OR recommended_offer_code='retention') "
+            "AND state = 'IL'",
+            "an OR across two columns is broader than either column alone",
+        ),
+        (
+            "SELECT * FROM mip.gold.borrower_360 WHERE second_lien_itm AND state = 'IL'",
+            "an S1.3 overlay segment is outside the reviewed replay vocabulary",
+        ),
+    ],
+)
+def test_unreplayable_segment_predicate_is_disclosed_in_the_stored_cohort(
+    sql: str, why: str
+) -> None:
+    status, stored = _stored_cohort_route_filters(sql)
+
+    # The action must still succeed: the queue opens BROADER than the answer,
+    # which is a disclosure, not a refusal.
+    assert status == 200, why
+    assert stored is not None, why
+    assert stored["unreplayable_filters"] == ["segment_codes_predicate"], why
+    # ... and it must not have guessed a cohort out of the shape it refused.
+    assert "segment_codes" not in stored, why
+    assert stored["states"] == ["IL"], why
+
+
+def test_a_readable_segment_predicate_still_reaches_the_stored_cohort() -> None:
+    """The control: the same path with a shape the reader CAN replay exactly."""
+
+    status, stored = _stored_cohort_route_filters(
+        "SELECT * FROM mip.gold.borrower_360 WHERE in_the_money AND state = 'IL'"
+    )
+
+    assert status == 200
+    assert stored is not None
+    assert stored["segment_codes"] == ["itm"]
+    assert stored["segment_mode"] == "any"
+    assert "unreplayable_filters" not in stored
+
+
+def test_the_genie_replay_segment_vocabulary_has_exactly_one_definition() -> None:
+    """Three readers used to keep three private copies of this set.
+
+    The answer's segment reader emitted from one, the Genie cohort writer
+    validated against another, and the campaign JSON projection against a
+    third. A code accepted by the first and rejected by the other two is not a
+    validation error, it is a governed action that cannot be taken -- so the
+    set is defined once and every reader is pinned to that object here.
+    """
+
+    from backend.schemas.campaign_json_projection import _GENIE_SEGMENT_CODES
+    from backend.schemas.lead import GENIE_REPLAY_SEGMENT_CODES, SEGMENT_CODE_VALUES
+    from backend.services.genie_actions import _GENIE_SEGMENT_CODE_RE
+
+    assert _GENIE_SEGMENT_CODES is GENIE_REPLAY_SEGMENT_CODES
+    assert set(GENIE_REPLAY_SEGMENT_CODES) <= set(SEGMENT_CODE_VALUES)
+    for code in SEGMENT_CODE_VALUES:
+        assert bool(_GENIE_SEGMENT_CODE_RE.fullmatch(code)) == (
+            code in GENIE_REPLAY_SEGMENT_CODES
+        ), code

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -971,7 +971,12 @@ def test_county_fips_rows_route_to_county_filtered_lead_queue() -> None:
     action = next(row for row in result.actions if row.id == "open-cohort")
 
     assert action.criteria["result_filters"]["county"] == "12011"
-    assert action.route == "/lead-queue?county=12011&segment=itm"
+    # No `segment=itm`, and the answer is why: this statement has no WHERE at
+    # all, so its 308 is every borrower in the county, not the in-the-money
+    # ones the QUESTION asked about. Replaying `itm` would open a queue
+    # smaller than the number the user just read. The word "in-the-money" in
+    # the question is not evidence that the answer applied it.
+    assert action.route == "/lead-queue?county=12011"
 
 
 def test_multiple_county_rows_preserve_all_counties_for_cohort_action() -> None:
@@ -995,7 +1000,9 @@ def test_multiple_county_rows_preserve_all_counties_for_cohort_action() -> None:
     action = next(row for row in result.actions if row.id == "open-cohort")
 
     assert action.criteria["result_filters"]["counties"] == ["12011", "17031"]
-    assert action.route == "/lead-queue?counties=12011%2C17031&segment=itm"
+    # Same reason as the single-county case: the statement has no WHERE, so
+    # the counts are all borrowers and the cohort must be too.
+    assert action.route == "/lead-queue?counties=12011%2C17031"
 
 
 def test_non_replayable_aggregate_answer_does_not_offer_lead_queue_action() -> None:

--- a/tests/unit/test_genie_sql_floor_extraction.py
+++ b/tests/unit/test_genie_sql_floor_extraction.py
@@ -499,12 +499,15 @@ def test_a_string_literal_body_cannot_fabricate_an_intersection() -> None:
         f"SELECT * FROM {_B360} WHERE array_contains(segment_codes,'itm') "
         'AND note = "array_contains(segment_codes,\'equity\')"'
     )
-    assert _mode(attack, ["itm", "equity"]) == "any"
+    # The literal is opaqued before this reader ever sees it, so the spelled
+    # conjunct is not even visible as a segment predicate: the cohort is the
+    # one real conjunct, not the intersection the literal asked for.
+    assert _segments(attack) == (["itm"], "any", False)
     real = (
         f"SELECT * FROM {_B360} WHERE array_contains(segment_codes,'itm') "
         "AND array_contains(segment_codes,'equity')"
     )
-    assert _mode(real, ["itm", "equity"]) == "all"
+    assert _segments(real) == (["itm", "equity"], "all", False)
 
 
 def test_a_comment_inside_a_literal_no_longer_truncates_the_predicate() -> None:
@@ -805,12 +808,13 @@ def test_disclosure_survives_all_five_closed_vocabularies() -> None:
 # "and" and no "or" — true for two calls in different CTEs or inside COUNT_IF.
 
 
-def _mode(sql: str, codes: list[str]) -> str:
+def _segments(sql: str) -> tuple[list[str], str, bool]:
+    from backend.services.genie_sql_predicates import read_sql_filters
     from backend.services.repositories.databricks_genie_actions import (
-        _segment_mode_from_sql,
+        _segment_selection_from_sql,
     )
 
-    return _segment_mode_from_sql(sql, codes)
+    return _segment_selection_from_sql(read_sql_filters(sql))
 
 
 def test_a_real_top_level_intersection_is_still_all() -> None:
@@ -819,15 +823,21 @@ def test_a_real_top_level_intersection_is_still_all() -> None:
         "WHERE array_contains(segment_codes,'itm') "
         "AND array_contains(segment_codes,'equity')"
     )
-    assert _mode(sql, ["itm", "equity"]) == "all"
+    assert _segments(sql) == (["itm", "equity"], "all", False)
+
+
+def test_a_pure_disjunction_is_the_union_the_queue_replays_as_any() -> None:
+    sql = (
+        "SELECT * FROM mip.gold.borrower_360 "
+        "WHERE (array_contains(segment_codes,'itm') "
+        "OR array_contains(segment_codes,'equity')) AND state='IL'"
+    )
+    assert _segments(sql) == (["itm", "equity"], "any", False)
 
 
 @pytest.mark.parametrize(
     "sql",
     [
-        # Union — never an intersection.
-        "SELECT * FROM mip.gold.borrower_360 WHERE array_contains(segment_codes,'itm') "
-        "OR array_contains(segment_codes,'equity')",
         # Breakdown columns: the curated space teaches this idiom.
         "SELECT COUNT_IF(array_contains(segment_codes,'itm')) AS a, "
         "COUNT_IF(array_contains(segment_codes,'equity')) AS b "
@@ -839,8 +849,210 @@ def test_a_real_top_level_intersection_is_still_all() -> None:
         # A CASE arm projects a label and selects nothing.
         "SELECT CASE WHEN array_contains(segment_codes,'itm') AND "
         "array_contains(segment_codes,'equity') THEN 1 END FROM t",
+        # The shape that motivated the whole change: segment is what the answer
+        # GROUPS BY, so the answer spans every segment and filters on none.
+        "SELECT sc, COUNT(*) FROM mip.gold.borrower_360 "
+        "LATERAL VIEW EXPLODE(segment_codes) s AS sc GROUP BY sc",
     ],
 )
-def test_non_filtering_segment_pairs_never_become_an_intersection(sql: str) -> None:
-    assert _mode(sql, ["itm", "equity"]) == "any"
+def test_segments_the_answer_never_filtered_on_yield_no_cohort(sql: str) -> None:
+    codes, mode, unreadable = _segments(sql)
+    assert (codes, mode) == ([], "any")
+    assert unreadable is False
 
+
+@pytest.mark.parametrize(
+    ("sql", "why"),
+    [
+        (
+            # Live case: the queue replayed the strict second branch and opened
+            # 1,991 against an answer reporting 19,166.
+            "SELECT * FROM mip.gold.borrower_360 WHERE "
+            "(array_contains(segment_codes,'retention') "
+            "OR recommended_offer_code='retention')",
+            "an OR across two columns is broader than either column alone",
+        ),
+        (
+            "SELECT * FROM mip.gold.borrower_360 "
+            "WHERE NOT array_contains(segment_codes,'itm')",
+            "negation inverts membership and the queue has no NOT",
+        ),
+        (
+            "SELECT * FROM mip.gold.borrower_360 "
+            "WHERE array_contains(segment_codes,'not_a_reviewed_code')",
+            "an unreviewed code is outside the replayable vocabulary",
+        ),
+        (
+            "SELECT * FROM mip.gold.borrower_360 WHERE "
+            "(array_contains(segment_codes,'itm') OR array_contains(segment_codes,'equity')) "
+            "AND array_contains(segment_codes,'listed')",
+            "a conjunction of disjunctions has no single any/all reading",
+        ),
+    ],
+)
+def test_unreadable_segment_predicates_are_disclosed_not_guessed(sql: str, why: str) -> None:
+    codes, mode, unreadable = _segments(sql)
+    assert (codes, mode) == ([], "any"), why
+    assert unreadable is True, why
+
+
+
+# --- The flag-column map is pinned to the gold CASE ladder ------------------
+
+
+def test_segment_flag_columns_match_the_gold_case_ladder() -> None:
+    """`WHERE in_the_money` may stand in for `itm` only while the SQL says so.
+
+    ``_SEGMENT_FLAG_COLUMNS`` claims a boolean column selects EXACTLY a
+    segment's population. That is true only because the arm building the code
+    in gold_borrower_360 is nothing but that column, and nothing stops someone
+    from making an arm compound later -- at which point the queue would replay
+    a cohort the answer never described, silently and in the narrowing
+    direction. So the claim is re-derived from the SQL on every run.
+
+    It fails in BOTH directions on purpose: a mapped arm that stops being one
+    bare column, and a compound arm that becomes one without being added.
+    """
+
+    from pathlib import Path
+
+    from backend.services.repositories.databricks_genie_actions import (
+        _SEGMENT_FLAG_COLUMNS,
+    )
+
+    sql = Path("sql/transformations/gold_borrower_360.sql").read_text()
+    ladder = sql.split("with_segments AS (", 1)[1].split("AS segment_codes", 1)[0]
+    ladder = re.sub(r"--[^\n]*", " ", ladder)
+    arms = {
+        code: re.sub(r"\s+", " ", expression).strip()
+        for expression, code in re.findall(
+            r"CASE\s+WHEN\s+(.+?)\s+THEN\s+'([a-z_]+)'\s+END", ladder, re.DOTALL
+        )
+    }
+    assert arms, "could not parse the segment CASE ladder"
+
+    expected_single = {code: col for col, code in _SEGMENT_FLAG_COLUMNS.items()}
+    for code, expression in arms.items():
+        bare = re.fullmatch(r"(?:\w+\.)?(\w+)", expression)
+        mapped = expected_single.get(code)
+        if mapped is not None:
+            assert bare is not None, (
+                f"segment {code!r} is mapped to a single boolean column but its arm is "
+                f"now compound ({expression!r}); drop it from _SEGMENT_FLAG_COLUMNS"
+            )
+            assert bare.group(1) == mapped, (
+                f"segment {code!r} is now defined by {bare.group(1)!r}, "
+                f"not {mapped!r}"
+            )
+        else:
+            assert bare is None, (
+                f"segment {code!r} is now exactly the column {expression!r}; add it to "
+                "_SEGMENT_FLAG_COLUMNS so the queue can replay the answer's own filter"
+            )
+    assert set(expected_single) <= set(arms), (
+        f"mapped segments missing from the ladder: {set(expected_single) - set(arms)}"
+    )
+
+
+# --- Refused spans may only be re-read when the refusal was SHAPE alone -----
+#
+# `_segment_selection_from_sql` re-reads conjuncts the floor reader refused,
+# because a real segment filter is usually an OR and the splitter will not
+# break an OR apart. Adversarial review 2026-08-11 found two ways that let a
+# STRICT SUBSET of the answer's population through with no disclosure at all.
+
+
+@pytest.mark.parametrize(
+    ("sql", "why"),
+    [
+        (
+            # LEFT/RIGHT are join keywords AND string builtins. The call used
+            # to close the filter region mid-OR, leaving the fragment
+            # "array_contains(segment_codes,'itm') or" -- which reads as a
+            # pure membership test. Answer: itm UNION zip-prefix. Replay was:
+            # itm alone.
+            f"SELECT COUNT(*) FROM {_B360} "
+            "WHERE array_contains(segment_codes,'itm') OR LEFT(zip, 3) = '606'",
+            "a dangling OR is a fragment of a longer disjunction",
+        ),
+        (
+            f"SELECT * FROM {_B360} WHERE in_the_money OR RIGHT(zip,2)='01'",
+            "same truncation reached through the flag-column spelling",
+        ),
+        (
+            # Two truncated regions compounded into an INTERSECTION: answer
+            # was (itm ∪ z) ∩ (listed ∪ c), replay was itm ∩ listed.
+            f"SELECT COUNT(*) FROM {_B360} b JOIN mip.gold.evidence_events e "
+            "ON array_contains(b.segment_codes,'itm') OR LEFT(b.zip,3)='606' "
+            "WHERE array_contains(b.segment_codes,'listed') OR LEFT(b.city,1)='C'",
+            "two truncations must not compound into a narrowing intersection",
+        ),
+        (
+            # The grain gate refused this leaf; re-reading it reopened exactly
+            # the failure the module's "Position is not grain" section exists
+            # to prevent. Answer: itm UNION listed. Replay was: itm.
+            "WITH pool AS (SELECT clip, state, (in_the_money OR listed_for_sale) "
+            f"AS in_the_money FROM {_B360}) "
+            "SELECT state, COUNT(*) FROM pool WHERE in_the_money GROUP BY state",
+            "a rebound column is not the base column it shadows",
+        ),
+        (
+            "WITH pool AS (SELECT clip, state, ARRAY('itm','listed','equity') "
+            f"AS segment_codes FROM {_B360}) "
+            "SELECT state FROM pool WHERE array_contains(segment_codes,'itm')",
+            "a fabricated array column is not the borrower's segment list",
+        ),
+    ],
+)
+def test_a_refused_span_is_never_re_read_into_a_narrower_cohort(sql: str, why: str) -> None:
+    codes, mode, unreadable = _segments(sql)
+    assert (codes, mode) == ([], "any"), why
+    assert unreadable is True, why
+
+
+def test_a_partially_unread_segment_axis_is_still_disclosed() -> None:
+    """`itm AND (listed OR score >= 80)` replays `itm` -- broader, and it says so.
+
+    The disclosure used to be suppressed whenever any readable conjunct had
+    already set `segment_codes`, on the reasoning that the queue was then "not
+    broader on this axis". It is: the answer intersected a second segment
+    predicate that the queue cannot express.
+    """
+
+    codes, mode, unreadable = _segments(
+        f"SELECT * FROM {_B360} WHERE array_contains(segment_codes,'itm') "
+        "AND (array_contains(segment_codes,'listed') OR opportunity_score >= 80)"
+    )
+    assert (codes, mode) == (["itm"], "any")
+    assert unreadable is True
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        # A genuine parenthesised disjunction still reads exactly -- the
+        # surgical LEFT/RIGHT rule must not stop `WHERE (` opening a region.
+        (
+            f"SELECT * FROM {_B360} WHERE (array_contains(segment_codes,'itm') "
+            "OR array_contains(segment_codes,'equity')) AND state='IL'",
+            (["itm", "equity"], "any", False),
+        ),
+        # Two membership tests, one code: the arity guard counts MATCHES, not
+        # deduped codes, or this legitimate canonical shape would be refused.
+        (
+            f"SELECT * FROM {_B360} "
+            "WHERE array_contains(segment_codes,'investor') OR is_investor = TRUE",
+            (["investor"], "any", False),
+        ),
+        # A real LEFT JOIN is untouched by the function-call rule.
+        (
+            f"SELECT * FROM {_B360} b LEFT JOIN mip.gold.evidence_events e "
+            "ON e.clip = b.clip WHERE in_the_money",
+            (["itm"], "any", False),
+        ),
+    ],
+)
+def test_legitimate_disjunctions_still_replay_exactly(
+    sql: str, expected: tuple[list[str], str, bool]
+) -> None:
+    assert _segments(sql) == expected


### PR DESCRIPTION
## What

Segments handed from a Genie answer to the Lead Queue were still inferred from the **question's wording** — the last member of a family whose siblings were deleted for exactly this reason. Prose has no position to gate on, so a segment the answer merely *mentioned* was indistinguishable from one it *filtered on*, and the mismatch always narrowed.

Captured live on paychex 2026-08-11:

> **Q:** "Which segment converts best: HELOC, cash-out, or retention?"
> **Answer:** a three-segment comparison over `mip.semantics.segment_performance_metric_view`
> **Queue opened:** `segment_codes=permit,retention` — `heloc` mistranslated to `permit`, `cash-out` silently dropped, and `permit` is not one of the three segments the answer named.

## How

Segments now come from the answer's own top-level AND-conjuncts, plus a map from the 8 gold boolean columns whose `CASE` arm in `gold_borrower_360` is **one bare column** — `WHERE in_the_money` and `array_contains(segment_codes,'itm')` select the identical population, and Genie writes the flag at least as often as the array. `test_segment_flag_columns_match_the_gold_case_ladder` parses that ladder and fails in **both** directions if it drifts.

Two repo-authored canonical statements have no filter position at all (their filters live in CTE bodies), so they now **declare** their cohort next to the SQL rather than have it guessed.

## Adversarial review findings, all fixed here

Two subagent reviewers were run against the first cut. Four defects, three of them narrowing:

| | Defect | Direction |
|---|---|---|
| 1 | `LEFT(`/`RIGHT(` are string builtins as well as join keywords, so a call closed the filter region mid-`OR`, leaving the fragment `array_contains(...,'itm') or` — which reads as a pure membership test. Answer: `itm ∪ zip-prefix`; replay: `itm` alone. | **narrowing, undisclosed** |
| 2 | Refused spans were republished for re-reading regardless of *why* they were refused, so a leaf the grain gate had just rejected could be re-admitted — reopening "Position is not grain" on the segment axis. | **narrowing, undisclosed** |
| 3 | The S1.3 overlay codes sit outside the reviewed replay vocabulary, which three readers each kept a private copy of. An answer filtering on one 400'd **all four** governed actions. | dead feature |
| 4 | The unreplayable-segment disclosure was appended to a list that was never read. | silent divergence |

Finding 3 is the PR #191 shape and is why the vocabulary now has **one** definition (`GENIE_REPLAY_SEGMENT_CODES`), pinned by a test across all three readers.

## Verification

- Live turn re-run through the new reader produces the **identical** cohort — and produces it unchanged when the segment words are stripped from the question, which is the property that matters.
- Regression tests drive real SQL through to the **stored Lakebase cohort row**, not just the routing helper: every defect above passed at the helper layer.
- Local gate green: unit suite, `ruff`, `mypy` (251 files), file-size gate.

`tests/unit/test_deploy_dev_workflow_contract.py` fails 19 locally on unmodified `origin/main` too — a pre-existing environment issue, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)