### PR TITLE
fix(map): stop the legend covering the ZIP drill's reconciliation line

### DIFF
--- a/frontend/src/design-system/components.css
+++ b/frontend/src/design-system/components.css
@@ -3862,6 +3862,18 @@ a.lineage-node__chip:focus-visible {
   padding: var(--sp-2) var(--sp-3);
   font-size: 11px; color: var(--text-3);
 }
+/* The ZIP drill ends with `.zip-tiles__reconcile`, a full-width flow row that
+   states how much of the state is NOT in view. An absolutely-anchored legend
+   lands on top of its first ~190px, so it read "…7 ZIPs — 14,954 of 31,114
+   borrowers in view" with the "Showing the 24 densest of 8" clipped off
+   (measured live 2026-08-11). Since a reconciliation the user cannot read is
+   the bug it exists to prevent, the legend joins the flow below it here. The
+   state map has no such row and keeps the overlay. */
+.map-wrap:has(.zip-tiles) .map-legend {
+  position: static;
+  width: max-content;
+  margin: 0 var(--sp-3) var(--sp-3);
+}
 .map-legend__bar { display: flex; height: 8px; margin: 4px 0; border-radius: 2px; overflow: hidden; width: 140px; }
 .map-legend__bar span { flex: 1; }
 .map-legend__header {


### PR DESCRIPTION
Found during the live browser audit of the deployed app.

`.map-legend` is anchored `position: absolute; bottom` inside `.map-wrap`, while the ZIP drill ends with `.zip-tiles__reconcile` — a full-width flow row. The legend landed on top of the row's first ~190px, so it rendered as:

> …7 ZIPs — 14,954 of 31,114 borrowers in view.

with **"Showing the 24 densest of 8"** clipped off.

Measured in the live DOM (legend `x 109–295`, row `x 97–1109`, overlap confirmed), not inferred from the source.

That row exists so a drill-down showing a third of the population doesn't read as a broken widget — so a reconciliation the user can't read is exactly the bug it was added to prevent. In ZIP view the legend now joins the flow below the row; the state map has no such row and keeps the overlay.

The fix was previewed against the deployed app and the row re-measured fully visible before it was written to source. jsdom computes no layout, so no unit test can see this class of defect — the browser measurement is the proof.

Frontend gate green: eslint, 1028 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)