### PR TITLE
ci(shell): add a pinned shellcheck gate at warning severity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-# Slice 9 CI -- PR + push workflow. Six jobs run in parallel; in-progress
+# Slice 9 CI -- PR + push workflow. Every job below runs in parallel; in-progress
 # runs on the same ref are cancelled by `concurrency` so rapid pushes only
 # burn one runner per branch. Everything here is credential-free; the
 # nightly workflow (nightly.yml) handles live-UC checks with secrets.
@@ -25,6 +25,10 @@ env:
   # frontend/package.json requires Node >=22.22; follow the current Node 22
   # LTS line so CI receives patch updates while satisfying that floor.
   NODE_VERSION: '22'
+  # Pinned exactly, like every other tool version here: the runner image's
+  # preinstalled shellcheck drifts, and a new release adding one check would
+  # redden CI on a commit that changed no shell at all.
+  SHELLCHECK_VERSION: 'v0.11.0'
   # Placeholder BUNDLE_VARs so `databricks bundle validate` can resolve
   # variable references without any real workspace secrets. The nightly
   # workflow swaps these for real values.
@@ -171,6 +175,32 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Enforce monolith allowlist
         run: python tools/check_file_sizes.py --warn 500 --fail 900
+
+  shell-lint:
+    name: shell (shellcheck)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install pinned shellcheck
+        run: |
+          set -euo pipefail
+          url="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          curl -fsSL --retry 3 "$url" | tar -xJ -C /tmp
+          sudo install -m 0755 "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+          shellcheck --version
+      - name: Lint tracked shell scripts
+        # --severity=warning is the enforced floor. The 85 remaining info-level
+        # findings are almost all SC2030/SC2031 subshell-scope noise, which the
+        # deploy script's M2M subshells trip by design; deploy.sh already
+        # carries targeted `# shellcheck disable=SC2031` directives with
+        # reasons where it matters.
+        #
+        # Warning level is the point of this gate: SC2154 (referenced but not
+        # assigned) is what catches a function moved into scripts/lib/ that
+        # still reads a caller-scoped variable -- the failure mode a shell
+        # split introduces silently and no test here would otherwise see.
+        run: make lint-shell
 
   release-hygiene:
     name: release source hygiene

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,14 @@ Key PR gates:
   single canonical source, and backend modules carry docstrings.
 - Frontend lint/test/build/budget: TypeScript, React/Vitest coverage, Vite
   production build, and bundle-size budgets.
+- `make lint-shell` (`shellcheck --severity=warning` over every tracked
+  `*.sh`): shell correctness for `scripts/deploy.sh`, its `scripts/lib/*`
+  libs, and the kill-drill harness. Warning level is deliberate — SC2154
+  catches a function moved into a sourced lib that still reads a
+  caller-scoped variable, which is the way a shell split breaks silently.
+  Suppress a genuine false positive with an inline
+  `# shellcheck disable=SCxxxx  # reason.` at the site, never a blanket
+  exclude.
 - Security job: gitleaks, bandit, pip-audit, and npm audit.
 
 Nightly gates include SQL/Python parity, Lakebase round-trip, Genie live and

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # only `python3` is on PATH. Override by running `make PYTHON=python3 …`.
 PYTHON ?= $(shell [ -x .venv/bin/python ] && echo .venv/bin/python || echo python3)
 
-.PHONY: setup dev-api dev-ui test test-e2e lint build validate bundle-validate bundle-plan bundle-deploy zip \
+.PHONY: setup dev-api dev-ui test test-e2e lint lint-shell build validate bundle-validate bundle-plan bundle-deploy zip \
         provision-genie bundle-validate-env bundle-deploy-dev deploy-dev check-workspace-host \
         configure-workspace render-sql
 
@@ -30,6 +30,18 @@ test-e2e:
 lint:
 	$(PYTHON) -m ruff check backend tests tools
 	npm --prefix frontend run lint
+	$(MAKE) lint-shell
+
+# Shell lint. `git ls-files` is the file list on purpose: it tracks new
+# scripts automatically and never walks dist/ or node_modules.
+# Fails loudly when shellcheck is absent rather than skipping — a lint gate
+# that silently passes when its linter is missing is worse than no gate.
+lint-shell:
+	@command -v shellcheck >/dev/null 2>&1 || { \
+	  echo "shellcheck not found. Install it: brew install shellcheck (macOS) / apt-get install shellcheck (Debian)"; \
+	  exit 1; \
+	}
+	shellcheck --severity=warning $$(git ls-files '*.sh')
 
 # 2026-06-11 audit P2-14: ratcheted mypy gate — exemption list in
 # pyproject.toml [tool.mypy] overrides may only shrink.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -338,7 +338,9 @@ MIP_APP_ROLLBACK_PROXY_CREDENTIAL_IDS=""
 MIP_APP_ROLLBACK_RECORD_VERSION=""
 MIP_APP_ROLLBACK_PROXY_MODE=""
 MIP_APP_ROLLBACK_DEPLOYMENT_ID=""
+# shellcheck disable=SC2034  # MIP_APP_ROLLBACK_* contract surface; emitted by app_deployment_rollback_cli.py, not read in bash.
 MIP_APP_ROLLBACK_GATEWAY_ENDPOINT_ID=""
+# shellcheck disable=SC2034  # MIP_APP_ROLLBACK_* contract surface; emitted by app_deployment_rollback_cli.py, not read in bash.
 MIP_APP_ROLLBACK_GATEWAY_CREATOR=""
 MIP_APP_ROLLBACK_GATEWAY_PIN_JSON=""
 MIP_APP_ROLLBACK_GATEWAY_INFERENCE_TABLE_PREFIX=""
@@ -2355,6 +2357,7 @@ if [[ -z "$_GATEWAY_MODEL_PREVIOUS_KEY_RESOLVED" ]]; then
   )"
 fi
 if [[ -n "$_GATEWAY_MODEL_PREVIOUS_KEY_RESOLVED" ]]; then
+  # shellcheck disable=SC2155  # Splitting would expose printf's status to set -e on a secret export.
   export MIP_GATEWAY_MODEL_ATTESTATION_PREVIOUS_VERIFY_KEY="$(
     printf '%s' "$_GATEWAY_MODEL_PREVIOUS_KEY_RESOLVED"
   )"

--- a/scripts/lib/deploy_agent_proxy_lifecycle.sh
+++ b/scripts/lib/deploy_agent_proxy_lifecycle.sh
@@ -168,6 +168,7 @@ compensate_agent_proxy_access() {
         "$MIP_AGENT_SUPERVISOR_ENDPOINT" \
         "$MIP_AGENT_SUPERVISOR_ENDPOINT_ID" \
         "${captured_preserve_args[@]:0:6}" || return 1
+      # shellcheck disable=SC2034  # Set here, read by scripts/deploy.sh after this lib is sourced.
       CAPTURED_PROXY_BOUNDARY_PROVEN=1
       ;;
     green_verified)

--- a/scripts/lib/deploy_cutover_journal_lifecycle.sh
+++ b/scripts/lib/deploy_cutover_journal_lifecycle.sh
@@ -78,6 +78,7 @@ merge_historical_cutover_journal_preservation() {
       fi
       ;;
     stale)
+      # shellcheck disable=SC2034  # Set here, read by scripts/deploy.sh after this lib is sourced.
       STALE_CUTOVER_JOURNAL_PENDING=1
       ;;
     absent)
@@ -104,6 +105,7 @@ journal_preactivation_app_acl_endpoint() {
     [[ "$existing" == "$endpoint" ]] && return 0
   done
   PREACTIVATION_APP_REVOKE_ENDPOINTS+=("$endpoint")
+  # shellcheck disable=SC2034  # Set here, read by scripts/deploy.sh after this lib is sourced.
   PREACTIVATION_APP_ACL_MUTATED=1
 }
 
@@ -399,6 +401,7 @@ load_captured_live_old_resources() {
       "$MIP_REPLACED_AGENT_GATEWAY_ENDPOINT" \
       "$MIP_REPLACED_AGENT_GATEWAY_ENDPOINT_ID" \
       "$MIP_REPLACED_AGENT_GATEWAY_CREATOR"; then
+      # shellcheck disable=SC2034  # Set here, read by scripts/deploy.sh after this lib is sourced.
       CAPTURED_OLD_GATEWAY_LIVE=1
     else
       status=$?
@@ -410,6 +413,7 @@ load_captured_live_old_resources() {
       "$MIP_REPLACED_AGENT_SUPERVISOR_ENDPOINT" \
       "$MIP_REPLACED_AGENT_SUPERVISOR_ENDPOINT_ID" \
       "$MIP_REPLACED_AGENT_SUPERVISOR_CREATOR"; then
+      # shellcheck disable=SC2034  # Set here, read by scripts/deploy.sh after this lib is sourced.
       CAPTURED_OLD_SUPERVISOR_LIVE=1
     else
       status=$?
@@ -566,8 +570,11 @@ complete_captured_runtime_retirement_journal() {
     --app-name "$_GRANTS_APP_NAME" \
     --deployment-lease-id "$MIP_APP_DEPLOYMENT_LEASE_ID" \
     --deployment-source-git-sha "$SOURCE_GIT_SHA" || return 1
+  # shellcheck disable=SC2034  # Set here, read by scripts/deploy.sh after this lib is sourced.
   CAPTURED_RUNTIME_RETIREMENT_COMPLETE=0
+  # shellcheck disable=SC2034  # Set here, read by scripts/deploy.sh after this lib is sourced.
   AGENT_PROXY_ACCESS_MUTATED=0
+  # shellcheck disable=SC2034  # Set here, read by scripts/deploy.sh after this lib is sourced.
   VERIFIER_GATEWAY_CUTOVER_MUTATED=0
   APP_UPGRADE_STATE="green_verified"
 }

--- a/scripts/lib/deploy_verifier_gateway_lifecycle.sh
+++ b/scripts/lib/deploy_verifier_gateway_lifecycle.sh
@@ -96,6 +96,7 @@ compensate_verifier_gateway_access() {
         "$MIP_APP_ROLLBACK_GATEWAY_INFERENCE_TABLE_PREFIX" \
         "${captured_proof_args[@]}" || failed=1
       if [[ "$failed" -eq 0 ]]; then
+        # shellcheck disable=SC2034  # Set here, read by scripts/deploy.sh after this lib is sourced.
         CAPTURED_VERIFIER_BOUNDARY_PROVEN=1
       fi
     fi


### PR DESCRIPTION
The repo had **zero shell linting**. That's the missing safety net under `scripts/deploy.sh`, its four `scripts/lib/*` libs, and the kill-drill harness — roughly 4,000 lines of bash on the customer-facing deploy path with no automated check of any kind.

This came out of asking whether `tools/kill_drill/run_drill.sh` (886 lines, 14 from the file-size fail gate) should be split now. It shouldn't yet — it's grown +14 lines in three months, it's operator-run so a latent break surfaces during an actual resilience drill, and there was no way to verify a shell split. This fixes the last part.

## Why warning severity, not error

`--severity=error` would pass today and catch almost nothing. **Warning is where SC2154 lives** (*referenced but not assigned*) — exactly what catches a function moved into a sourced lib that still reads a caller-scoped variable. That's how a shell split breaks silently, and it's the reason not to attempt one before this gate exists.

Verified it has teeth:

```
foo() { echo "$undefined_var"; }
  ^------------^ SC2154 (warning): undefined_var is referenced but not assigned.
exit=1
```

## Baseline was already good

**97 findings, zero errors.** `run_drill.sh` itself is clean as-is. The 12 warnings were 11× SC2034 + 1× SC2155, all in the deploy machinery, and all verified false positives:

- Every SC2034 variable is a **genuine cross-file read** — set in a lib, consumed by `deploy.sh` after sourcing. shellcheck analyses per file, and `-x` can't follow these source paths statically (I measured: `-x` changes nothing, 97/0/12/85 either way).
- The SC2155 is `export KEY="$(printf ...)"` on a **secret**. Splitting it as shellcheck suggests would newly expose `printf`'s status to `set -e` in the deploy path — the mechanical "fix" is a behaviour change.

Each is suppressed with an inline `# shellcheck disable=SCxxxx  # reason.` at the site, matching the idiom `deploy.sh` already uses at line 2362 — never a blanket exclude, so SC2034 stays live for genuinely new dead variables.

**Every one of the 12 edits is a comment.** The diff adds 12 lines to shell files and deletes none.

## One finding reported rather than papered over

`MIP_APP_ROLLBACK_GATEWAY_ENDPOINT_ID` and `MIP_APP_ROLLBACK_GATEWAY_CREATOR` are declared in `deploy.sh:341-342`, emitted by `app_deployment_rollback_cli.py`, and **read by nothing in bash** — unlike their ~14 siblings in the same block, which shellcheck did not flag. I confirmed they aren't reachable through the `${!name}` indirection either (that loop iterates a fixed literal list).

Left in place, with a comment saying exactly that. Removing lines from the deploy contract is the deploy owner's call, not a lint cleanup.

## Pinning

shellcheck is pinned to `v0.11.0` rather than taken from the runner image, so a new release adding one check can't redden CI on a commit that touched no shell. Install path and URL verified against the real tarball (`shellcheck-v0.11.0/shellcheck`, HTTP 200). Local and CI run the same command via `make lint-shell`, which **fails loudly when shellcheck is missing** rather than skipping — a lint gate that silently passes without its linter is worse than no gate.

## Validation

| Gate | Result |
|---|---|
| `make lint-shell` | clean |
| `pytest tests/unit` | 13,454 passed, 0 failed |
| `ruff check backend tests tools` | clean |
| `mypy backend` | no issues, 251 files |
| `tools/check_file_sizes.py` | exit 0 |
| docs + architecture contracts | 127 passed |
| `ci.yml` YAML parse | 9 jobs, `shell-lint` registered, no secret refs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)