### PR TITLE
refactor(deploy): drop the two unread signed-blue gateway pre-bindings

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -338,10 +338,11 @@ MIP_APP_ROLLBACK_PROXY_CREDENTIAL_IDS=""
 MIP_APP_ROLLBACK_RECORD_VERSION=""
 MIP_APP_ROLLBACK_PROXY_MODE=""
 MIP_APP_ROLLBACK_DEPLOYMENT_ID=""
-# shellcheck disable=SC2034  # MIP_APP_ROLLBACK_* contract surface; emitted by app_deployment_rollback_cli.py, not read in bash.
-MIP_APP_ROLLBACK_GATEWAY_ENDPOINT_ID=""
-# shellcheck disable=SC2034  # MIP_APP_ROLLBACK_* contract surface; emitted by app_deployment_rollback_cli.py, not read in bash.
-MIP_APP_ROLLBACK_GATEWAY_CREATOR=""
+# This block pre-binds only the names bash later dereferences without a `:-`
+# default, so `set -u` survives the paths that never source the binding env.
+# app_deployment_rollback_cli.py also emits MIP_APP_ROLLBACK_GATEWAY_ENDPOINT_ID
+# and MIP_APP_ROLLBACK_GATEWAY_CREATOR, but bash never reads either: the
+# preservation guards take the same two fields through the pin JSON below.
 MIP_APP_ROLLBACK_GATEWAY_PIN_JSON=""
 MIP_APP_ROLLBACK_GATEWAY_INFERENCE_TABLE_PREFIX=""
 MIP_APP_ROLLBACK_SUPERVISOR_ID=""


### PR DESCRIPTION
Resolves the two SC2034 findings that PR #197's shellcheck gate surfaced in `scripts/deploy.sh`, after establishing which of the two possible causes was true.

## Verdict: vestigial, not missing scaffolding

The `MIP_APP_ROLLBACK_*` block at the top of `deploy.sh` is **not** a mirror of the rollback CLI's emitted contract. It pre-binds the subset of names bash later dereferences *unbraced*, so `set -euo pipefail` survives the paths that never source the binding env (first install, no signed blue).

`MIP_APP_ROLLBACK_GATEWAY_ENDPOINT` is the control case that proves the rule: emitted by the same CLI, read **30 times** in bash, and deliberately absent from the block — because every read site guards with `${...:-}`.

`MIP_APP_ROLLBACK_GATEWAY_ENDPOINT_ID` and `MIP_APP_ROLLBACK_GATEWAY_CREATOR` have **no bash reads at all**, guarded or otherwise. The pre-binding does nothing, so SC2034 was right.

## Nothing is lost

The emitted env-file contract is untouched:
- `app_deployment_rollback_cli.py` still emits both names (pinned by `tests/unit/test_app_deployment_rollback.py`).
- `deploy.sh` still sources that file under `set -a` (`scripts/deploy.sh:2917`, `:3830`) — the earlier read that "nothing sources it" was inaccurate.
- The same two fields already reach the preservation guards through `MIP_APP_ROLLBACK_GATEWAY_PIN_JSON` (`{name, endpoint_id, creator}`), consumed by `--preserve-gateway-json` and `MIP_CUTOVER_SIGNED_BLUE_GATEWAY_PIN_JSON` across four Python tools.

Deletion is **export-neutral** — verified empirically that bash re-exports an already-declared unexported variable when it is reassigned under `set -a`, so subprocesses see the same environment either way.

## Why option 2 (wire up a consumer) was ruled out

The bare `--old-gateway-endpoint-id` / `--old-gateway-creator` flags at `scripts/deploy.sh:4894` are fed by the `MIP_REPLACED_AGENT_GATEWAY_*` family, produced by `cutover_agent_runtime_supervisor.py` from the cutover journal's `old_gateway_*` fields — the blue endpoint being *retired*, a different lifecycle stage from the signed rollback target. That family carries **zero** pre-declarations because its reads sit behind an `[[ -n "${...:-}" ]]` guard. Repointing those flags at the rollback contract would change deploy semantics, not fix a lint finding.

## Validation

| Gate | Result |
| --- | --- |
| `make lint-shell` | clean — both SC2034s gone, no new findings |
| `bash -n scripts/deploy.sh` | OK |
| `ruff check backend tests tools` | All checks passed |
| `npm --prefix frontend run lint` | passed |
| `pytest tests/unit -q` | exit 0 — 13,454 passed, 3 skipped, no F/E |

The two inline disables are replaced by a comment stating the block's actual rule, so the next reader diffing the CLI's emit list against this block does not re-add them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)