### PR TITLE
fix(genie): answer the comparative-segment family, and make it actionable

### DIFF
--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -15,6 +15,26 @@ from backend.schemas.marketing_selection_reviewed_analytics import (
 )
 
 REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT = (
+    # An aggregate qualifier is a DESCRIPTOR of a reviewed attribute, not a new
+    # selection criterion: "average rate spread" selects on rate spread exactly
+    # as "rate spread" does. These were admitted on the opportunity/lead-score
+    # alternative below and nowhere else, so the same aggregate flipped every
+    # OTHER reviewed attribute to unreviewed and the prompt failed closed.
+    #
+    # Live on paychex 2026-08-11: "Rank our segments by average rate spread."
+    # was refused with "it is outside the reviewed Module 0 vocabulary" in
+    # ~1s, before any repository call -- while
+    # `_canonical_mean_rate_spread_by_segment_scope` already matched that exact
+    # string and its canonical SQL was sitting there unreachable. Measured
+    # matrix: `rate spread` passed bare and with "high", and refused with
+    # "average", "mean" and "highest"; `home equity`, `LTV`, `loan balance` and
+    # `property value` behaved the same way.
+    #
+    # This does NOT weaken the fail-closed default. The attribute alternation
+    # below is unchanged, so an UNREVIEWED attribute stays unreviewed with or
+    # without a qualifier -- "average credit score" still refuses, and
+    # ``test_aggregate_qualifiers_never_admit_an_unreviewed_attribute`` pins it.
+    r"(?:(?:average|avg|mean|median|typical|high(?:est)?|low(?:est)?|top|bottom)\s+)?"
     r"(?:(?:high|strong|substantial|sufficient|available|usable)\s+(?:home[- ]?)?equity|"
     r"substantial\s+modeled\s+(?:home[- ]?)?equity|"
     r"(?:high|low|rising|falling|current|elevated)\s+"
@@ -61,7 +81,18 @@ REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT = (
     r"(?:an?\s+)?(?:especially\s+|particularly\s+|very\s+)?"
     r"(?:strong|good|great|excellent|prime|ideal|top|promising)\s+"
     r"(?:candidates?|prospects?|fits?|matches?|opportunit(?:y|ies))|"
-    r"(?:fixed|adjustable)[- ]?rate\s+(?:mortgages?|loans?))"
+    r"(?:fixed|adjustable)[- ]?rate\s+(?:mortgages?|loans?)|"
+    # Bare "home equity" / "equity percentage". Every other equity alternative
+    # above REQUIRES a qualifier ("strong equity", "substantial equity"), so
+    # "Rank our segments by home equity" -- a plain analytics question about
+    # the signal this product is built on (CLAUDE.md: HELOC/Cash-out
+    # candidates = strong equity) -- failed closed as an unknown criterion,
+    # with or without an aggregate. Deliberately anchored on "home" or on an
+    # explicit percentage noun: bare "equity" on its own is left out because
+    # it is also the DEI sense of the word, and the protected-class terms are
+    # matched before this fragment is ever consulted. Placed last so it cannot
+    # shadow "home equity line of credit" or "home equity intent" above.
+    r"(?:home[- ]?equity|equity\s+(?:pct|percent(?:age)?|share)))"
 )
 REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT = (
     rf"(?:{REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT})"

--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -42,6 +42,7 @@ from backend.services.repositories.databricks_genie_canonical import (
     _CANONICAL_RETENTION_COMPETITOR_LIEN_LIST_SQL,
     _CANONICAL_RETENTION_ELIGIBILITY_SUMMARY_BY_STATE_SQL,
     _CANONICAL_RETENTION_ELIGIBILITY_SUMMARY_GLOBAL_SQL,
+    _CANONICAL_SEGMENT_APPROVAL_RATE_SQL,
     _CANONICAL_TOP_BORROWERS_ALL_SEGMENTS_SQL,
     _CANONICAL_TOP_BORROWERS_BY_STATE_INTENT_SQL,
     _CANONICAL_TOP_BORROWERS_BY_STATE_SQL,
@@ -55,6 +56,7 @@ from backend.services.repositories.databricks_genie_canonical import (
     _canonical_itm_zip_scope,
     _canonical_listed_purchase_scope,
     _canonical_msa_score_scope,
+    _canonical_segment_performance_rescue_scope,
     _canonical_specific_top_borrowers_global_scope,
     _canonical_specific_top_borrowers_state_scope,
     _canonical_top_borrowers_all_segments_scope,
@@ -2024,6 +2026,71 @@ def _canonical_genie_answer(
             visualization=visualization,
             actions=actions,
             table_rows=rows,
+        )
+
+    if _canonical_segment_performance_rescue_scope(question):
+        # RESCUE ONLY. Genie has already failed to return trusted SQL for this
+        # turn, so the choice here is this statement or a refusal -- not this
+        # statement or a live answer. See
+        # ``_canonical_segment_performance_rescue_scope``.
+        try:
+            rows = sql_client.execute(_CANONICAL_SEGMENT_APPROVAL_RATE_SQL)
+        except DatabricksSqlError as exc:
+            _emit_genie_warning("canonical_genie_segment_performance_failed", exc=exc)
+            return None
+        rows = _redact_genie_rows(rows) or []
+        segment_asset = qualify("semantics", "segment_performance_metric_view")
+        trusted_assets = [segment_asset]
+        question_hash = _genie_question_hash(question)
+        proof = _build_genie_proof(
+            sql_query=_CANONICAL_SEGMENT_APPROVAL_RATE_SQL,
+            trusted_assets=trusted_assets,
+            rows=rows,
+            question=question,
+            conversation_id=result.conversation_id,
+            message_id=result.message_id,
+            elapsed_ms=result.elapsed_ms,
+        )
+        visualization = _plan_genie_visualization(question, rows)
+        actions = _suggest_genie_actions(
+            question=question,
+            rows=rows,
+            trusted_assets=trusted_assets,
+            visualization=visualization,
+            conversation_id=result.conversation_id,
+            message_id=result.message_id,
+            question_hash=question_hash,
+            sql_query=_CANONICAL_SEGMENT_APPROVAL_RATE_SQL,
+            source="trusted_sql",
+        )
+        if rows:
+            answer = (
+                "I compared every segment side by side from "
+                f"{segment_asset}: approval rate, outreach rate, borrower count and "
+                "average opportunity score, ordered by approval rate. Approval and "
+                "outreach rates are governed campaign outcomes, so a segment with no "
+                "completed campaigns shows a rate of zero rather than a missing row."
+            )
+        else:
+            answer = (
+                f"The governed segment performance view returned no rows from {segment_asset} "
+                "for the current refreshed coverage, so there is no segment comparison to show."
+            )
+        return GenieMessageResponse(
+            conversation_id=result.conversation_id,
+            message_id=result.message_id,
+            elapsed_ms=result.elapsed_ms,
+            question_hash=question_hash,
+            question=question,
+            answer=answer,
+            source="trusted_sql",
+            trusted_assets=trusted_assets,
+            sql_query=_CANONICAL_SEGMENT_APPROVAL_RATE_SQL,
+            row_count=len(rows),
+            table_rows=rows,
+            proof=proof,
+            visualization=visualization,
+            actions=actions,
         )
 
     scope = _canonical_in_the_money_count_scope(question)

--- a/backend/services/repositories/databricks_genie_actions.py
+++ b/backend/services/repositories/databricks_genie_actions.py
@@ -474,12 +474,16 @@ def _route_from_answer_rows(
     zips = _row_values(rows, "zip", "zip_code", "zipcode", "postal_code", digits=5)
     counties = _row_values(rows, "county_fips_5", "county_fips", "fips_5", "fips", digits=5)
     states = _row_values(rows, "state", "state_code", upper=True)
-    if (
-        states
-        and re.search(r"\bwhich\s+state\b|\bwhat\s+state\b", question.lower())
-        and _actionable_total_from_rows(rows) is None
-    ):
-        states = states[:1]
+    # The rows the answer returned ARE the answer's geography. A reader that
+    # kept only the first one when the QUESTION said "which state" was the last
+    # wording-gated narrowing left in this function, and it failed the same way
+    # its siblings did: live on paychex 2026-08-11, "Which state should we
+    # prioritize next quarter and why?" was answered over six state rows and
+    # recommended CA AND IL in the narrative, while the cohort silently opened
+    # CA alone. Prose cannot tell a superlative apart from a ranking -- an
+    # answer that ranks six states to argue for two still starts with "which
+    # state". When Genie really does mean one state it returns one row, and
+    # that single row narrows the cohort by itself.
     reading = read_sql_filters(sql_query)
     # Segments come from the ANSWER'S OWN conjuncts, never from the question's
     # wording: see ``_segment_selection_from_sql``.

--- a/backend/services/repositories/databricks_genie_canonical.py
+++ b/backend/services/repositories/databricks_genie_canonical.py
@@ -2849,6 +2849,178 @@ def _canonical_segment_approval_rate_scope(question: str) -> bool:
     )
 
 
+# Columns `mip.semantics.segment_performance_metric_view` actually carries, in
+# the words a user reaches for. The view is one row per segment with
+# approval_rate, outreach_rate, count and avg_score, so it answers the whole
+# "compare our segments" family from a single statement.
+_SEGMENT_PERFORMANCE_METRIC_TERMS = (
+    "approval",
+    "approve",
+    "convert",
+    "conversion",
+    "outreach",
+    "opportunity score",
+    "lead score",
+    # NOT "avg score": ``_normalized_question`` rewrites "avg" to "average"
+    # before this list is consulted, so that term could never match.
+    "average score",
+    "perform",
+    "response rate",
+    "win rate",
+    # The view carries `count AS segment_borrowers`, so size comparisons are
+    # answerable from the same statement.
+    "size",
+    "sizes",
+    "how many borrowers",
+    "borrower count",
+    "largest",
+    "smallest",
+)
+# Metrics the view does NOT carry. Naming one means the question belongs to a
+# different statement (rate spread has its own) or to Genie. Standing aside is
+# the whole point: answering a rate-spread question with approval-rate columns
+# would be a confident wrong answer, which is worse than no rescue.
+_SEGMENT_PERFORMANCE_FOREIGN_TERMS = (
+    "rate spread",
+    "spread",
+    "equity",
+    "ltv",
+    "balance",
+    "income",
+    "delinquen",
+    "days on market",
+    "permit",
+    "listing",
+)
+_SEGMENT_COMPARISON_TERMS = (
+    "which",
+    # NOT "what": it is the most common English question word, not a
+    # comparison. With it in the list, "What is the average opportunity score
+    # for the retention segment?" -- a question about ONE segment -- was served
+    # the whole-portfolio ranking of all six.
+    "highest",
+    "lowest",
+    "best",
+    "worst",
+    "top",
+    "rank",
+    "compare",
+    "comparison",
+    "versus",
+    " vs ",
+    "better",
+    "across",
+)
+
+# The statement this predicate serves is ONE ROW PER SEGMENT, nationally
+# (`WHERE state = '_ALL'`), at the current snapshot. It therefore cannot answer
+# a question that varies along any other axis, and the failure is silent: the
+# answer looks authoritative and is about a different population.
+#
+# Adversarial review 2026-08-11 measured all three, each of which turned a
+# refusal into a confidently wrong answer:
+#   * "Which segment performs best in California?"        -> national figures
+#   * "Show me the top 10 borrowers by lead score in each segment" -> 6 rows
+#   * "Which segment converted best last quarter?"        -> today's snapshot
+_SEGMENT_PERFORMANCE_OFF_AXIS_TERMS = (
+    # Geography — the view HAS a state dimension, but this statement pins
+    # `_ALL`. Standing aside is honest; scoping it is a separate change.
+    " in ca",
+    " in tx",
+    " in il",
+    " in fl",
+    " in wa",
+    " in co",
+    "state",
+    "states",
+    "city",
+    "cities",
+    "zip",
+    "county",
+    "market",
+    "markets",
+    "msa",
+    "metro",
+    "region",
+    "california",
+    "texas",
+    "illinois",
+    "florida",
+    "washington",
+    "colorado",
+    # Grain — one row per SEGMENT, never per borrower.
+    "borrower id",
+    "borrowers by",
+    "top 10 borrowers",
+    "top 20 borrowers",
+    "top 5 borrowers",
+    "each borrower",
+    "individual borrower",
+    "list borrowers",
+    "show me borrowers",
+    "which borrowers",
+    # Time — the view is the current snapshot, with no period selector.
+    "last quarter",
+    "last month",
+    "last year",
+    "this quarter",
+    "this month",
+    "year over year",
+    "yoy",
+    "trend",
+    "over time",
+    "since",
+    "january",
+    "february",
+    "march",
+    "april",
+    " may ",
+    "june",
+    "july",
+    "august",
+    "september",
+    "october",
+    "november",
+    "december",
+)
+
+
+def _canonical_segment_performance_rescue_scope(question: str) -> bool:
+    """Comparative "how do our segments stack up" questions, for RESCUE ONLY.
+
+    Deliberately broader than ``_canonical_segment_approval_rate_scope`` and
+    deliberately NOT wired into ``direct_canonical_response``. The direct path
+    PREEMPTS the live Genie turn, and the live-first doctrine reserves that for
+    narrow count prompts -- overlaying a good live turn is prohibited. This
+    predicate runs only after Genie has already failed to return trusted SQL,
+    where the alternative is not a live answer but a refusal.
+
+    Measured live on paychex 2026-08-11: "Which segment converts best: HELOC,
+    cash-out, or retention?" returned `sql_query: null` from Genie, so the app
+    refused -- while `_CANONICAL_SEGMENT_APPROVAL_RATE_SQL` had the answer the
+    whole time. The old matcher required the literal words "approval rate"; the
+    user said "converts best".
+
+    Strict on the METRIC, loose on the PHRASING: the view's columns are a
+    closed set, so a question naming a metric it does not carry gets no rescue
+    rather than a confidently wrong one.
+    """
+
+    q = _normalized_question(question)
+    if "segment" not in q:
+        return False
+    if any(term in q for term in _SEGMENT_PERFORMANCE_FOREIGN_TERMS):
+        return False
+    # Metric is only one of four axes. The statement is national, per-segment
+    # and current, so a question that moves along geography, grain or time is
+    # asking something this rescue cannot answer.
+    if any(term in f" {q} " for term in _SEGMENT_PERFORMANCE_OFF_AXIS_TERMS):
+        return False
+    return any(term in q for term in _SEGMENT_PERFORMANCE_METRIC_TERMS) and any(
+        term in q for term in _SEGMENT_COMPARISON_TERMS
+    )
+
+
 def _canonical_mean_lead_score_by_state_scope(question: str) -> bool:
     q = _normalized_question(question)
     return (

--- a/frontend/src/components/mortgage/GenieAnswer.tsx
+++ b/frontend/src/components/mortgage/GenieAnswer.tsx
@@ -36,7 +36,7 @@ import {
   pickPlan,
 } from './GenieAnswer.logic';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
-import { genieCellHref } from '../../lib/genieCellLinks';
+import { answerCohortFromActions, genieCellHref } from '../../lib/genieCellLinks';
 
 export { stripQuestionRestatement } from './GenieAnswer.markdown';
 export { inferChartFromRows } from './GenieAnswer.logic';
@@ -99,6 +99,9 @@ export function GenieAnswer({
   const visibleRows = rows.slice(0, MAX_TABLE_ROWS);
   const hiddenRows = Math.max(0, rows.length - MAX_TABLE_ROWS);
   const columns = visibleRows[0] ? Object.keys(visibleRows[0]).slice(0, MAX_TABLE_COLS) : [];
+  // The answer's own filters, so a row link opens the population the row
+  // reports rather than every borrower in that geography.
+  const cellCohort = answerCohortFromActions(actions);
   const chartColumns = rows[0] ? Object.keys(rows[0]) : [];
   const cleanedAnswer = answer ? normalizeGenieAnswerLanguage(stripQuestionRestatement(answer)) : '';
   const isGenieApiAnswer = payload.source === 'genie';
@@ -347,7 +350,7 @@ export function GenieAnswer({
                         // geography map navigates to on a state click.
                         // Everything else (including city — no route filters
                         // by city) renders as plain text.
-                        const href = genieCellHref(c, v);
+                        const href = genieCellHref(c, v, cellCohort, row);
                         return (
                           <td key={c} className={isNum ? 'num' : undefined}>
                             {href ? (

--- a/frontend/src/lib/genieCellLinks.test.ts
+++ b/frontend/src/lib/genieCellLinks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { borrower360Path, genieCellHref, isMaskedBorrowerId, stateLeadQueuePath } from './genieCellLinks';
+import { answerCohortFromActions, borrower360Path, genieCellHref, isMaskedBorrowerId, stateLeadQueuePath } from './genieCellLinks';
 
 const BORROWER = 'B-7K2M9QX4TB3PZ';
 
@@ -61,5 +61,166 @@ describe('path builders', () => {
 
   it('upper-cases the state before building the queue path', () => {
     expect(stateLeadQueuePath(' ca ')).toBe('/lead-queue?state=CA');
+  });
+});
+
+// --- A row link must open the population the ROW reports ------------------
+//
+// Measured live on paychex 2026-08-11: the answer to "Which states have the
+// highest average opportunity score among in-the-money borrowers?" rendered a
+// row reading "WA — 5,847 in-the-money borrowers" whose link was
+// `/lead-queue?state=WA` — all 31,114 contactable WA borrowers, ~5x the row,
+// with no disclosure. The governed action next to it carried the right cohort
+// the whole time; only the table cell dropped it.
+
+describe('answer-scoped row links', () => {
+  const itmAction = {
+    action_type: 'open_cohort',
+    criteria: {
+      result_filters: {
+        states: ['WA', 'TX', 'CA'],
+        segment_codes: ['itm'],
+        segment_mode: 'any',
+      },
+    },
+  };
+
+  it('carries the answer segment onto the row state link', () => {
+    const cohort = answerCohortFromActions([itmAction]);
+    const href = genieCellHref('state', 'WA', cohort);
+    expect(href).toContain('state=WA');
+    expect(href).toContain('segment=itm');
+  });
+
+  it('scopes the link to the ROW state, never the answer whole state list', () => {
+    const cohort = answerCohortFromActions([itmAction]);
+    const href = genieCellHref('state', 'WA', cohort) ?? '';
+    expect(href).not.toContain('TX');
+    expect(href).not.toContain('CA');
+    expect(href).not.toContain('states=');
+  });
+
+  it('carries a numeric floor and a portfolio criterion', () => {
+    const cohort = answerCohortFromActions([{
+      action_type: 'open_cohort',
+      criteria: {
+        result_filters: {
+          min_opportunity_score: 75,
+          portfolio_criteria: { occupancy: 'Owner-occupied' },
+        },
+      },
+    }]);
+    const href = genieCellHref('state', 'IL', cohort) ?? '';
+    expect(href).toContain('min_opportunity_score=75');
+    expect(href).toContain('occupancy=Owner-occupied');
+  });
+
+  it('emits segment_codes + mode when the answer covered several segments', () => {
+    const cohort = answerCohortFromActions([{
+      action_type: 'open_cohort',
+      criteria: { result_filters: { segment_codes: ['itm', 'equity'], segment_mode: 'all' } },
+    }]);
+    const href = genieCellHref('state', 'IL', cohort) ?? '';
+    expect(href).toContain('segment_codes=itm%2Cequity');
+    expect(href).toContain('segment_mode=all');
+  });
+
+  it('falls back to geography alone when the answer has no governed cohort', () => {
+    expect(answerCohortFromActions([])).toEqual({});
+    expect(answerCohortFromActions(null)).toEqual({});
+    expect(genieCellHref('state', 'WA', {})).toBe('/lead-queue?state=WA');
+  });
+
+  it('ignores non-cohort actions when reading the answer filters', () => {
+    const cohort = answerCohortFromActions([
+      { action_type: 'save_borrowers', criteria: { result_filters: { segment_codes: ['listed'] } } },
+    ]);
+    expect(cohort).toEqual({});
+  });
+
+  it('does not link a borrower id through the cohort path', () => {
+    const cohort = answerCohortFromActions([itmAction]);
+    expect(genieCellHref('borrower_id', 'B-102FL7THC6Q3L', cohort))
+      .toBe('/borrower-360/B-102FL7THC6Q3L');
+  });
+});
+
+// --- A segment comparison must be actionable per row ----------------------
+//
+// Live sweep 2026-08-11: 14 of 23 questions answered with trusted SQL and
+// offered NO governed action, because a `GROUP BY segment_code` answer has no
+// single cohort — correctly, since the answer spans every segment. That left
+// "which segment converts best" as a ranking the reader could not act on.
+// The row IS the cohort: each row of a segment breakdown is one segment.
+
+describe('segment row links', () => {
+  it('links a segment_code cell to that segment queue', () => {
+    expect(genieCellHref('segment_code', 'itm')).toBe('/lead-queue?segment=itm');
+  });
+
+  it('accepts the S1.3 overlay codes the queue can filter on', () => {
+    expect(genieCellHref('segment_code', 'second_lien_itm'))
+      .toBe('/lead-queue?segment=second_lien_itm');
+  });
+
+  it('does not link a segment the queue cannot filter on', () => {
+    // The live metric view spells conversion segments differently from
+    // borrower_360 (`heloc`, `cash_out`); a link that silently drops the
+    // filter is the failure this whole module guards against.
+    expect(genieCellHref('segment_code', 'heloc')).toBeNull();
+    expect(genieCellHref('segment_code', 'cash_out')).toBeNull();
+    expect(genieCellHref('segment_code', '')).toBeNull();
+    expect(genieCellHref('segment_code', 42)).toBeNull();
+  });
+
+  it('carries the answer portfolio criteria but never its segment list', () => {
+    const cohort = answerCohortFromActions([{
+      action_type: 'open_cohort',
+      criteria: {
+        result_filters: {
+          segment_codes: ['listed'],
+          min_equity_pct: 35,
+        },
+      },
+    }]);
+    const href = genieCellHref('segment_code', 'itm', cohort) ?? '';
+    // The ROW's segment wins — the answer's own segment list would contradict it.
+    expect(href).toContain('segment=itm');
+    expect(href).not.toContain('listed');
+    expect(href).toContain('min_equity_pct=35');
+  });
+});
+
+// A `state, segment_code, borrowers` row reports the INTERSECTION. Adversarial
+// review 2026-08-11: the segment cell opened that segment NATIONALLY, turning
+// "WA — itm — 5,847" into every in-the-money borrower in the country.
+describe('segment links on a row that also carries geography', () => {
+  const row = { state: 'WA', segment_code: 'itm', borrowers: 5847 };
+
+  it('carries the ROW state onto the segment link', () => {
+    const href = genieCellHref('segment_code', 'itm', {}, row) ?? '';
+    expect(href).toContain('state=WA');
+    expect(href).toContain('segment=itm');
+  });
+
+  it('still opens nationally when the row has no geography', () => {
+    expect(genieCellHref('segment_code', 'itm', {}, { segment_code: 'itm', approval_rate: 0.1 }))
+      .toBe('/lead-queue?segment=itm');
+  });
+
+  it('ignores a row whose state is not a usable code', () => {
+    expect(genieCellHref('segment_code', 'itm', {}, { state: '_ALL', segment_code: 'itm' }))
+      .toBe('/lead-queue?segment=itm');
+  });
+
+  it('takes the row state, never the answer-wide state list', () => {
+    const cohort = answerCohortFromActions([{
+      action_type: 'open_cohort',
+      criteria: { result_filters: { states: ['WA', 'TX', 'CA'], segment_codes: ['itm'] } },
+    }]);
+    const href = genieCellHref('segment_code', 'itm', cohort, row) ?? '';
+    expect(href).toContain('state=WA');
+    expect(href).not.toContain('TX');
+    expect(href).not.toContain('CA');
   });
 });

--- a/frontend/src/lib/genieCellLinks.ts
+++ b/frontend/src/lib/genieCellLinks.ts
@@ -27,6 +27,21 @@ const BORROWER_ID_COLUMNS = new Set(['borrower_id']);
 /** Columns whose values address a state. */
 const STATE_COLUMNS = new Set(['state', 'state_code']);
 
+/** Columns whose values address a segment. */
+const SEGMENT_COLUMNS = new Set(['segment_code', 'segment']);
+
+/**
+ * The segments the Lead Queue can filter on, mirroring `SegmentCode` in
+ * `backend/schemas/lead.py`. A value outside this set gets no link rather than
+ * a queue that silently ignores the parameter.
+ */
+const LINKABLE_SEGMENT_CODES = new Set([
+  'itm', 'listed', 'permit', 'investor', 'equity', 'retention',
+  'second_lien_itm', 'heloc_draw_to_payback', 'home_equity_history',
+  'refi_propensity', 'itm_on_related_property', 'payoff_loss_leads',
+  'permit_activity',
+]);
+
 export function isMaskedBorrowerId(value: unknown): value is string {
   return typeof value === 'string' && MASKED_BORROWER_ID_RE.test(value.trim());
 }
@@ -41,28 +56,146 @@ export function borrower360Path(borrowerId: string): string {
 }
 
 /**
+ * The answer's own non-geographic filters, as read from the governed action's
+ * `criteria.result_filters` (the backend derives them from the answer's SQL in
+ * `_route_from_answer_rows`).
+ *
+ * Geography is deliberately excluded: a row link is scoped to THAT row's
+ * state, not to every state the answer covered.
+ */
+export interface GenieAnswerCohort {
+  segmentFilter?: string[];
+  segmentFilterMode?: 'any' | 'all';
+  portfolioCriteria?: Record<string, string | number>;
+}
+
+const REPLAYABLE_NUMERIC_FILTERS = [
+  'min_opportunity_score',
+  'min_equity_pct',
+  'min_rate_spread_bps',
+] as const;
+
+/**
+ * Lift the answer's replayable filters off its `open_cohort` action.
+ *
+ * Returns `{}` when the answer has no governed cohort — in which case a row
+ * link carries geography alone, exactly as before.
+ */
+export function answerCohortFromActions(
+  actions: readonly { action_type?: string; criteria?: Record<string, unknown> | null }[] | null
+    | undefined,
+): GenieAnswerCohort {
+  const action = (actions ?? []).find((a) => a.action_type === 'open_cohort');
+  const raw = action?.criteria?.result_filters;
+  const filters = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : null;
+  if (!filters) return {};
+  const cohort: GenieAnswerCohort = {};
+  const segments = Array.isArray(filters.segment_codes)
+    ? filters.segment_codes.filter((s): s is string => typeof s === 'string')
+    : [];
+  if (segments.length > 0) {
+    cohort.segmentFilter = segments;
+    cohort.segmentFilterMode = filters.segment_mode === 'all' ? 'all' : 'any';
+  }
+  const criteria: Record<string, string | number> = {};
+  const portfolio = filters.portfolio_criteria;
+  if (portfolio && typeof portfolio === 'object') {
+    Object.entries(portfolio as Record<string, unknown>).forEach(([key, value]) => {
+      if (typeof value === 'string' && value !== '') criteria[key] = value;
+    });
+  }
+  REPLAYABLE_NUMERIC_FILTERS.forEach((key) => {
+    const value = filters[key];
+    if (typeof value === 'number' && Number.isFinite(value)) criteria[key] = value;
+  });
+  if (Object.keys(criteria).length > 0) cohort.portfolioCriteria = criteria;
+  return cohort;
+}
+
+/**
  * State-filtered Lead Queue link. Reuses `buildLeadQueuePath`, the exact
  * helper the geography drill-down map calls on a state click
  * (`USChoroplethMap.tsx` → `navigate(leadQueuePath({ state }))`), so a Genie
  * answer and the map land on an identically-filtered queue.
+ *
+ * `cohort` carries the ANSWER'S own filters so the link opens the population
+ * the row actually reports. Without it the link dropped every non-geographic
+ * filter: measured live on paychex 2026-08-11, a row reading "WA — 5,847
+ * in-the-money borrowers" linked to `/lead-queue?state=WA`, which opens all
+ * 31,114 contactable WA borrowers. That is the same silent divergence the
+ * cohort handoff was fixed for, on a surface nobody had checked.
  */
-export function stateLeadQueuePath(state: string): string {
-  return buildLeadQueuePath({ geo: { state: state.trim().toUpperCase() } });
+export function stateLeadQueuePath(state: string, cohort: GenieAnswerCohort = {}): string {
+  return buildLeadQueuePath({
+    geo: { state: state.trim().toUpperCase() },
+    segmentFilter: cohort.segmentFilter,
+    segmentFilterMode: cohort.segmentFilterMode ?? 'any',
+    portfolioCriteria: cohort.portfolioCriteria,
+  });
+}
+
+export function isLinkableSegmentCode(value: unknown): value is string {
+  return typeof value === 'string' && LINKABLE_SEGMENT_CODES.has(value.trim().toLowerCase());
+}
+
+/**
+ * Segment-filtered Lead Queue link for a row of a segment COMPARISON.
+ *
+ * A "which segment converts best" answer groups by segment, so it has no
+ * single cohort and correctly gets no governed cohort action — but that left
+ * the reader with a ranking they could not act on. Measured live on paychex
+ * 2026-08-11: 14 of 23 swept questions answered with trusted SQL and offered
+ * nothing to click, breaking the product flow at the "recommend" step.
+ *
+ * The row itself is the missing cohort. Each row of a segment breakdown IS one
+ * segment, so linking the row to that segment's queue is a statement the
+ * answer already made, not an inference about it. The answer's other filters
+ * ride along for the same reason they do on a state row.
+ */
+export function segmentLeadQueuePath(
+  segment: string,
+  cohort: GenieAnswerCohort = {},
+  row?: Record<string, unknown> | null,
+): string {
+  // A `state, segment_code, borrowers` row reports the INTERSECTION, so the
+  // segment cell has to carry the row's own state or it opens that segment
+  // nationwide — 5,847 WA in-the-money borrowers becoming every in-the-money
+  // borrower in the country (adversarial review 2026-08-11). The state comes
+  // from the row, never from the answer's overall state list, for the same
+  // reason the state cell's link does not carry the answer's other states.
+  const rowState = row
+    ? Object.entries(row).find(([key]) => STATE_COLUMNS.has(key.trim().toLowerCase()))?.[1]
+    : undefined;
+  return buildLeadQueuePath({
+    geo: isStateCode(rowState) ? { state: (rowState as string).trim().toUpperCase() } : {},
+    segmentFilter: [segment.trim().toLowerCase()],
+    segmentFilterMode: 'any',
+    portfolioCriteria: cohort.portfolioCriteria,
+  });
 }
 
 /**
  * Resolve a table cell to an in-app route, or null when it should render as
  * plain text. `city` intentionally returns null: no route in `app.tsx`
  * supports a city filter (`lead-queue.filters.ts` has no city param), and a
- * link that silently drops the filter misleads the reader.
+ * link that silently drops the filter misleads the reader — which is exactly
+ * why `cohort` exists for the state case.
  */
-export function genieCellHref(column: string, value: unknown): string | null {
+export function genieCellHref(
+  column: string,
+  value: unknown,
+  cohort: GenieAnswerCohort = {},
+  row?: Record<string, unknown> | null,
+): string | null {
   const key = column.trim().toLowerCase();
   if (BORROWER_ID_COLUMNS.has(key) && isMaskedBorrowerId(value)) {
     return borrower360Path(value as string);
   }
   if (STATE_COLUMNS.has(key) && isStateCode(value)) {
-    return stateLeadQueuePath(value as string);
+    return stateLeadQueuePath(value as string, cohort);
+  }
+  if (SEGMENT_COLUMNS.has(key) && isLinkableSegmentCode(value)) {
+    return segmentLeadQueuePath(value as string, cohort, row);
   }
   return null;
 }

--- a/tests/unit/test_genie_no_refusal_battery.py
+++ b/tests/unit/test_genie_no_refusal_battery.py
@@ -177,3 +177,80 @@ def test_flagship_trusted_turn_is_live_first_with_cross_check() -> None:
     assert any(
         "Governed cross-check" in step.content for step in result.reasoning_trace
     )
+
+
+# --- An aggregate qualifier describes a reviewed attribute; it is not a new
+# --- selection criterion -----------------------------------------------------
+#
+# Live on paychex 2026-08-11, "Rank our segments by average rate spread." was
+# refused as `unreviewed_criterion` in ~1s, before any repository call, while
+# `_canonical_mean_rate_spread_by_segment_scope` already matched that exact
+# string and its canonical SQL sat unreachable behind the refusal.
+#
+# Root cause was an asymmetry in `REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT`:
+# `average|mean` was admitted on the opportunity/lead-score alternative and
+# nowhere else, so the same aggregate flipped every OTHER reviewed attribute to
+# unreviewed. The fix hoists the qualifier to the front of the fragment.
+
+_AGGREGATE_QUALIFIERS = ("", "average ", "avg ", "mean ", "median ", "high ", "highest ", "top ")
+_REVIEWED_ATTRIBUTES = (
+    "rate spread",
+    "home equity",
+    "equity percentage",
+    "LTV",
+    "loan balance",
+    "property value",
+    "opportunity score",
+    "lead score",
+)
+# Attributes that are NOT reviewed Module 0 vocabulary, and one protected class.
+# An aggregate must not launder any of them into the reviewed set.
+_UNREVIEWED_ATTRIBUTES = (
+    "credit score",
+    "FICO",
+    "household income",
+    "net worth",
+    "employment length",
+    "citizenship",
+    "marital status",
+    "age",
+    "race",
+    "religion",
+)
+
+
+@pytest.mark.parametrize("attribute", _REVIEWED_ATTRIBUTES)
+@pytest.mark.parametrize("qualifier", _AGGREGATE_QUALIFIERS)
+def test_an_aggregate_over_a_reviewed_attribute_is_answerable(
+    qualifier: str, attribute: str
+) -> None:
+    question = f"Rank our segments by {qualifier}{attribute}."
+    assert protected_prompt_match(question) is None, question
+
+
+@pytest.mark.parametrize("attribute", _UNREVIEWED_ATTRIBUTES)
+@pytest.mark.parametrize("qualifier", _AGGREGATE_QUALIFIERS)
+def test_aggregate_qualifiers_never_admit_an_unreviewed_attribute(
+    qualifier: str, attribute: str
+) -> None:
+    """The fail-closed default must be exactly as strong as before the fix.
+
+    This is the test `REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT`'s comment points
+    at. It is the whole safety argument for hoisting the qualifier: the
+    attribute alternation is untouched, so an unreviewed attribute stays
+    unreviewed with or without an aggregate in front of it.
+    """
+
+    question = f"Rank our segments by {qualifier}{attribute}."
+    assert protected_prompt_match(question) is not None, question
+
+
+def test_an_aggregate_cannot_launder_an_unreviewed_attribute_through_a_reviewed_one() -> None:
+    """Chaining a reviewed attribute must not carry an unreviewed one with it."""
+
+    for question in (
+        "Select borrowers with home equity and credit score.",
+        "Rank our segments by average rate spread and household income.",
+        "Rank our segments by average home equity and race.",
+    ):
+        assert protected_prompt_match(question) is not None, question

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -718,7 +718,25 @@ def test_cash_out_question_routes_to_offer_filter_not_equity_segment() -> None:
     }
 
 
-def test_singular_state_ranked_question_routes_to_top_state_only() -> None:
+def test_a_ranked_state_answer_opens_every_state_row_it_returned() -> None:
+    """The ROWS are the answer's geography, not the question's grammar.
+
+    This used to keep only the first row whenever the question matched "which
+    state". The wording cannot tell a superlative from a ranking: this question
+    asks for "the most" and its narrative names Illinois, while
+    "Which state should we prioritize next quarter and why?" ranks six states
+    to argue for two. Both start with "which state".
+
+    Live on paychex 2026-08-11, the second shape was answered over six state
+    rows recommending CA AND IL while the cohort silently opened CA alone —
+    the narrowing, invisible direction. Reading the rows instead errs broad
+    (this cohort opens the three states the table shows rather than the one the
+    prose highlights), which `X-Cohort-Count-Delta` surfaces. When Genie
+    really does mean one state it returns one row and the cohort is one state:
+    `test_cash_out_question_routes_to_offer_filter_not_equity_segment` above
+    still pins that, with the same question and a `LIMIT 1` statement.
+    """
+
     live = GenieResponse(
         answer_text="Illinois has the most cash-out borrowers.",
         sql_query=(
@@ -741,9 +759,9 @@ def test_singular_state_ranked_question_routes_to_top_state_only() -> None:
     result = repo.respond("Which state has the most cash-out opportunity right now?")
     action = next(row for row in result.actions if row.id == "open-cohort")
 
-    assert action.route == "/lead-queue?states=IL&product=Cash-out"
+    assert action.route == "/lead-queue?states=IL%2CCA%2CFL&product=Cash-out"
     assert action.criteria["result_filters"] == {
-        "states": ["IL"],
+        "states": ["IL", "CA", "FL"],
         "portfolio_criteria": {"product": "Cash-out"},
     }
 
@@ -4064,3 +4082,141 @@ def test_contradiction_detector_zero_claim_and_identifier_guard() -> None:
         "Borrowers with equity >= 35% qualify; 0.5% margin applies.", "122598"
     )
     assert contradicted is False
+
+
+# --- Comparative segment questions get rescued, not refused ----------------
+#
+# Measured live on paychex 2026-08-11: "Which segment converts best: HELOC,
+# cash-out, or retention?" came back from Genie with `sql_query: null`, so the
+# app refused with `source: policy_blocked` — while
+# `_CANONICAL_SEGMENT_APPROVAL_RATE_SQL` had the comparison the whole time.
+# The matcher required the literal words "approval rate"; the user said
+# "converts best".
+#
+# The rescue is deliberately NOT wired into `direct_canonical_response`, which
+# PREEMPTS the live turn. It fires only after Genie has already failed, where
+# the alternative is a refusal rather than a live answer.
+
+_SEGMENT_PERF_ROWS = [
+    {
+        "segment_code": "retention",
+        "name": "Retention Risk",
+        "segment_borrowers": 19166,
+        "approval_rate": 0.0,
+        "outreach_rate": 0.0,
+        "avg_score": 54.2,
+        "refreshed_at": "2026-08-09T16:56:59Z",
+    },
+    {
+        "segment_code": "itm",
+        "name": "Prime Refi Candidates",
+        "segment_borrowers": 74357,
+        "approval_rate": 0.12,
+        "outreach_rate": 0.31,
+        "avg_score": 61.8,
+        "refreshed_at": "2026-08-09T16:56:59Z",
+    },
+]
+
+
+def _text_only_turn(question_id: str) -> GenieResponse:
+    """A live turn that produced prose but no SQL — the rescue trigger."""
+    return GenieResponse(
+        answer_text="Retention looks strongest.",
+        sql_query=None,
+        sql_result_rows=[],
+        conversation_id=f"conv-{question_id}",
+        message_id=f"msg-{question_id}",
+    )
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        "Which segment converts best: HELOC, cash-out, or retention?",
+        "Which borrower segment has the highest approval rate?",
+        "Compare approval rates across all segments.",
+        "Which segment has the best average opportunity score?",
+        "Which segment performs best?",
+    ],
+)
+def test_comparative_segment_questions_are_rescued_not_refused(question: str) -> None:
+    sql = _StubSqlClient(list(_SEGMENT_PERF_ROWS))
+
+    result = _adapt_genie_response(
+        question,
+        _text_only_turn("seg-perf"),
+        sql_client=sql,  # type: ignore[arg-type]
+    )
+
+    assert result.source == "trusted_sql", question
+    assert result.source != "policy_blocked", question
+    assert result.trusted_assets == ["mip.semantics.segment_performance_metric_view"]
+    assert result.proof is not None and result.proof.trusted is True
+    assert "segment_performance_metric_view" in (result.sql_query or "")
+    assert result.row_count == len(_SEGMENT_PERF_ROWS)
+    # The comparison itself has to reach the reader, not just a citation.
+    assert result.table_rows == _SEGMENT_PERF_ROWS
+
+
+@pytest.mark.parametrize(
+    ("question", "why"),
+    [
+        (
+            "Rank our segments by average rate spread.",
+            "rate spread is not a column of the segment performance view",
+        ),
+        (
+            "Which segment has the most equity?",
+            "equity is not a column of the view either",
+        ),
+        (
+            "Which state has the highest approval rate?",
+            "a state comparison is not a segment comparison",
+        ),
+    ],
+)
+def test_the_segment_rescue_stands_aside_for_metrics_it_does_not_carry(
+    question: str, why: str
+) -> None:
+    """A confidently wrong answer is worse than no rescue."""
+
+    sql = _StubSqlClient(list(_SEGMENT_PERF_ROWS))
+
+    result = _adapt_genie_response(
+        question,
+        _text_only_turn("seg-foreign"),
+        sql_client=sql,  # type: ignore[arg-type]
+    )
+
+    assert "segment_performance_metric_view" not in (result.sql_query or ""), why
+
+
+def test_a_good_live_segment_turn_is_never_overwritten_by_the_rescue() -> None:
+    """Live-first: the rescue fires only where Genie produced no SQL proof.
+
+    Overlaying a trusted live turn is prohibited by the doctrine — the
+    deterministic layer rescues and cross-checks, it does not replace.
+    """
+
+    live_sql = (
+        "SELECT segment_code, approval_rate FROM mip.semantics.segment_performance_metric_view "
+        "WHERE state = '_ALL'"
+    )
+    live = GenieResponse(
+        answer_text="Retention leads on approval rate.",
+        sql_query=live_sql,
+        sql_result_rows=[{"segment_code": "retention", "approval_rate": 0.0}],
+        conversation_id="conv-live-seg",
+        message_id="msg-live-seg",
+    )
+    sql = _StubSqlClient(list(_SEGMENT_PERF_ROWS))
+
+    result = _adapt_genie_response(
+        "Which segment converts best: HELOC, cash-out, or retention?",
+        live,
+        sql_client=sql,  # type: ignore[arg-type]
+    )
+
+    assert result.sql_query == live_sql
+    assert result.table_rows == [{"segment_code": "retention", "approval_rate": 0.0}]


### PR DESCRIPTION
A live sweep of 23 questions against the deployed app found **only 4 fully clean** — across **four independent mechanisms**, not one bug. This fixes three at the root.

| Mechanism | Count | This PR |
|---|---|---|
| Comparison answers with no actionable cohort | 14 | fixed |
| Guard false-positive (`unreviewed_criterion`) | 1, deterministic | fixed |
| Cohort ≠ answer (wording-gated truncation) | 2 | fixed |
| Output-guard flakiness on model narrative | 2, intermittent | **not fixed** — needs the server-side `unsafe_field` log |

## 1 · A guard refused legitimate analytics

"Rank our segments by average rate spread." was refused as `unreviewed_criterion` in ~1s, before any repository call — while `_canonical_mean_rate_spread_by_segment_scope` already matched that exact string and its canonical SQL sat unreachable behind the refusal.

`average|mean` was admitted on the opportunity/lead-score alternative of `REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT` and nowhere else, so the same aggregate flipped **rate spread, home equity, LTV, loan balance and property value** to unreviewed. The qualifier is hoisted to the front; the attribute alternation is untouched.

`test_aggregate_qualifiers_never_admit_an_unreviewed_attribute` pins both directions and was **mutation-checked**: reverting the fix turns the reviewed-attribute half red while the fail-closed half stays green. `average credit score`, `highest household income`, `average age`, `median race` all still refuse.

## 2 · Comparative segment questions had no rescue

Genie returns no SQL for "Which segment converts best: HELOC, cash-out, or retention?", so the app refused — while `_CANONICAL_SEGMENT_APPROVAL_RATE_SQL` had the comparison all along. The old matcher required the literal words "approval rate".

The new predicate is wired **only** into the rescue path, never into `direct_canonical_response`, which preempts the live turn — live-first is preserved and the rescue fires only where the alternative is a refusal.

Adversarial review then found it strict on the metric axis and blind to the other three, each turning a refusal into a confidently **wrong** answer. The statement is national, per-segment and current, so it now stands aside on:
- **geography** — "Which segment performs best in California?" was served `WHERE state = '_ALL'`, national figures, undisclosed
- **borrower grain** — "top 10 borrowers by lead score in each segment" got a 6-row segment table
- **time** — "converted best last quarter" got today's snapshot

`what` is dropped as a comparison term (it swallowed single-segment questions), and the branch moved below `_canonical_msa_score_scope`, which it was shadowing.

## 3 · Comparisons were unactionable

A `GROUP BY segment` answer correctly has no single cohort, so 14 of 23 questions answered with trusted SQL and offered nothing to click — breaking the flow at **recommend**. The row *is* the cohort: segment cells link to that segment's queue, carrying the row's own state when the row reports an intersection (a `state, segment_code` row otherwise opened that segment nationwide).

## Plus: the last wording-gated narrowing

`_route_from_answer_rows` kept only the first state row when the question said "which state". Live: six state rows backing a recommendation of **CA and IL** opened CA alone. The rows the answer returned are the answer's geography. One test encoded the old behaviour and was re-baselined with its reasoning recorded — erring broad is visible via `X-Cohort-Count-Delta`; erring narrow is silent.

## Reverted rather than shipped half-right

I also drafted a fair-lending proxy tightening ("diverse neighborhoods" passes the guard today). Review showed it matched **across sentence boundaries** — "Our product set is diverse. Communities we serve are growing." would have written a fair-lending finding on benign prose — and it blocked the CRA self-audit questions a lender must ask ("Compare approval rates in underserved neighborhoods"). Since the canonical phrase "target minority neighborhoods" still passes anyway, shipping it would have implied coverage that isn't there. Reverted; filed as its own work.

## Verification

Local gate green: backend unit suite, `ruff`, `mypy` (251 files), file-size gate, eslint, **1,043** frontend tests, build.

Two adversarial subagent reviews. One finding is **not** actioned: it reported the row-link fix doesn't fix its own motivating case, using column `is_in_the_money` — which has **zero** occurrences in gold. With the real column `in_the_money` the case is fixed and carries `segment_codes: ['itm']`, verified directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)