### PR TITLE
fix(genie): a pending feed blocks the answer served, not the rescue

### DIFF
--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -532,17 +532,38 @@ def _adapt_genie_response(
         result.sql_query
         and _sql_uses_impossible_retention_conjunction(question, result.sql_query)
     )
+    # `depends_on_pending_feeds` is read off the LIVE turn's material -- the SQL
+    # Genie wrote and the rows it returned. It must block that answer, and it
+    # does, below. It must NOT veto the rescue, because the rescue serves a
+    # DIFFERENT statement: whether Genie's discarded SQL happened to mention a
+    # pending feed says nothing about whether the canonical one does.
+    #
+    # Measured live on paychex 2026-08-12: "Which segment converts best: HELOC,
+    # cash-out, or retention?" returns SQL referencing a permit column --
+    # unsurprising, since HELOC Intent IS the permit segment -- so the pending
+    # Building Permits feed set this flag and the rescue never ran. The
+    # canonical statement it would have served reads
+    # `mip.semantics.segment_performance_metric_view` and touches no permit
+    # column at all. The user got a refusal that cited a data gap irrelevant to
+    # the answer they could have had.
     canonical_rescue_eligible = (
         lacks_trusted_proof
         or (unsafe_live_sql and stale_evidence_enum_only)
         or semantically_broken_sql
-    ) and not depends_on_pending_feeds
+    )
     if canonical_rescue_eligible:
         canonical = _canonical_genie_answer(
             question=question,
             result=result,
             sql_client=sql_client,
         )
+        # The guarantee is preserved where it belongs: on the statement actually
+        # being served. A canonical statement that DOES depend on a pending feed
+        # is still refused.
+        if canonical is not None and _pending_feed_gaps_from_material(
+            canonical.sql_query or ""
+        ):
+            canonical = None
         if canonical is not None:
             # Governance (re-executed counts, trusted-asset policy, proof,
             # visualization, actions, scrubbing) is done. Restore Genie's own

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -4220,3 +4220,57 @@ def test_a_good_live_segment_turn_is_never_overwritten_by_the_rescue() -> None:
 
     assert result.sql_query == live_sql
     assert result.table_rows == [{"segment_code": "retention", "approval_rate": 0.0}]
+
+
+# --- A pending feed blocks the ANSWER SERVED, not the rescue --------------
+#
+# `depends_on_pending_feeds` is read off the LIVE turn's material. It must
+# block that answer -- and it does -- but it used to also veto the rescue,
+# which serves a DIFFERENT statement.
+#
+# Measured live on paychex 2026-08-12: "Which segment converts best: HELOC,
+# cash-out, or retention?" returns SQL referencing a permit column (HELOC
+# Intent IS the permit segment), so the pending Building Permits feed set the
+# flag and the rescue never ran. The canonical statement it would have served
+# reads the segment performance metric view and touches no permit column at
+# all, so the user got a refusal citing a data gap irrelevant to the answer
+# they could have had.
+
+
+def _permit_referencing_turn() -> GenieResponse:
+    return GenieResponse(
+        answer_text="Retention looks strongest.",
+        sql_query="SELECT segment_code FROM some_view WHERE has_permit = TRUE",
+        sql_result_rows=[],
+        conversation_id="conv-permit",
+        message_id="msg-permit",
+    )
+
+
+def test_a_pending_feed_in_genies_sql_does_not_veto_a_clean_rescue() -> None:
+    result = _adapt_genie_response(
+        "Which segment converts best: HELOC, cash-out, or retention?",
+        _permit_referencing_turn(),
+        sql_client=_StubSqlClient(list(_SEGMENT_PERF_ROWS)),  # type: ignore[arg-type]
+    )
+
+    assert result.source == "trusted_sql"
+    assert "segment_performance_metric_view" in (result.sql_query or "")
+
+
+def test_the_pending_feed_guarantee_still_binds_the_statement_actually_served() -> None:
+    """The guarantee moved, it did not weaken.
+
+    A canonical statement that itself depends on a pending feed must still be
+    refused, whatever the live turn looked like.
+    """
+
+    from backend.services.repositories import databricks_genie as module
+
+    assert module._pending_feed_gaps_from_material(
+        "SELECT clip FROM mip.gold.borrower_360 WHERE has_permit = TRUE"
+    )
+    # ...and the statement this rescue serves is clean, which is why it may run.
+    assert not module._pending_feed_gaps_from_material(
+        module._CANONICAL_SEGMENT_APPROVAL_RATE_SQL
+    )


### PR DESCRIPTION
`depends_on_pending_feeds` is read off the **live turn's** material — the SQL Genie wrote and the rows it returned. It correctly blocks that answer. It was also ANDed into `canonical_rescue_eligible`, which is wrong: the rescue serves a **different statement**, and whether Genie's discarded SQL happened to mention a pending feed says nothing about whether the canonical one does.

## Measured live

"Which segment converts best: HELOC, cash-out, or retention?" returns SQL referencing a permit column — HELOC Intent *is* the permit segment, so this is the normal shape, not an edge case. The pending Cotality Building Permits feed therefore set the flag and the rescue never ran.

The user got:

> Genie did not return trusted SQL and source assets… **Known data gap: Cotality Building Permits feed is pending.**

A refusal citing a gap irrelevant to the answer they could have had: `_CANONICAL_SEGMENT_APPROVAL_RATE_SQL` reads `mip.semantics.segment_performance_metric_view` and touches no permit column at all.

## The guarantee moves, it does not weaken

It now binds the statement **actually being served**, so a canonical statement that itself depends on a pending feed is still refused. Both directions are pinned by tests.

## How it was found

Worth recording, because **two wrong theories preceded it**:

- The app log carries **zero** `canonical_genie_*` events for these turns — ruling out every `except DatabricksSqlError` exit.
- `_retention_risk_question` is `False` — ruling out the branch that shadows on "retention".
- The corroborating detail was in the earlier sweep all along: across 23 live questions, **not one** ever returned `trusted_sql`.

The deciding test was reproducing the live *shape* — untrusted SQL that references a permit column — rather than the empty-row turn I had been testing, which never set the flag and so always passed. That is why my first "correction" to the user was itself wrong.

## Verification

Backend unit suite, `ruff`, `mypy` (251 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)