### PR TITLE
fix(genie): the rescue's last silent exit now says why it declined

### DIFF
--- a/backend/services/repositories/databricks_genie.py
+++ b/backend/services/repositories/databricks_genie.py
@@ -1224,6 +1224,11 @@ def _canonical_genie_answer(
     cannot mask a policy failure.
     """
     if sql_client is None:
+        # The ONLY exit in this function that says nothing. Every other one
+        # emits a warning, so a rescue that silently declines is invisible in
+        # the logs and indistinguishable from "no canonical statement matched"
+        # -- which cost two wrong diagnoses of a live refusal (2026-08-12).
+        _emit_genie_warning("canonical_genie_no_sql_client")
         return None
     borrower_asset = qualify("gold", "borrower_360")
     lead_population_asset = qualify("gold", "lead_population")

--- a/tests/unit/test_genie_repository.py
+++ b/tests/unit/test_genie_repository.py
@@ -4274,3 +4274,28 @@ def test_the_pending_feed_guarantee_still_binds_the_statement_actually_served() 
     assert not module._pending_feed_gaps_from_material(
         module._CANONICAL_SEGMENT_APPROVAL_RATE_SQL
     )
+
+
+def test_a_rescue_declined_for_want_of_a_sql_client_is_not_silent() -> None:
+    """Every other exit in `_canonical_genie_answer` emits a warning.
+
+    This one did not, so a rescue that declined because it had no warehouse
+    was indistinguishable in the logs from "no canonical statement matched".
+    That ambiguity cost two wrong diagnoses of a live refusal on 2026-08-12.
+    """
+
+    from unittest.mock import patch
+
+    from backend.services.repositories import databricks_genie as module
+
+    with patch.object(module, "_emit_genie_warning") as warn:
+        assert (
+            module._canonical_genie_answer(
+                question="Which segment converts best?",
+                result=_text_only_turn("no-sql-client"),
+                sql_client=None,
+            )
+            is None
+        )
+    assert warn.call_args is not None
+    assert warn.call_args[0][0] == "canonical_genie_no_sql_client"


### PR DESCRIPTION
`_canonical_genie_answer` emits a warning on every exit **but one**: when it has no SQL client it returns `None` saying nothing. A rescue that declined for want of a warehouse is therefore indistinguishable in the logs from "no canonical statement matched for this question".

That ambiguity has now cost **two wrong diagnoses** of a single live refusal. What is established:

- the rescue predicate returns `True` for the live question
- both deployed modules hash-match local
- the app log carries **zero** `canonical_genie_*` events for those turns

Every remaining inference points at this exit — but inference is exactly what was wrong the first two times, so this makes the code answer instead of me.

Worth landing on its own merits regardless of what it turns out to be hiding: a governed rescue path that declines in silence is a defect. If it fires in dev, the entire deterministic rescue layer is dark in the deployed app, which would also explain why not one of 23 swept live questions ever returned `trusted_sql`.

Pinned by `test_a_rescue_declined_for_want_of_a_sql_client_is_not_silent`.

Gates: backend unit suite, `ruff`, `mypy` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)