### PR TITLE
feat(cohorts): a city-grain answer hands off the city, not the state

### DIFF
--- a/backend/api/leads.py
+++ b/backend/api/leads.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request,
 
 from backend.schemas._validators_tenant import normalize_public_lender_ref
 from backend.schemas.common import validate_internal_staff_email
+from backend.schemas.genie_geo_filters import GENIE_CITY_FILTER_KEY
 from backend.schemas.lead import SEGMENT_CODE_VALUES, LeadSummary
 from backend.schemas.lead_query import (
     DEFAULT_LEAD_LIMIT,
@@ -24,6 +25,7 @@ from backend.schemas.lead_query import (
     ApprovalStatusParam,
     AssignedToParam,
     BorrowerIdsParam,
+    CitiesParam,
     CohortIdParam,
     ConsentStatusParam,
     CountiesParam,
@@ -65,6 +67,9 @@ from backend.services.lead_query_helpers import (
 )
 from backend.services.lead_query_helpers import (
     parse_borrower_ids as _parse_borrower_ids,
+)
+from backend.services.lead_query_helpers import (
+    parse_city_states as _parse_city_states,
 )
 from backend.services.lead_query_helpers import (
     parse_csv_filter as _parse_csv_filter,
@@ -165,6 +170,7 @@ def list_leads(
     states: StatesParam = None,
     zips: ZipsParam = None,
     counties: CountiesParam = None,
+    cities: CitiesParam = None,
     borrower_ids: BorrowerIdsParam = None,
     target_lender_ref: TargetLenderRefParam = None,
     geography: GeographyParam = None,
@@ -233,6 +239,9 @@ def list_leads(
     parsed_states = _parse_csv_filter(states, width=2, label="states")
     parsed_zips = _parse_csv_filter(zips, width=5, label="zips", numeric=True)
     parsed_counties = _parse_csv_filter(counties, width=5, label="counties", numeric=True)
+    # Pairs, not a CSV of names: `parse_csv_filter`'s isalpha()/width check
+    # rejects every multi-word city and every `CITY~ST` token.
+    parsed_cities = _parse_city_states(cities)
     parsed_borrower_ids = _parse_borrower_ids(borrower_ids)
     if growth_handoff and (assigned_to or parsed_borrower_ids):
         raise HTTPException(
@@ -315,6 +324,7 @@ def list_leads(
         parsed_states = replay.state_codes
         parsed_zips = replay.zip_codes
         parsed_counties = replay.county_fipses
+        parsed_cities = replay.city_states
         parsed_borrower_ids = replay.borrower_ids
     try:
         target_lender_ref = normalize_public_lender_ref(target_lender_ref, allow_all=True)
@@ -334,6 +344,7 @@ def list_leads(
                     parsed_states,
                     parsed_zips,
                     parsed_counties,
+                    parsed_cities,
                     parsed_borrower_ids,
                     county,
                     parsed_segments,
@@ -398,6 +409,7 @@ def list_leads(
         "county_fips": county,
         "state_codes": parsed_states,
         "zip_codes": parsed_zips,
+        "city_states": parsed_cities,
         "borrower_ids": parsed_borrower_ids,
         "segment_codes": parsed_segments,
         "segment_mode": segment_mode,
@@ -422,6 +434,7 @@ def list_leads(
                     county_fipses=parsed_counties,
                     state_codes=parsed_states,
                     zip_codes=parsed_zips,
+                    city_states=parsed_cities,
                     borrower_ids=parsed_borrower_ids,
                     segment_codes=parsed_segments,
                     segment_mode=segment_mode,
@@ -541,6 +554,8 @@ def list_leads(
         audit_payload["states"] = parsed_states
     if parsed_zips:
         audit_payload["zips"] = parsed_zips
+    if parsed_cities:
+        audit_payload[GENIE_CITY_FILTER_KEY] = parsed_cities
     if parsed_counties:
         audit_payload["counties"] = parsed_counties
     if parsed_borrower_ids:

--- a/backend/schemas/campaign_json_projection.py
+++ b/backend/schemas/campaign_json_projection.py
@@ -21,6 +21,11 @@ from backend.schemas.campaign_json_inputs import (
     require_exact_json_keys,
 )
 from backend.schemas.common import validate_public_campaign_label
+from backend.schemas.genie_geo_filters import (
+    CITY_STATE_PAIR_RE,
+    GENIE_CITY_FILTER_KEY,
+    MAX_CITY_FILTER_VALUES,
+)
 from backend.schemas.genie_numeric_filters import (
     GENIE_NUMERIC_FILTER_BOUNDS,
     GENIE_NUMERIC_FILTER_KEYS,
@@ -78,6 +83,10 @@ _GENIE_CRITERIA_KEYS = frozenset(
 _GENIE_REPLAY_FILTER_KEYS = frozenset(
     {
         "zips",
+        # A draft campaign built from a city-grain Genie answer carries
+        # this, and this projection gates the approval decision proof: an
+        # unprojected key makes that campaign permanently unapprovable.
+        GENIE_CITY_FILTER_KEY,
         "county",
         "counties",
         "states",
@@ -402,6 +411,13 @@ def _project_genie_replay_filters(
         field_name="criteria.result_filters",
     )
     out: dict[str, object] = {}
+    if GENIE_CITY_FILTER_KEY in value:
+        out[GENIE_CITY_FILTER_KEY] = _reviewed_text_list(
+            value[GENIE_CITY_FILTER_KEY],
+            field_name=f"criteria.result_filters.{GENIE_CITY_FILTER_KEY}",
+            pattern=CITY_STATE_PAIR_RE.pattern,
+            max_items=MAX_CITY_FILTER_VALUES,
+        )
     for key in ("zips", "counties"):
         if key in value:
             out[key] = _reviewed_text_list(

--- a/backend/schemas/genie_geo_filters.py
+++ b/backend/schemas/genie_geo_filters.py
@@ -1,0 +1,139 @@
+"""Canonical shape for the `(city, state)` cohort filter.
+
+One definition, seven readers. A city-grain Genie answer is the one geography
+the Lead Queue could not replay, and both of the shapes it degraded into were
+measured live on paychex gold 2026-08-11 against an answer stating
+Chicago = 523,010 cash-out candidates:
+
+    rows [{city}]         -> no geography at all: 3,474,216 opened, 6.6x
+    rows [{city, state}]  -> the STATE substituted for the city, which is
+                             worse because it looks deliberate: 1,181,043, 2.3x
+
+Both were merely DISCLOSED (``city_grain_unreplayable``). This module is the
+key that makes the cohort exact instead.
+
+Why a PAIR and not a name
+-------------------------
+``mip.gold.borrower_360.city`` carries 428 distinct names but 433 distinct
+``(city, state)`` pairs (measured 2026-08-12, 5,085,969 of 5,156,184 rows
+non-null). Five names span two states, and the minority side is tiny:
+
+    CYPRESS          CA 14,630 / TX      1   -> 14,631x wrong on the TX side
+    MIDLOTHIAN       IL  6,211 / TX     31
+    SUNNYVALE        TX  3,833 / CA      1
+    UNIVERSITY PARK  TX     39 / IL      6
+    HIGHLAND PARK    TX     10 / IL      3
+
+A name-only filter is therefore not "slightly broad"; on the minority side it
+is wrong by four orders of magnitude. Carrying the state also preserves file
+pruning -- ``borrower_360`` is ``CLUSTER BY (state, clip)`` -- so the pair is
+cheaper to read than the name alone would be.
+
+Why `~` and why plural-only
+---------------------------
+``~`` is RFC-3986 *unreserved*, so ``urlencode`` leaves it literal and a shared
+link reads ``cities=CHICAGO~IL`` rather than ``CHICAGO%7EIL``. No city in gold
+contains it (measured: the only non-``[A-Z]`` characters in the column are
+space and hyphen). There is exactly ONE key, ``cities``, always plural: the
+singular/plural pairs elsewhere in this vocabulary (``zip``/``zips``,
+``state``/``states``) each need a second entry in every closed set they pass
+through, and a key accepted by one vocabulary and rejected by another is how
+PR #191 shipped a write-then-500.
+
+Why the county key is not the model
+-----------------------------------
+``county_fips_5`` is NULL on every gold row since audit C2, so the county
+filter matches nothing. City is modelled on ``state``/``zips`` -- vocabularies
+that are alive -- and never on the county path.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+# The one key. Plural, always: see the module docstring.
+GENIE_CITY_FILTER_KEY: Final[str] = "cities"
+
+# The pair separator. Unreserved in RFC-3986 and absent from every gold city.
+CITY_STATE_SEPARATOR: Final[str] = "~"
+
+# ``CITY~ST``. The city side is deliberately tighter than "any text":
+# uppercase letters, spaces, hyphens and periods only. Measured live, gold
+# holds nothing but ``[A-Z]``, space and hyphen (one hyphenated value,
+# ``UNION HILL-NOVELTY HILL, WA``); the period is admitted for the ``ST. LOUIS``
+# shape so a legitimate future refresh is not rejected. An apostrophe is NOT
+# admitted -- no gold row needs one, and the narrower the class the smaller the
+# surface that reaches a bound parameter. Anything outside this shape fails
+# closed to the existing ``city_grain_unreplayable`` disclosure rather than
+# widening to the state.
+#
+# 48 characters is ~2x the observed maximum (23, ``UNION HILL-NOVELTY HILL``).
+MAX_CITY_NAME_LEN: Final[int] = 48
+CITY_STATE_PAIR_RE: Final[re.Pattern[str]] = re.compile(
+    rf"^(?P<city>[A-Z][A-Z .-]{{0,{MAX_CITY_NAME_LEN - 1}}})"
+    rf"{re.escape(CITY_STATE_SEPARATOR)}"
+    r"(?P<state>[A-Z]{2})$"
+)
+
+# 433 pairs exist in gold today. 500 matches ``_MAX_ACTION_FILTER_VALUES`` (the
+# ZIP cap) and comfortably covers "every city in the footprint" while still
+# bounding a malformed answer.
+MAX_CITY_FILTER_VALUES: Final[int] = 500
+
+
+def format_city_state_pair(city: str, state: str) -> str:
+    """Render one reviewed ``CITY~ST`` token, or ``""`` when the pair is unusable.
+
+    Fails closed on purpose. A caller that gets ``""`` must emit NO city filter
+    and keep the ``city_grain_unreplayable`` disclosure -- it must never fall
+    through to the state, which is the 2.3x silent substitution this replaces.
+    """
+
+    city_text = " ".join(str(city or "").strip().upper().split())
+    state_text = str(state or "").strip().upper()
+    if not city_text or not state_text:
+        return ""
+    candidate = f"{city_text}{CITY_STATE_SEPARATOR}{state_text}"
+    return candidate if CITY_STATE_PAIR_RE.fullmatch(candidate) else ""
+
+
+def parse_city_state_pair(value: object) -> tuple[str, str] | None:
+    """Split a ``CITY~ST`` token into ``(city, state)``, or None if malformed.
+
+    Normalizes the way ``format_city_state_pair`` does (upper, collapse runs of
+    whitespace) so a hand-typed ``?cities=fort  lauderdale~fl`` round-trips to
+    the same pair the writer emitted.
+    """
+
+    text = str(value or "").strip()
+    if not text:
+        return None
+    city_raw, separator, state_raw = text.partition(CITY_STATE_SEPARATOR)
+    if not separator:
+        return None
+    normalized = format_city_state_pair(city_raw, state_raw)
+    if not normalized:
+        return None
+    city, _, state = normalized.partition(CITY_STATE_SEPARATOR)
+    return city, state
+
+
+def normalise_city_state_pairs(values: object) -> list[str]:
+    """Return the deduplicated, reviewed ``CITY~ST`` tokens in ``values``.
+
+    Silently drops malformed entries (fail closed, per the module docstring)
+    and caps the result. Order is preserved so a URL round-trips stably.
+    """
+
+    if isinstance(values, str) or not isinstance(values, list | tuple):
+        return []
+    out: list[str] = []
+    for value in values:
+        pair = parse_city_state_pair(value)
+        if pair is None:
+            continue
+        token = f"{pair[0]}{CITY_STATE_SEPARATOR}{pair[1]}"
+        if token not in out:
+            out.append(token)
+    return out[:MAX_CITY_FILTER_VALUES]

--- a/backend/schemas/lead_query.py
+++ b/backend/schemas/lead_query.py
@@ -114,6 +114,20 @@ ZipsParam = Annotated[
     ),
 ]
 
+CitiesParam = Annotated[
+    str | None,
+    Query(
+        alias="cities",
+        max_length=4096,
+        description=(
+            "Optional comma-separated CITY~ST pairs (for example "
+            "CHICAGO~IL,FORT LAUDERDALE~FL) for city-grain Genie cohort "
+            "actions. Always a pair: 5 city names in gold span two states, "
+            "so a bare name opens the wrong population."
+        ),
+    ),
+]
+
 CountiesParam = Annotated[
     str | None,
     Query(

--- a/backend/services/audit_store.py
+++ b/backend/services/audit_store.py
@@ -39,6 +39,11 @@ from backend.schemas.common import (
     validate_public_campaign_label,
     validate_public_opaque_id,
 )
+from backend.schemas.genie_geo_filters import (
+    CITY_STATE_PAIR_RE,
+    GENIE_CITY_FILTER_KEY,
+    MAX_CITY_FILTER_VALUES,
+)
 from backend.schemas.genie_numeric_filters import (
     GENIE_NUMERIC_FILTER_BOUNDS,
     GENIE_NUMERIC_FILTER_KEYS,
@@ -235,6 +240,8 @@ _ALLOWED_METADATA_KEYS: frozenset[str] = frozenset(
         "counties",
         "states",
         "zips",
+        # Emitted by /leads when the request carried a city cohort.
+        GENIE_CITY_FILTER_KEY,
         "limit",
         "approval_status",
         "outreach_status",
@@ -567,6 +574,10 @@ def _metadata_values_for(
 _ALLOWED_RESULT_FILTER_KEYS: frozenset[str] = frozenset(
     {
         "zips",
+        # Reviewed `(city, state)` pairs. Named from the canonical module
+        # rather than spelled out, so the ledger cannot reject a key the
+        # cohort writer accepted -- the write-then-500 shape of PR #191.
+        GENIE_CITY_FILTER_KEY,
         "states",
         "county",
         "counties",
@@ -1451,6 +1462,15 @@ def _assert_result_filters_value_policy(value: Any) -> None:
         raise AuditMetadataValueViolation(
             "result_filters",
             "contains unreviewed keys: " + ", ".join(sorted(unexpected)),
+        )
+    if GENIE_CITY_FILTER_KEY in value:
+        # Pattern-checked against the SAME regex the cohort writer used,
+        # so a pair one accepts cannot be the pair the other refuses.
+        _assert_string_list(
+            f"result_filters.{GENIE_CITY_FILTER_KEY}",
+            value[GENIE_CITY_FILTER_KEY],
+            pattern=CITY_STATE_PAIR_RE.pattern,
+            max_items=MAX_CITY_FILTER_VALUES,
         )
     if "zips" in value:
         _assert_string_list(

--- a/backend/services/campaign_treatment.py
+++ b/backend/services/campaign_treatment.py
@@ -10,6 +10,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 from uuid import uuid4
 
+from backend.schemas.genie_geo_filters import GENIE_CITY_FILTER_KEY
 from backend.schemas.genie_numeric_filters import is_reviewed_numeric_floor
 from backend.schemas.portfolio import (
     CAMPAIGN_BUILD_LIMIT,
@@ -274,6 +275,9 @@ def cohort_filters_from_campaign_criteria(criteria: dict[str, Any]) -> LeadCohor
         county_fipses=_strings(filters.get("counties")),
         state_codes=_strings(filters.get("states")),
         zip_codes=_strings(filters.get("zips")),
+        # Without this the approved treatment set materializes the STATE
+        # the pairs live in rather than the cities the answer described.
+        city_states=_strings(filters.get(GENIE_CITY_FILTER_KEY)),
         borrower_ids=borrower_ids,
         segment_codes=_strings(filters.get("segment_codes")),
         segment_mode=str(filters.get("segment_mode") or "any"),

--- a/backend/services/genie_actions.py
+++ b/backend/services/genie_actions.py
@@ -24,6 +24,11 @@ from backend.config.runtime_secret_policy import (
 from backend.config.settings import settings
 from backend.schemas._validators_tenant import normalize_public_lender_ref
 from backend.schemas.common import validate_public_borrower_id
+from backend.schemas.genie_geo_filters import (
+    GENIE_CITY_FILTER_KEY,
+    MAX_CITY_FILTER_VALUES,
+    parse_city_state_pair,
+)
 from backend.schemas.genie_numeric_filters import GENIE_NUMERIC_FILTER_BOUNDS
 from backend.schemas.lead import GENIE_REPLAY_SEGMENT_CODES
 from backend.schemas.portfolio import PortfolioCriteria
@@ -86,6 +91,7 @@ _REPLAYABLE_NUMERIC_FILTERS: Mapping[str, tuple[int, int]] = GENIE_NUMERIC_FILTE
 _REPLAYABLE_FILTER_KEYS = frozenset(
     {
         "zips",
+        GENIE_CITY_FILTER_KEY,
         "county",
         "counties",
         "states",
@@ -115,6 +121,10 @@ _LEAD_QUEUE_REPLAY_KEYS = frozenset(
         "states",
         "zip",
         "zips",
+        # Plural-only, and stripped off the inbound URL like every other
+        # replayable key: `_route_with_cohort` re-adds it from the cohort row,
+        # so a hand-edited `?cities=…` cannot survive alongside a cohort_id.
+        GENIE_CITY_FILTER_KEY,
         "county",
         "counties",
         "borrower_ids",
@@ -971,6 +981,41 @@ def _list_filter(
     return out
 
 
+def _city_states_filter(raw: Any) -> list[str]:
+    """Validate the cohort's ``CITY~ST`` list, or 400 like every sibling key.
+
+    Deliberately STRICTER than the writer, which fails closed to a disclosure:
+    by the time a payload reaches here the pairs are a reviewed cohort key, and
+    a malformed one is a bad request rather than a city we could not read.
+    """
+
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Genie cohort {GENIE_CITY_FILTER_KEY} filter must be a reviewed list",
+        )
+    out: list[str] = []
+    for item in raw:
+        pair = parse_city_state_pair(item)
+        if pair is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Genie cohort includes invalid replay filter",
+            )
+        value = f"{pair[0]}~{pair[1]}"
+        if value in out:
+            continue
+        if len(out) >= MAX_CITY_FILTER_VALUES:
+            raise HTTPException(
+                status_code=400,
+                detail="Genie cohort includes too many replay filters",
+            )
+        out.append(value)
+    return out
+
+
 def _numeric_floor(raw: Any, *, field: str, minimum: int, maximum: int) -> int | None:
     """Return a reviewed integer floor, or None when the answer omitted it.
 
@@ -1043,6 +1088,9 @@ def _cohort_route_filters(
     )
     if zips:
         out["zips"] = zips
+    city_states = _city_states_filter(filters.get(GENIE_CITY_FILTER_KEY))
+    if city_states:
+        out[GENIE_CITY_FILTER_KEY] = city_states
     county_raw = str(filters.get("county") or "").strip()
     if county_raw:
         if not re.fullmatch(r"^\d{5}$", county_raw):
@@ -1203,6 +1251,11 @@ def _route_with_cohort(
             query[plural] = ",".join(str(v) for v in values)
 
     set_one_or_many(singular="zip", plural="zips", values=filters.get("zips"))
+    # No singular form: one key, always plural. `~` is unreserved, so urlencode
+    # leaves it literal and a shared link reads `cities=CHICAGO~IL`.
+    city_states = filters.get(GENIE_CITY_FILTER_KEY)
+    if isinstance(city_states, list) and city_states:
+        query[GENIE_CITY_FILTER_KEY] = ",".join(str(v) for v in city_states)
     set_one_or_many(singular="state", plural="states", values=filters.get("states"))
     set_one_or_many(singular="county", plural="counties", values=filters.get("counties"))
     borrower_ids = filters.get("borrower_ids")

--- a/backend/services/lead_cohort_replay.py
+++ b/backend/services/lead_cohort_replay.py
@@ -30,6 +30,7 @@ from fastapi import HTTPException
 from backend.schemas.portfolio import PortfolioCriteria
 from backend.services.lakebase import LakebaseError, get_lakebase_client
 from backend.services.lead_query_helpers import (
+    cohort_city_states,
     cohort_list,
     cohort_numeric_floor,
     cohort_segment_mode,
@@ -97,6 +98,9 @@ class CohortReplay:
     segment_mode: str
     state_codes: list[str] | None
     zip_codes: list[str] | None
+    # Reviewed `CITY~ST` pairs. Replayed verbatim so a city-grain answer
+    # opens the cities it named, not the states they sit in.
+    city_states: list[str] | None
     county_fipses: list[str] | None
     borrower_ids: list[str] | None
     segment_codes: list[str] | None
@@ -183,6 +187,7 @@ def resolve_cohort_replay(cohort_id: str, *, actor: str) -> CohortReplay:
     segment_mode = cohort_segment_mode(filters)
     state_codes = cohort_list(filters, "states", width=2)
     zip_codes = cohort_list(filters, "zips", width=5, numeric=True)
+    city_states = cohort_city_states(filters)
     county_fipses = cohort_list(filters, "counties", width=5, numeric=True)
     borrower_ids = cohort_list(filters, "borrower_ids", borrower_ids=True)
 
@@ -209,6 +214,7 @@ def resolve_cohort_replay(cohort_id: str, *, actor: str) -> CohortReplay:
         segment_mode=segment_mode,
         state_codes=state_codes,
         zip_codes=zip_codes,
+        city_states=city_states,
         county_fipses=county_fipses,
         borrower_ids=borrower_ids,
         segment_codes=segment_codes,

--- a/backend/services/lead_query_helpers.py
+++ b/backend/services/lead_query_helpers.py
@@ -8,6 +8,12 @@ from typing import Literal, cast
 from fastapi import HTTPException
 
 from backend.schemas.common import validate_public_borrower_id
+from backend.schemas.genie_geo_filters import (
+    CITY_STATE_SEPARATOR,
+    GENIE_CITY_FILTER_KEY,
+    MAX_CITY_FILTER_VALUES,
+    parse_city_state_pair,
+)
 from backend.schemas.genie_numeric_filters import GENIE_NUMERIC_FILTER_BOUNDS
 from backend.schemas.lead import SEGMENT_CODE_VALUES
 from backend.schemas.portfolio import PortfolioCriteria
@@ -46,6 +52,82 @@ def parse_csv_filter(
             seen.add(value)
             out.append(value)
     return out
+
+
+def parse_city_states(raw: str | None) -> list[str] | None:
+    """Parse ``?cities=CHICAGO~IL,FORT LAUDERDALE~FL`` into reviewed pairs.
+
+    Deliberately NOT ``parse_csv_filter``: that helper checks ``value.isalpha()``
+    and a fixed width, which rejects every multi-word city (``FORT LAUDERDALE``
+    has a space, ``UNION HILL-NOVELTY HILL`` a hyphen) and every pair
+    (``~`` is not alphabetic). 4 of the 428 gold city names are multi-word at
+    the maximum, so reusing it would have silently 422'd most of the vocabulary.
+
+    Raises 422 on a malformed pair rather than dropping it: at this layer the
+    value came from a URL the user can see, so a broken filter must fail
+    visibly instead of quietly opening a wider cohort.
+    """
+
+    if raw is None:
+        return None
+    out: list[str] = []
+    for part in raw.split(","):
+        text = part.strip()
+        if not text:
+            continue
+        pair = parse_city_state_pair(text)
+        if pair is None:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"{GENIE_CITY_FILTER_KEY} must be comma-separated CITY~ST pairs "
+                    "such as CHICAGO~IL"
+                ),
+            )
+        value = f"{pair[0]}{CITY_STATE_SEPARATOR}{pair[1]}"
+        if value in out:
+            continue
+        if len(out) >= MAX_CITY_FILTER_VALUES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"{GENIE_CITY_FILTER_KEY} accepts at most {MAX_CITY_FILTER_VALUES} pairs",
+            )
+        out.append(value)
+    return out or None
+
+
+def cohort_city_states(filters: dict[str, object]) -> list[str] | None:
+    """Return the reviewed ``CITY~ST`` pairs stored on a governed cohort.
+
+    A stored cohort gets no more trust than a hand-typed URL, so this applies
+    the same validation ``parse_city_states`` does.
+    """
+
+    raw = filters.get(GENIE_CITY_FILTER_KEY)
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise HTTPException(
+            status_code=422,
+            detail=f"cohort {GENIE_CITY_FILTER_KEY} filter is invalid",
+        )
+    out: list[str] = []
+    for item in raw:
+        pair = parse_city_state_pair(item)
+        if pair is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"cohort {GENIE_CITY_FILTER_KEY} filter is invalid",
+            )
+        value = f"{pair[0]}{CITY_STATE_SEPARATOR}{pair[1]}"
+        if value not in out:
+            out.append(value)
+    if len(out) > MAX_CITY_FILTER_VALUES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"cohort {GENIE_CITY_FILTER_KEY} filter is invalid",
+        )
+    return out or None
 
 
 def parse_segment_codes(raw: str | None) -> list[str] | None:

--- a/backend/services/repositories/databricks_genie_actions.py
+++ b/backend/services/repositories/databricks_genie_actions.py
@@ -13,6 +13,11 @@ from typing import Any
 from urllib.parse import urlencode
 
 from backend.schemas.common import validate_public_borrower_id
+from backend.schemas.genie_geo_filters import (
+    GENIE_CITY_FILTER_KEY,
+    MAX_CITY_FILTER_VALUES,
+    format_city_state_pair,
+)
 from backend.schemas.lead import GENIE_REPLAY_SEGMENT_CODES
 from backend.services.genie_answers import GenieActionSuggestion, GenieVisualizationSpec
 from backend.services.genie_sql_predicates import SqlFilterReading, read_sql_filters
@@ -26,6 +31,7 @@ _REPLAYABLE_ROUTE_FILTER_KEYS = frozenset(
     {
         "borrower_ids",
         "zips",
+        GENIE_CITY_FILTER_KEY,
         "county",
         "counties",
         "states",
@@ -104,9 +110,14 @@ _SEGMENT_COLUMN_RE = re.compile(
 # Disclosure name for the former. Identifier-shaped and bounded, like the
 # threshold disclosures it rides alongside in `unreplayable_filters`.
 _SEGMENT_PREDICATE_DISCLOSURE = "segment_codes_predicate"
-# The answer is city-grain and the queue has no city filter, so the cohort is
-# broader than the answer on the geography axis. Same disclosure vocabulary.
+# The answer named a city the cohort could NOT be keyed on -- no state beside
+# it in the same row, or a name outside the reviewed shape. The queue then
+# opens a broader population than the answer on the geography axis, and says
+# so. Same disclosure vocabulary as the thresholds.
 _CITY_GRAIN_DISCLOSURE = "city_grain_unreplayable"
+# Column names a Genie answer uses for the two halves of the city key.
+_CITY_COLUMNS: tuple[str, ...] = ("city", "situs_city")
+_STATE_COLUMNS: tuple[str, ...] = ("state", "state_code")
 
 # `recommended_offer_code = 'x'` or `recommended_offer_code IN ('x', 'y')`.
 # The alternation is anchored on the quotes so the list branch cannot run past
@@ -205,6 +216,86 @@ def _row_values(
             if value not in values:
                 values.append(value)
     return values
+
+
+def _first_column_value(row: dict[str, Any], columns: tuple[str, ...]) -> str | None:
+    """Return the first non-empty value ``row`` carries for ``columns``."""
+
+    for column in columns:
+        raw = row.get(column)
+        if raw is None:
+            continue
+        value = str(raw).strip()
+        if value:
+            return value
+    return None
+
+
+def _row_pairs(
+    rows: list[dict[str, Any]] | None,
+    *,
+    left_columns: tuple[str, ...],
+    right_columns: tuple[str, ...],
+) -> list[tuple[str, str]]:
+    """Read a TWO-COLUMN key out of each row, never across rows.
+
+    A row contributes a pair only when it carries BOTH halves itself. A row
+    with a left value and no right value contributes nothing -- a left value
+    alone is not the key.
+
+    Reading the two columns with two separate ``_row_values`` calls and
+    cross-producting them is the bug this exists to prevent. Given rows
+    ``[{CYPRESS, CA}, {SUNNYVALE, TX}]`` the cross product also yields
+    ``CYPRESS~TX`` and ``SUNNYVALE~CA`` -- two cohorts the answer never
+    described, and in the live data the wrong side of a 14,631x split
+    (CYPRESS is CA 14,630 / TX 1, SUNNYVALE is TX 3,833 / CA 1).
+    """
+
+    pairs: list[tuple[str, str]] = []
+    for row in rows or []:
+        left = _first_column_value(row, left_columns)
+        if left is None:
+            continue
+        right = _first_column_value(row, right_columns)
+        if right is None:
+            continue
+        pair = (left, right)
+        if pair not in pairs:
+            pairs.append(pair)
+    return pairs
+
+
+def _city_state_filter_from_rows(rows: list[dict[str, Any]] | None) -> list[str]:
+    """Return the answer's reviewed ``CITY~ST`` tokens, or ``[]`` to fail closed.
+
+    Fails closed AS A UNIT: if any city the answer named did not survive --
+    no state beside it in the same row, or a name outside the reviewed shape
+    -- the whole filter is dropped and the caller discloses
+    ``city_grain_unreplayable`` instead. Replaying only the cities that did
+    parse would answer a NARROWER question than the one on screen under the
+    same heading: the mirror image of the 2.3x state substitution this
+    replaces, and just as silent.
+    """
+
+    named_cities = _row_values(rows, *_CITY_COLUMNS)
+    if not named_cities:
+        return []
+    pairs = _row_pairs(rows, left_columns=_CITY_COLUMNS, right_columns=_STATE_COLUMNS)
+    tokens: list[str] = []
+    for city, state in pairs:
+        token = format_city_state_pair(city, state)
+        if not token:
+            return []
+        if token not in tokens:
+            tokens.append(token)
+    if len(tokens) > MAX_CITY_FILTER_VALUES:
+        return []
+    # Every city the answer named has to be represented. A city that appears
+    # in `named_cities` but in no pair is one whose row carried no state.
+    paired_cities = {city for city, _ in pairs}
+    if any(city not in paired_cities for city in named_cities):
+        return []
+    return tokens
 
 
 def _segment_selection_from_sql(
@@ -510,6 +601,10 @@ def _route_from_answer_rows(
     # here narrows, and why prose cannot be gated the way SQL conjuncts can.
     portfolio_criteria = _portfolio_criteria_from_sql(sql_query, reading)
 
+    # Read as PAIRS, out of one row at a time. `_row_pairs` explains why two
+    # `_row_values` calls would invent cohorts the answer never described.
+    city_states = _city_state_filter_from_rows(rows)
+
     city_disclosures: list[str] = []
     if borrower_ids:
         filter_criteria["borrower_ids"] = borrower_ids
@@ -517,6 +612,15 @@ def _route_from_answer_rows(
     elif zips:
         params["zips"] = ",".join(zips)
         filter_criteria["zips"] = zips
+    elif city_states:
+        # Ahead of `states` on purpose, and mutually exclusive with it: the
+        # pair ALREADY carries the state, so adding `states` alongside would
+        # be redundant at best. Falling THROUGH to it is the 2.3x silent
+        # substitution measured live 2026-08-11 (Chicago's 523,010 opening
+        # all 1,181,043 of IL) -- the shape that looks deliberate and is
+        # therefore worse than opening everything.
+        params[GENIE_CITY_FILTER_KEY] = ",".join(city_states)
+        filter_criteria[GENIE_CITY_FILTER_KEY] = city_states
     elif counties:
         if len(counties) == 1:
             params["county"] = counties[0]
@@ -528,27 +632,30 @@ def _route_from_answer_rows(
         params["states"] = ",".join(states)
         filter_criteria["states"] = states
 
-    # A CITY answer has no cohort dimension: the Lead Queue cannot filter by
-    # city, so `_row_values` never reads one. That is survivable on its own --
-    # the cohort is simply broader. What is not survivable is doing it in
-    # SILENCE, and there are two shapes, both measured live on paychex gold
+    # A city answer the cohort could NOT be keyed on. The queue then opens a
+    # broader population than the answer, which is survivable; doing it in
+    # SILENCE is not. Both silent shapes were measured live on paychex gold
     # 2026-08-11 against an answer stating Chicago = 523,010:
     #
     #   rows [{city}]         -> no geography at all: 3,474,216 opened, 6.6x
-    #   rows [{city, state}]  -> the STATE substitutes for the city, which is
+    #   rows [{city, state}]  -> the STATE substituted for the city, which is
     #                            worse because it looks deliberate:
     #                            1,181,043 opened, 2.3x
     #
-    # Naming it is what the `unreplayable_filters` disclosure is for. The real
-    # fix is a `(city, state)` filter on the queue -- city alone is ambiguous
-    # across states (CYPRESS is CA 14,630 / TX 1, so a name-only cohort is
-    # 14,631x wrong on the minority side), so it needs a pair-keyed parameter
-    # threaded through six closed vocabularies, which is its own slice.
+    # The second shape is now EXACT (`cities` above), so this fires only for
+    # the first: a city with no state beside it in the same row, or a name
+    # outside the reviewed shape. Naming it is what `unreplayable_filters` is
+    # for.
+    #
     # Not when `borrower_ids` pinned the cohort: those rows ARE the answer's
     # population, exactly, and a `city` column alongside them broadens nothing.
     # A borrower list that happens to project city was the first false positive
     # this disclosure produced.
-    if not borrower_ids and _row_values(rows, "city", "situs_city"):
+    if (
+        not borrower_ids
+        and not filter_criteria.get(GENIE_CITY_FILTER_KEY)
+        and _row_values(rows, *_CITY_COLUMNS)
+    ):
         city_disclosures.append(_CITY_GRAIN_DISCLOSURE)
 
     if segment_codes:

--- a/backend/services/repositories/databricks_lead_cohort_support.py
+++ b/backend/services/repositories/databricks_lead_cohort_support.py
@@ -6,6 +6,10 @@ from types import ModuleType
 from typing import Any
 
 from backend.schemas.common import validate_public_borrower_id
+from backend.schemas.genie_geo_filters import (
+    normalise_city_state_pairs,
+    parse_city_state_pair,
+)
 from backend.services.databricks_sql_helpers import qualify
 from backend.services.scoring import HIGH_OPPORTUNITY_THRESHOLD
 from backend.services.segment_predicates import (
@@ -68,6 +72,59 @@ class LeadCohortQuerySupport:
             if len(code) == 5 and code.isdigit() and code not in out:
                 out.append(code)
         return out
+
+    @staticmethod
+    def normalise_city_states(city_states: list[str] | None) -> list[str]:
+        """Return the reviewed ``CITY~ST`` tokens a cohort can filter on.
+
+        Malformed entries are dropped rather than widened -- see
+        ``backend/schemas/genie_geo_filters`` for why a city name without its
+        state is 14,631x wrong on the minority side of ``CYPRESS``.
+        """
+
+        return normalise_city_state_pairs(list(city_states or []))
+
+    @staticmethod
+    def city_state_clause(
+        *,
+        values: list[str],
+        params: dict[str, object],
+        alias: str = "b",
+    ) -> str:
+        """Compile ``CITY~ST`` tokens to an OR-of-ANDs over bound placeholders.
+
+        Each token is a PAIR, so it compiles to a conjunction and the tokens
+        are OR'd together::
+
+            AND ((UPPER(b.city) = :city_0 AND b.state = :cstate_0)
+              OR (UPPER(b.city) = :city_1 AND b.state = :cstate_1))
+
+        Cross-producting the two axes instead -- ``city IN (...) AND state IN
+        (...)`` -- is the bug this shape exists to avoid: given CYPRESS/CA and
+        SUNNYVALE/TX it also matches CYPRESS/TX and SUNNYVALE/CA, two cohorts
+        the answer never described.
+
+        ``UPPER()`` on the city only. Gold stores city uppercase already, so
+        this is defence against a hand-typed URL, not a data quirk; ``state``
+        is compared bare so ``CLUSTER BY (state, clip)`` file pruning survives.
+        """
+
+        if not values:
+            return ""
+        terms: list[str] = []
+        for index, token in enumerate(values):
+            pair = parse_city_state_pair(token)
+            if pair is None:
+                continue
+            city, state = pair
+            city_key = f"city_{index}"
+            state_key = f"cstate_{index}"
+            params[city_key] = city
+            params[state_key] = state
+            terms.append(f"(UPPER({alias}.city) = :{city_key} AND {alias}.state = :{state_key})")
+        if not terms:
+            return ""
+        return f"AND ({' OR '.join(terms)})"
 
     @staticmethod
     def normalise_borrower_ids(borrower_ids: list[str] | None) -> list[str]:

--- a/backend/services/repositories/databricks_lead_cohorts.py
+++ b/backend/services/repositories/databricks_lead_cohorts.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from types import ModuleType
 from typing import Any
 
+from backend.schemas.genie_geo_filters import GENIE_CITY_FILTER_KEY
 from backend.schemas.lead import LeadSummary
 from backend.schemas.portfolio import PortfolioCriteria
 from backend.services.databricks_sql import DatabricksSqlClient
@@ -68,6 +69,11 @@ class LeadCohortFilters:
     county_fipses: list[str] | None = None
     state_codes: list[str] | None = None
     zip_codes: list[str] | None = None
+    # Reviewed ``CITY~ST`` pairs. A pair, never a bare name: see
+    # ``backend/schemas/genie_geo_filters`` for the five names that span two
+    # states and the 14,631x error a name-only cohort makes on the minority
+    # side of ``CYPRESS``.
+    city_states: list[str] | None = None
     borrower_ids: list[str] | None = None
     segment_codes: list[str] | None = None
     segment_mode: str = "any"
@@ -110,7 +116,8 @@ class LeadCohortQueries(LeadCohortQuerySupport):
         f"SELECT {{aggregate_select}} FROM {qualify('gold', 'borrower_360')} b "
         f"LEFT JOIN {qualify('gold', 'borrower_lifecycle_state')} ls "
         "  ON ls.borrower_id = b.borrower_id "
-        "WHERE 1=1 {state_clause} {zip_clause} {county_clause} {borrower_clause} "
+        "WHERE 1=1 {state_clause} {zip_clause} {county_clause} {city_clause} "
+        "{borrower_clause} "
         "{segment_clause} {funnel_stage_clause} {lender_clause} {portfolio_clause} "
         "{lifecycle_clause} {freshness_clause}"
     )
@@ -313,6 +320,7 @@ LEFT JOIN ranked ON TRUE
             filters.county_fips,
             filters.county_fipses,
         )
+        normalised_cities = self.normalise_city_states(filters.city_states)
         normalised_borrower_ids = self.normalise_borrower_ids(filters.borrower_ids)
         lifecycle_clause_geo, lifecycle_params_geo = self.lifecycle_filter_clause(
             source_alias="b",
@@ -360,6 +368,7 @@ LEFT JOIN ranked ON TRUE
             normalised_states
             or normalised_zips
             or normalised_county
+            or normalised_cities
             or normalised_borrower_ids
             or filters.funnel_stage
             or lender_clause
@@ -389,6 +398,10 @@ LEFT JOIN ranked ON TRUE
                     column="b.county_fips_5",
                     prefix="county",
                     values=normalised_county,
+                    params=params,
+                ),
+                city_clause=self.city_state_clause(
+                    values=normalised_cities,
                     params=params,
                 ),
                 borrower_clause=self.in_clause(
@@ -459,6 +472,7 @@ def normalise_growth_agent_handoff_filters(
             county_fipses=_string_list(raw_filters.get("counties")),
             state_codes=_string_list(raw_filters.get("states")),
             zip_codes=_string_list(raw_filters.get("zips")),
+            city_states=_string_list(raw_filters.get(GENIE_CITY_FILTER_KEY)),
             segment_codes=_string_list(raw_filters.get("segment_codes")),
             segment_mode=_optional_text(raw_filters.get("segment_mode")) or "any",
             target_lender_ref=_optional_text(raw_filters.get("target_lender_ref")),
@@ -509,6 +523,12 @@ def normalise_lead_queue_handoff_filters(
     zip_codes = sorted(LeadCohortQueries.normalise_zips(filters.zip_code, filters.zip_codes))
     if zip_codes:
         normalized["zips"] = zip_codes
+    # Inside the fingerprint, like every other narrowing geography key. A
+    # cohort filtered to CHICAGO~IL and one filtered to HOUSTON~TX are
+    # different populations, so they must not sign the same handoff.
+    city_states = sorted(LeadCohortQueries.normalise_city_states(filters.city_states))
+    if city_states:
+        normalized[GENIE_CITY_FILTER_KEY] = city_states
     county_fipses = sorted(
         LeadCohortQueries.normalise_county_fips(filters.county_fips, filters.county_fipses)
     )

--- a/backend/services/repositories/databricks_leads.py
+++ b/backend/services/repositories/databricks_leads.py
@@ -107,7 +107,8 @@ class DatabricksLeadRepository:
         f"FROM {qualify('gold', 'borrower_360')} b "
         f"LEFT JOIN {qualify('gold', 'borrower_lifecycle_state')} ls "
         "  ON ls.borrower_id = b.borrower_id "
-        "WHERE 1=1 {state_clause} {zip_clause} {county_clause} {borrower_clause} "
+        "WHERE 1=1 {state_clause} {zip_clause} {county_clause} {city_clause} "
+        "{borrower_clause} "
         "{segment_clause} {funnel_stage_clause} {lender_clause} {portfolio_clause} "
         "{lifecycle_clause} {freshness_clause} "
         "ORDER BY b.opportunity_score DESC, b.borrower_id ASC "
@@ -125,6 +126,7 @@ class DatabricksLeadRepository:
         county_fipses: list[str] | None = None,
         state_codes: list[str] | None = None,
         zip_codes: list[str] | None = None,
+        city_states: list[str] | None = None,
         borrower_ids: list[str] | None = None,
         segment_codes: list[str] | None = None,
         segment_mode: str = "any",
@@ -153,6 +155,7 @@ class DatabricksLeadRepository:
                 "county_fipses": county_fipses,
                 "state_codes": state_codes,
                 "zip_codes": zip_codes,
+                "city_states": city_states,
                 "borrower_ids": borrower_ids,
                 "segment_codes": segment_codes,
                 "segment_mode": segment_mode,
@@ -185,6 +188,7 @@ class DatabricksLeadRepository:
             county_fips,
             county_fipses,
         )
+        normalised_cities = self._cohort_queries.normalise_city_states(city_states)
         normalised_borrower_ids = self._cohort_queries.normalise_borrower_ids(borrower_ids)
         lifecycle_clause, lifecycle_params = self._cohort_queries.lifecycle_filter_clause(
             source_alias="b",
@@ -224,6 +228,7 @@ class DatabricksLeadRepository:
             normalised_states
             or normalised_zips
             or normalised_county
+            or normalised_cities
             or normalised_borrower_ids
             or funnel_stage
             or lender_clause
@@ -253,6 +258,10 @@ class DatabricksLeadRepository:
                 values=normalised_county,
                 params=params,
             )
+            city_clause = self._cohort_queries.city_state_clause(
+                values=normalised_cities,
+                params=params,
+            )
             borrower_clause = self._cohort_queries.in_clause(
                 column="b.borrower_id",
                 prefix="borrower_id",
@@ -264,6 +273,7 @@ class DatabricksLeadRepository:
                 state_clause=state_clause,
                 zip_clause=zip_clause,
                 county_clause=county_clause,
+                city_clause=city_clause,
                 borrower_clause=borrower_clause,
                 segment_clause=geo_segment_clause,
                 funnel_stage_clause=funnel_stage_clause,
@@ -317,6 +327,7 @@ class DatabricksLeadRepository:
         county_fipses: list[str] | None = None,
         state_codes: list[str] | None = None,
         zip_codes: list[str] | None = None,
+        city_states: list[str] | None = None,
         borrower_ids: list[str] | None = None,
         segment_codes: list[str] | None = None,
         segment_mode: str = "any",
@@ -341,6 +352,7 @@ class DatabricksLeadRepository:
                 "county_fipses": county_fipses,
                 "state_codes": state_codes,
                 "zip_codes": zip_codes,
+                "city_states": city_states,
                 "borrower_ids": borrower_ids,
                 "segment_codes": segment_codes,
                 "segment_mode": segment_mode,
@@ -368,6 +380,7 @@ class DatabricksLeadRepository:
                 county_fipses=county_fipses,
                 state_codes=state_codes,
                 zip_codes=zip_codes,
+                city_states=city_states,
                 borrower_ids=borrower_ids,
                 segment_codes=segment_codes,
                 segment_mode=segment_mode,
@@ -394,6 +407,7 @@ class DatabricksLeadRepository:
         county_fipses: list[str] | None = None,
         state_codes: list[str] | None = None,
         zip_codes: list[str] | None = None,
+        city_states: list[str] | None = None,
         borrower_ids: list[str] | None = None,
         segment_codes: list[str] | None = None,
         segment_mode: str = "any",
@@ -418,6 +432,7 @@ class DatabricksLeadRepository:
                 county_fipses=county_fipses,
                 state_codes=state_codes,
                 zip_codes=zip_codes,
+                city_states=city_states,
                 borrower_ids=borrower_ids,
                 segment_codes=segment_codes,
                 segment_mode=segment_mode,
@@ -462,6 +477,7 @@ class DatabricksLeadRepository:
         county_fipses: list[str] | None = None,
         state_codes: list[str] | None = None,
         zip_codes: list[str] | None = None,
+        city_states: list[str] | None = None,
         borrower_ids: list[str] | None = None,
         segment_codes: list[str] | None = None,
         segment_mode: str = "any",
@@ -486,6 +502,7 @@ class DatabricksLeadRepository:
                 county_fipses=county_fipses,
                 state_codes=state_codes,
                 zip_codes=zip_codes,
+                city_states=city_states,
                 borrower_ids=borrower_ids,
                 segment_codes=segment_codes,
                 segment_mode=segment_mode,

--- a/backend/services/repositories/protocols.py
+++ b/backend/services/repositories/protocols.py
@@ -176,6 +176,7 @@ class LeadRepository(Protocol):
         county_fipses: list[str] | None = None,
         state_codes: list[str] | None = None,
         zip_codes: list[str] | None = None,
+        city_states: list[str] | None = None,
         borrower_ids: list[str] | None = None,
         segment_codes: list[str] | None = None,
         segment_mode: str = "any",
@@ -192,7 +193,7 @@ class LeadRepository(Protocol):
         """Return up to ``limit`` ranked leads.
 
         ``state`` / ``zip_code`` / ``county_fips`` / ``borrower_ids`` and the multi-value
-        ``state_codes`` / ``zip_codes``
+        ``state_codes`` / ``zip_codes`` / ``city_states``
         (optional, 2026-05-04 FIX beta plus Genie cohort extension):
         when provided, the implementation queries ``mip.gold.borrower_360``
         directly (no score floor) instead of ``mip.gold.lead_population``,
@@ -206,6 +207,11 @@ class LeadRepository(Protocol):
         cards into one de-duplicated cohort; ``"all"`` remains supported
         for analytic intersection filters where a borrower must carry
         every selected segment code.
+
+        ``city_states`` carries reviewed ``CITY~ST`` pairs. Always a pair:
+        5 of the 428 city names in gold span two states, and the minority
+        side is tiny (CYPRESS is CA 14,630 / TX 1), so a bare name opens a
+        population the answer never described.
 
         ``portfolio_criteria`` replays Portfolio Builder predicates when
         the CTA opens Lead Queue, so the queue reflects the built population
@@ -231,6 +237,7 @@ class LeadRepository(Protocol):
         county_fipses: list[str] | None = None,
         state_codes: list[str] | None = None,
         zip_codes: list[str] | None = None,
+        city_states: list[str] | None = None,
         borrower_ids: list[str] | None = None,
         segment_codes: list[str] | None = None,
         segment_mode: str = "any",

--- a/frontend/src/components/mortgage/GenieAnswer.links.test.tsx
+++ b/frontend/src/components/mortgage/GenieAnswer.links.test.tsx
@@ -91,7 +91,7 @@ describe('GenieAnswer UC + route linkage', () => {
     expect(container.textContent).toContain('Source: mip.gold.borrower_360');
   });
 
-  it('links borrower_id and state table cells, leaving city plain', () => {
+  it('links borrower_id, state, and a city that carries its own state', () => {
     mount(
       payload({
         answer: 'Top borrowers.',
@@ -103,7 +103,24 @@ describe('GenieAnswer UC + route linkage', () => {
     );
     expect(hrefs).toContain(`/borrower-360/${BORROWER}`);
     expect(hrefs).toContain('/lead-queue?state=IL');
-    expect(hrefs.some((h) => h?.includes('Chicago'))).toBe(false);
+    // The row carries both halves of the key, so the city is a real cohort.
+    // It opens the CITY, never the state it sits in.
+    expect(hrefs).toContain('/lead-queue?cities=CHICAGO~IL');
+  });
+
+  it('leaves a city cell plain when its row carries no state', () => {
+    // A bare name is not a cohort: CYPRESS is CA 14,630 / TX 1, so linking it
+    // to any single state's queue would be a guess. Plain text is honest.
+    mount(
+      payload({
+        answer: 'Top cities.',
+        table_rows: [{ city: 'Chicago', borrowers: 523010 }],
+      } as Partial<GenieAnswerShape>),
+    );
+    const hrefs = Array.from(container.querySelectorAll('.genie-answer__table a')).map((a) =>
+      a.getAttribute('href'),
+    );
+    expect(hrefs.some((h) => h?.toLowerCase().includes('chicago'))).toBe(false);
   });
 
   it('leaves a borrower_id that is not a masked id as plain text', () => {

--- a/frontend/src/components/mortgage/USChoroplethMap.utils.ts
+++ b/frontend/src/components/mortgage/USChoroplethMap.utils.ts
@@ -195,7 +195,9 @@ export interface HoverState {
 }
 
 export interface LeadQueuePathInput {
-  geo: { state?: string; county?: string; zip?: string };
+  /** `cities` carries `CITY~ST` pairs — see `lib/cityStateFilter`. Always a
+   *  pair: a bare name is wrong by 14,631x on the minority side of CYPRESS. */
+  geo: { state?: string; county?: string; zip?: string; cities?: string[] };
   segmentFilter?: string[] | null;
   segmentFilterMode?: 'any' | 'all';
   portfolioCriteria?: Record<string, string | number | null | undefined>;
@@ -208,7 +210,14 @@ export function buildLeadQueuePath({
   portfolioCriteria,
 }: LeadQueuePathInput): string {
   const params = new URLSearchParams();
-  if (geo.state) params.set('state', geo.state);
+  // Ahead of `state` and mutually exclusive with it: the pair already
+  // carries the state, and falling back to it is the 2.3x substitution
+  // (Chicago's 523,010 opening all 1,181,043 of IL).
+  if (geo.cities && geo.cities.length > 0) {
+    params.set('cities', geo.cities.join(','));
+  } else if (geo.state) {
+    params.set('state', geo.state);
+  }
   if (geo.county) params.set('county', geo.county);
   if (geo.zip) params.set('zip', geo.zip);
   if (segmentFilter && segmentFilter.length > 0) {
@@ -223,7 +232,12 @@ export function buildLeadQueuePath({
     if (value === undefined || value === null || value === '') return;
     params.set(key, String(value));
   });
-  return `/lead-queue?${params.toString()}`;
+  // `URLSearchParams` percent-encodes `~` to `%7E`; Python's `urlencode` does
+  // not. Both decode identically and `~` is RFC-3986 unreserved, so restoring
+  // it is a no-op for parsing — but it keeps a frontend-built link
+  // byte-identical to the one the backend emits for the same cohort, which is
+  // what makes `cities=CHICAGO~IL` readable in a shared URL.
+  return `/lead-queue?${params.toString().replace(/%7E/g, '~')}`;
 }
 
 export function buildCountiesPayload(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1232,7 +1232,7 @@ export const api = {
   leadsPage: (
     segment?: string,
     signal?: AbortSignal,
-    geo?: { state?: string; zip?: string; county?: string; counties?: string[]; states?: string[]; zips?: string[]; borrowerIds?: string[] },
+    geo?: { state?: string; zip?: string; county?: string; counties?: string[]; states?: string[]; zips?: string[]; cities?: string[]; borrowerIds?: string[] },
     opts: LeadQueryOptions = {},
   ) => {
     // 2026-05-04 FIX β: forward state + zip to the API so the backend
@@ -1257,6 +1257,8 @@ export const api = {
     if (geo?.counties && geo.counties.length > 0) params.set('counties', geo.counties.join(','));
     if (geo?.states && geo.states.length > 0) params.set('states', geo.states.join(','));
     if (geo?.zips && geo.zips.length > 0) params.set('zips', geo.zips.join(','));
+    // `CITY~ST` pairs. `~` is unreserved, so it survives the encode literal.
+    if (geo?.cities && geo.cities.length > 0) params.set('cities', geo.cities.join(','));
     if (geo?.borrowerIds && geo.borrowerIds.length > 0) params.set('borrower_ids', geo.borrowerIds.join(','));
     if (opts.targetLenderRef) params.set('target_lender_ref', opts.targetLenderRef);
     if (opts.cohortId) params.set('cohort_id', opts.cohortId);
@@ -1294,7 +1296,7 @@ export const api = {
   leads: (
     segment?: string,
     signal?: AbortSignal,
-    geo?: { state?: string; zip?: string; county?: string; counties?: string[]; states?: string[]; zips?: string[]; borrowerIds?: string[] },
+    geo?: { state?: string; zip?: string; county?: string; counties?: string[]; states?: string[]; zips?: string[]; cities?: string[]; borrowerIds?: string[] },
     opts: LeadQueryOptions = {},
   ) => api.leadsPage(segment, signal, geo, opts).then((page) => page.leads),
 

--- a/frontend/src/lib/cityStateFilter.ts
+++ b/frontend/src/lib/cityStateFilter.ts
@@ -1,0 +1,65 @@
+/**
+ * The `(city, state)` cohort filter, frontend side.
+ *
+ * Mirrors `backend/schemas/genie_geo_filters.py`. One key, `cities`, always
+ * plural, whose values are `CITY~ST` pairs.
+ *
+ * A pair and never a bare name: `mip.gold.borrower_360` holds 428 distinct
+ * city names but 433 distinct `(city, state)` pairs, and five names span two
+ * states with a tiny minority side — CYPRESS is CA 14,630 / TX 1, so a
+ * name-only filter is wrong by 14,631x on the TX side. `~` is RFC-3986
+ * unreserved, so `URLSearchParams` leaves it literal and a shared link reads
+ * `?cities=CHICAGO~IL`.
+ */
+
+export const CITY_STATE_SEPARATOR = '~';
+
+/** `CITY~ST`. Mirrors `CITY_STATE_PAIR_RE`; keep the two in step. */
+export const CITY_STATE_PAIR_RE = /^[A-Z][A-Z .-]{0,47}~[A-Z]{2}$/;
+
+/** 2-letter USPS state code, as emitted by the gold tables. */
+export const CITY_STATE_CODE_RE = /^[A-Z]{2}$/;
+
+/** Gold stores city uppercase; collapse whitespace so hand-typed input matches. */
+export function normalizeCityName(value: string): string {
+  return value.trim().toUpperCase().replace(/\s+/g, ' ');
+}
+
+/**
+ * Build one `CITY~ST` token, or `null` when either half is unusable.
+ *
+ * Returning `null` must mean "render plain text" at every call site. Falling
+ * back to the state is the 2.3x silent substitution this filter replaces.
+ */
+export function formatCityStatePair(city: unknown, state: unknown): string | null {
+  if (typeof city !== 'string' || typeof state !== 'string') return null;
+  const cityText = normalizeCityName(city);
+  const stateText = state.trim().toUpperCase();
+  if (!cityText || !CITY_STATE_CODE_RE.test(stateText)) return null;
+  const token = `${cityText}${CITY_STATE_SEPARATOR}${stateText}`;
+  return CITY_STATE_PAIR_RE.test(token) ? token : null;
+}
+
+/** Columns a Genie answer uses for the city half of the key. */
+export const CITY_COLUMNS = new Set(['city', 'situs_city']);
+
+/** Columns a Genie answer uses for the state half of the key. */
+export const CITY_STATE_COLUMNS = new Set(['state', 'state_code']);
+
+/**
+ * Read the state that sits beside a city IN THE SAME ROW.
+ *
+ * The row is the unit. A state taken from anywhere else — the answer's overall
+ * state list, a neighbouring row — pairs a city with a state the answer never
+ * put it in, which is how `CYPRESS~TX` gets invented from a CA row.
+ */
+export function rowStateFor(row: Record<string, unknown> | null | undefined): string | null {
+  if (!row) return null;
+  for (const [key, value] of Object.entries(row)) {
+    if (!CITY_STATE_COLUMNS.has(key.trim().toLowerCase())) continue;
+    if (typeof value !== 'string') continue;
+    const state = value.trim().toUpperCase();
+    if (CITY_STATE_CODE_RE.test(state)) return state;
+  }
+  return null;
+}

--- a/frontend/src/lib/genieCellLinks.test.ts
+++ b/frontend/src/lib/genieCellLinks.test.ts
@@ -31,8 +31,17 @@ describe('genieCellHref', () => {
     expect(genieCellHref('state_code', 'TX')).toBe('/lead-queue?state=TX');
   });
 
-  it('leaves a city cell plain — no route supports a city filter', () => {
+  it('leaves a city cell plain when its own row carries no state', () => {
+    // Fail closed. A bare name is ambiguous across states (CYPRESS is
+    // CA 14,630 / TX 1), so there is no honest cohort to link to.
     expect(genieCellHref('city', 'Chicago')).toBeNull();
+    expect(genieCellHref('city', 'Chicago', {}, { city: 'Chicago', n: 523010 })).toBeNull();
+  });
+
+  it('links a city cell to the (city, state) cohort when the row carries a state', () => {
+    expect(genieCellHref('city', 'Chicago', {}, { city: 'Chicago', state: 'IL' })).toBe(
+      '/lead-queue?cities=CHICAGO~IL',
+    );
   });
 
   it('leaves a borrower_id that does not match the masked shape plain', () => {

--- a/frontend/src/lib/genieCellLinks.ts
+++ b/frontend/src/lib/genieCellLinks.ts
@@ -14,6 +14,7 @@
  */
 
 import { buildLeadQueuePath } from '../components/mortgage/USChoroplethMap.utils';
+import { CITY_COLUMNS, formatCityStatePair, rowStateFor } from './cityStateFilter';
 
 /** Canonical masked borrower id (CLAUDE.md naming rules). */
 export const MASKED_BORROWER_ID_RE = /^B-[0-9A-Z]{13}$/;
@@ -175,11 +176,42 @@ export function segmentLeadQueuePath(
 }
 
 /**
+ * City-filtered Lead Queue link, or null when the row cannot be keyed.
+ *
+ * The state MUST come from the row's own cells. A city name alone is not a
+ * cohort: 5 of the 428 city names in gold live in two states, and the minority
+ * side is tiny (CYPRESS is CA 14,630 / TX 1), so pairing a city with a state
+ * borrowed from anywhere else — the answer's overall state list, a
+ * neighbouring row — invents a cohort the answer never described.
+ *
+ * Returning null means the cell renders as plain text, which is the honest
+ * outcome for a city-only answer. It must never fall back to the state's
+ * queue: that is the 2.3x substitution measured live 2026-08-11 (Chicago's
+ * 523,010 opening all 1,181,043 of IL).
+ */
+export function cityLeadQueuePath(
+  city: unknown,
+  row: Record<string, unknown> | null | undefined,
+  cohort: GenieAnswerCohort = {},
+): string | null {
+  const pair = formatCityStatePair(city, rowStateFor(row));
+  if (!pair) return null;
+  return buildLeadQueuePath({
+    geo: { cities: [pair] },
+    segmentFilter: cohort.segmentFilter,
+    segmentFilterMode: cohort.segmentFilterMode ?? 'any',
+    portfolioCriteria: cohort.portfolioCriteria,
+  });
+}
+
+/**
  * Resolve a table cell to an in-app route, or null when it should render as
- * plain text. `city` intentionally returns null: no route in `app.tsx`
- * supports a city filter (`lead-queue.filters.ts` has no city param), and a
- * link that silently drops the filter misleads the reader — which is exactly
- * why `cohort` exists for the state case.
+ * plain text.
+ *
+ * A `city` cell links ONLY when its own row carries a state. Without one the
+ * cell stays plain text — a link that silently widened the filter to the state
+ * would mislead the reader, which is exactly why `cohort` exists for the state
+ * case.
  */
 export function genieCellHref(
   column: string,
@@ -190,6 +222,9 @@ export function genieCellHref(
   const key = column.trim().toLowerCase();
   if (BORROWER_ID_COLUMNS.has(key) && isMaskedBorrowerId(value)) {
     return borrower360Path(value as string);
+  }
+  if (CITY_COLUMNS.has(key)) {
+    return cityLeadQueuePath(value, row, cohort);
   }
   if (STATE_COLUMNS.has(key) && isStateCode(value)) {
     return stateLeadQueuePath(value as string, cohort);

--- a/frontend/src/routes/lead-queue.filters.ts
+++ b/frontend/src/routes/lead-queue.filters.ts
@@ -321,6 +321,10 @@ export interface LeadQueueExportFiltersInput {
   zipFilter?: string;
   stateFilters?: string[];
   zipFilters?: string[];
+  /** `CITY~ST` pairs. Unlisted keys are silently dropped by this
+   *  allowlist, so an export of a city cohort would otherwise describe
+   *  itself as unfiltered. */
+  cityFilters?: string[];
   borrowerIdFilters?: string[];
   countyFilter?: string;
   countyFilters?: string[];
@@ -346,6 +350,7 @@ export function buildLeadQueueExportFilters(input: LeadQueueExportFiltersInput):
   if (input.zipFilter) params.set('zip', input.zipFilter);
   if (input.stateFilters?.length) params.set('states', input.stateFilters.join(','));
   if (input.zipFilters?.length) params.set('zips', input.zipFilters.join(','));
+  if (input.cityFilters?.length) params.set('cities', input.cityFilters.join(','));
   if (input.borrowerIdFilters?.length) {
     params.set('borrower_ids', input.borrowerIdFilters.join(','));
   }

--- a/frontend/src/routes/lead-queue.tsx
+++ b/frontend/src/routes/lead-queue.tsx
@@ -15,6 +15,7 @@ import { useFootprint } from '../components/FootprintProvider';
 import { useApp } from '../components/AppContext';
 import { queryKeys } from '../lib/queryKeys';
 import { LENDER_RELATIONSHIP_OPTIONS } from '../lib/lenderFilters';
+import { CITY_STATE_PAIR_RE } from '../lib/cityStateFilter';
 import { LeadQueueTableSkeleton } from './lead-queue.skeleton';
 import {
   AGING_FILTER_OPTIONS,
@@ -94,6 +95,10 @@ export default function LeadQueue() {
   );
   const zipFilters = useMemo(
     () => parseCsvParam(searchParams.get('zips'), /^\d{5}$/, 50),
+    [searchParams],
+  );
+  const cityFilters = useMemo(
+    () => parseCsvParam(searchParams.get('cities'), CITY_STATE_PAIR_RE, 50),
     [searchParams],
   );
   const borrowerIdFilters = useMemo(
@@ -221,6 +226,7 @@ export default function LeadQueue() {
         counties: countyFilters,
         states: stateFilters,
         zips: zipFilters,
+        cities: cityFilters,
         borrowerIds: borrowerIdFilters,
       },
       {
@@ -244,6 +250,7 @@ export default function LeadQueue() {
       countyFilters.join(','),
       stateFilters.join(','),
       zipFilters.join(','),
+      cityFilters.join(','),
       borrowerIdFilters.join(','),
       segmentCodes.join(','),
       segmentMode,
@@ -361,6 +368,7 @@ export default function LeadQueue() {
       zipFilter,
       stateFilters,
       zipFilters,
+      cityFilters,
       borrowerIdFilters,
       countyFilter,
       countyFilters,
@@ -384,6 +392,7 @@ export default function LeadQueue() {
       || zipFilter
       || stateFilters.length > 0
       || zipFilters.length > 0
+      || cityFilters.length > 0
       || borrowerIdFilters.length > 0
       || countyFilter
       || countyFilters.length > 0
@@ -409,6 +418,11 @@ export default function LeadQueue() {
   if (zipFilter) heroFilterChips.push({ key: 'zip', variant: 'neutral', label: `zip = ${zipFilter}` });
   if (stateFilters.length > 0) heroFilterChips.push({ key: 'states', variant: 'neutral', label: `states = ${stateFilters.join(', ')}` });
   if (zipFilters.length > 0) heroFilterChips.push({ key: 'zips', variant: 'neutral', label: `zips = ${zipFilters.length} selected` });
+  if (cityFilters.length > 0) {
+    // Spell the pairs out: `CHICAGO~IL` is the whole point, and a count
+    // would hide which state each city was resolved in.
+    heroFilterChips.push({ key: 'cities', variant: 'neutral', label: `cities = ${cityFilters.join(', ')}` });
+  }
   if (borrowerIdFilters.length > 0) heroFilterChips.push({ key: 'borrowers', variant: 'neutral', label: `borrowers = ${borrowerIdFilters.length} selected` });
   if (countyFilter) heroFilterChips.push({ key: 'county', variant: 'neutral', label: `county = ${countyFilter}` });
   if (countyFilters.length > 0) heroFilterChips.push({ key: 'counties', variant: 'neutral', label: `counties = ${countyFilters.length} selected` });
@@ -432,6 +446,7 @@ export default function LeadQueue() {
       || stateFilter
       || stateFilters.length > 0
       || zipFilters.length > 0
+      || cityFilters.length > 0
       || borrowerIdFilters.length > 0,
   );
 
@@ -494,6 +509,7 @@ export default function LeadQueue() {
               {countyFilters.length > 0 && <span className="lead-queue-scope__pill">Counties: {countyFilters.join(', ')}</span>}
               {stateFilters.length > 0 && <span className="lead-queue-scope__pill">States: {stateFilters.join(', ')}</span>}
               {zipFilters.length > 0 && <span className="lead-queue-scope__pill">ZIPs: {zipFilters.join(', ')}</span>}
+              {cityFilters.length > 0 && <span className="lead-queue-scope__pill">Cities: {cityFilters.join(', ')}</span>}
               {borrowerIdFilters.length > 0 && <span className="lead-queue-scope__pill">Borrowers: {borrowerIdFilters.length}</span>}
               {/* 2026-08-07 audit C4: geo drill-ins show EVERY borrower the
                   map counted (no score floor — the map-tile promise), so the

--- a/tests/fixtures/in_process_repos.py
+++ b/tests/fixtures/in_process_repos.py
@@ -47,6 +47,7 @@ from backend.schemas.analytics import (
 )
 from backend.schemas.common import EvidenceEvent
 from backend.schemas.funnel import FunnelPopulation
+from backend.schemas.genie_geo_filters import parse_city_state_pair
 from backend.schemas.geo import (
     CountyRollup,
     CountyRollupResponse,
@@ -589,6 +590,7 @@ class InProcessMockLeadRepository:
         county_fipses: list[str] | None = None,
         state_codes: list[str] | None = None,
         zip_codes: list[str] | None = None,
+        city_states: list[str] | None = None,
         borrower_ids: list[str] | None = None,
         segment_codes: list[str] | None = None,
         segment_mode: str = "any",
@@ -680,6 +682,19 @@ class InProcessMockLeadRepository:
         if zip_codes:
             allowed_zips = {code for code in zip_codes if code}
             leads = [lead for lead in leads if lead.zip in allowed_zips]
+        if city_states:
+            # Pair-keyed, like the SQL: a bare name would match
+            # CYPRESS in both CA and TX.
+            allowed_pairs = {
+                (pair[0], pair[1])
+                for token in city_states
+                if (pair := parse_city_state_pair(token)) is not None
+            }
+            leads = [
+                lead for lead in leads
+                if ((lead.city or '').strip().upper(), (lead.state or '').strip().upper())
+                in allowed_pairs
+            ]
         if borrower_ids:
             allowed_ids = {borrower_id for borrower_id in borrower_ids if borrower_id}
             leads = [lead for lead in leads if lead.borrower_id in allowed_ids]
@@ -703,6 +718,7 @@ class InProcessMockLeadRepository:
         county_fipses: list[str] | None = None,
         state_codes: list[str] | None = None,
         zip_codes: list[str] | None = None,
+        city_states: list[str] | None = None,
         borrower_ids: list[str] | None = None,
         segment_codes: list[str] | None = None,
         segment_mode: str = "any",
@@ -727,6 +743,7 @@ class InProcessMockLeadRepository:
             county_fipses=county_fipses,
             state_codes=state_codes,
             zip_codes=zip_codes,
+            city_states=city_states,
             borrower_ids=borrower_ids,
             segment_codes=segment_codes,
             segment_mode=segment_mode,

--- a/tests/fixtures/openapi_baseline.json
+++ b/tests/fixtures/openapi_baseline.json
@@ -18672,6 +18672,25 @@
             }
           },
           {
+            "description": "Optional comma-separated CITY~ST pairs (for example CHICAGO~IL,FORT LAUDERDALE~FL) for city-grain Genie cohort actions. Always a pair: 5 city names in gold span two states, so a bare name opens the wrong population.",
+            "in": "query",
+            "name": "cities",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 4096,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional comma-separated CITY~ST pairs (for example CHICAGO~IL,FORT LAUDERDALE~FL) for city-grain Genie cohort actions. Always a pair: 5 city names in gold span two states, so a bare name opens the wrong population.",
+              "title": "Cities"
+            }
+          },
+          {
             "description": "Optional comma-separated synthetic borrower IDs for Genie borrower-list cohort actions.",
             "in": "query",
             "name": "borrower_ids",
@@ -26089,6 +26108,25 @@
               ],
               "description": "Optional comma-separated 5-digit county FIPS list for Genie-generated cohort actions.",
               "title": "Counties"
+            }
+          },
+          {
+            "description": "Optional comma-separated CITY~ST pairs (for example CHICAGO~IL,FORT LAUDERDALE~FL) for city-grain Genie cohort actions. Always a pair: 5 city names in gold span two states, so a bare name opens the wrong population.",
+            "in": "query",
+            "name": "cities",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 4096,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional comma-separated CITY~ST pairs (for example CHICAGO~IL,FORT LAUDERDALE~FL) for city-grain Genie cohort actions. Always a pair: 5 city names in gold span two states, so a bare name opens the wrong population.",
+              "title": "Cities"
             }
           },
           {

--- a/tests/unit/test_city_state_cohort_filter.py
+++ b/tests/unit/test_city_state_cohort_filter.py
@@ -1,0 +1,469 @@
+"""The `(city, state)` cohort filter, pinned at the layer each defect lives in.
+
+A city-grain Genie answer could not hand off an honest cohort. Measured live on
+paychex gold 2026-08-11 against an answer stating Chicago = 523,010 cash-out
+candidates:
+
+    rows [{city}]        -> `/lead-queue?product=Cash-out`   3,474,216   6.6x
+    rows [{city, state}] -> the STATE substituted             1,181,043   2.3x
+
+Both were merely disclosed. `cities=CHICAGO~IL` + cash-out returns 523,010 --
+the number the answer states (re-measured live 2026-08-12).
+
+Each test below asserts at the layer that can actually be wrong:
+
+1. the six closed vocabularies agree                (a key one accepts and
+                                                     another rejects 500s
+                                                     AFTER the cohort is written)
+2. the row reader pairs WITHIN a row                (a cross product invents
+                                                     CYPRESS~TX from a CA row)
+3. a city with no state emits nothing               (fail closed)
+4. a city with a state emits the CITY, not the state
+5. list / count / cohort_identity share one predicate, bound
+6. the router parses a multi-word city off the URL
+7. the handoff fingerprint moves when only `cities` moves
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.schemas.genie_geo_filters import (
+    CITY_STATE_PAIR_RE,
+    GENIE_CITY_FILTER_KEY,
+    MAX_CITY_FILTER_VALUES,
+    format_city_state_pair,
+    parse_city_state_pair,
+)
+from backend.schemas.lead import LeadSummary
+from backend.services.repositories import get_lead_repository
+from backend.services.repositories.databricks_genie_actions import (
+    _route_from_answer_rows,
+    _row_pairs,
+)
+from backend.services.repositories.databricks_lead_cohorts import (
+    LeadCohortFilters,
+    normalise_lead_queue_handoff_filters,
+)
+from backend.services.repositories.databricks_leads import DatabricksLeadRepository
+
+_B360 = "mip.gold.borrower_360"
+_CITY_SQL = (
+    f"SELECT city, state, COUNT(*) AS n FROM {_B360} "
+    "WHERE recommended_offer_code = 'cash_out' GROUP BY city, state"
+)
+
+
+# --- 1. the six closed vocabularies ----------------------------------------
+#
+# PR #191 added a key to ONE of these. Every Genie action carrying it would
+# have raised `AuditMetadataValueViolation` -- a RuntimeError, which
+# `handle_genie_action`'s `except ValueError` does not catch -- as an
+# unhandled 500, AFTER the Lakebase cohort row was already written.
+
+
+def test_cities_is_in_every_closed_vocabulary_that_gates_the_handoff() -> None:
+    from backend.schemas.campaign_json_projection import _GENIE_REPLAY_FILTER_KEYS
+    from backend.services.audit_store import _ALLOWED_RESULT_FILTER_KEYS
+    from backend.services.genie_actions import (
+        _LEAD_QUEUE_REPLAY_KEYS,
+        _REPLAYABLE_FILTER_KEYS,
+    )
+    from backend.services.repositories.databricks_genie_actions import (
+        _REPLAYABLE_ROUTE_FILTER_KEYS,
+    )
+
+    vocabularies = {
+        "databricks_genie_actions._REPLAYABLE_ROUTE_FILTER_KEYS": (
+            _REPLAYABLE_ROUTE_FILTER_KEYS
+        ),
+        "genie_actions._REPLAYABLE_FILTER_KEYS": _REPLAYABLE_FILTER_KEYS,
+        "genie_actions._LEAD_QUEUE_REPLAY_KEYS": _LEAD_QUEUE_REPLAY_KEYS,
+        "audit_store._ALLOWED_RESULT_FILTER_KEYS": _ALLOWED_RESULT_FILTER_KEYS,
+        "campaign_json_projection._GENIE_REPLAY_FILTER_KEYS": _GENIE_REPLAY_FILTER_KEYS,
+    }
+    missing = [name for name, vocab in vocabularies.items() if GENIE_CITY_FILTER_KEY not in vocab]
+    assert not missing, f"{GENIE_CITY_FILTER_KEY} missing from: {missing}"
+
+
+def test_the_sixth_vocabulary_projects_cities_into_the_treatment_set() -> None:
+    """``cohort_filters_from_campaign_criteria`` is a mapping, not a key set.
+
+    A key it ignores materializes the STATE the pairs live in rather than the
+    cities the approved answer described.
+    """
+
+    from backend.services.campaign_treatment import cohort_filters_from_campaign_criteria
+
+    filters = cohort_filters_from_campaign_criteria(
+        {
+            "source": "genie",
+            "result_filters": {GENIE_CITY_FILTER_KEY: ["CHICAGO~IL"]},
+        }
+    )
+    assert filters.city_states == ["CHICAGO~IL"]
+
+
+def test_the_audit_ledger_accepts_what_the_cohort_writer_emits() -> None:
+    """Same regex on both sides, so neither can refuse the other's pair."""
+
+    from backend.services.audit_store import _assert_result_filters_value_policy
+
+    _assert_result_filters_value_policy({GENIE_CITY_FILTER_KEY: ["FORT LAUDERDALE~FL"]})
+
+
+def test_the_audit_ledger_still_refuses_a_bare_city_name() -> None:
+    from backend.services.audit_store import (
+        AuditMetadataValueViolation,
+        _assert_result_filters_value_policy,
+    )
+
+    with pytest.raises(AuditMetadataValueViolation):
+        _assert_result_filters_value_policy({GENIE_CITY_FILTER_KEY: ["CHICAGO"]})
+
+
+# --- 2. the row reader pairs WITHIN a row ----------------------------------
+
+
+def test_row_pairs_never_cross_products_two_rows() -> None:
+    """The bug this reader exists to prevent.
+
+    Reading city and state with two `_row_values` calls yields
+    {CYPRESS, SUNNYVALE} x {CA, TX} = 4 pairs. Two of them are cohorts the
+    answer never described, and both sit on the wrong side of a 14,631x split
+    (CYPRESS is CA 14,630 / TX 1; SUNNYVALE is TX 3,833 / CA 1).
+    """
+
+    pairs = _row_pairs(
+        [
+            {"city": "CYPRESS", "state": "CA", "n": 14630},
+            {"city": "SUNNYVALE", "state": "TX", "n": 3833},
+        ],
+        left_columns=("city", "situs_city"),
+        right_columns=("state", "state_code"),
+    )
+
+    assert pairs == [("CYPRESS", "CA"), ("SUNNYVALE", "TX")]
+    assert ("CYPRESS", "TX") not in pairs
+    assert ("SUNNYVALE", "CA") not in pairs
+
+
+def test_row_pairs_drops_a_row_that_carries_only_the_left_half() -> None:
+    pairs = _row_pairs(
+        [{"city": "CHICAGO", "n": 523010}, {"city": "HOUSTON", "state": "TX"}],
+        left_columns=("city",),
+        right_columns=("state",),
+    )
+    assert pairs == [("HOUSTON", "TX")]
+
+
+# --- 3 & 4. what the route emits -------------------------------------------
+
+
+def test_a_city_without_a_state_emits_no_geography_at_all() -> None:
+    """Fail closed. Not `states`, not a guessed `cities` -- nothing."""
+
+    route, filters = _route_from_answer_rows(
+        question="Which city has the most cash-out candidates?",
+        rows=[{"city": "CHICAGO", "n": 523010}],
+        borrower_ids=[],
+        sql_query=_CITY_SQL,
+    )
+
+    assert GENIE_CITY_FILTER_KEY not in filters
+    assert "states" not in filters
+    assert filters["city_grain_unreplayable"] is True
+    assert "cities=" not in route
+    assert "states=" not in route
+
+
+def test_a_city_with_its_state_opens_the_city_and_not_the_state() -> None:
+    route, filters = _route_from_answer_rows(
+        question="Which city has the most cash-out candidates?",
+        rows=[{"city": "CHICAGO", "state": "IL", "n": 523010}],
+        borrower_ids=[],
+        sql_query=_CITY_SQL,
+    )
+
+    assert filters[GENIE_CITY_FILTER_KEY] == ["CHICAGO~IL"]
+    # The 2.3x substitution. The pair already carries IL; emitting `states`
+    # beside it re-opens all 1,181,043 of Illinois.
+    assert "states" not in filters
+    assert "city_grain_unreplayable" not in filters
+    assert "cities=CHICAGO~IL" in route
+
+
+def test_one_unpairable_city_suppresses_the_whole_filter() -> None:
+    """Partial replay would answer a NARROWER question under the same heading."""
+
+    _, filters = _route_from_answer_rows(
+        question="Which cities have the most cash-out candidates?",
+        rows=[
+            {"city": "CHICAGO", "state": "IL", "n": 523010},
+            {"city": "HOUSTON", "n": 311000},
+        ],
+        borrower_ids=[],
+        sql_query=_CITY_SQL,
+    )
+
+    assert GENIE_CITY_FILTER_KEY not in filters
+    assert filters["city_grain_unreplayable"] is True
+
+
+def test_the_two_state_split_survives_the_whole_route() -> None:
+    """Both sides of the ambiguity, from one answer, keyed correctly."""
+
+    _, filters = _route_from_answer_rows(
+        question="Where are the CYPRESS cash-out candidates?",
+        rows=[
+            {"city": "CYPRESS", "state": "CA", "n": 14630},
+            {"city": "CYPRESS", "state": "TX", "n": 1},
+        ],
+        borrower_ids=[],
+        sql_query=_CITY_SQL,
+    )
+
+    assert filters[GENIE_CITY_FILTER_KEY] == ["CYPRESS~CA", "CYPRESS~TX"]
+
+
+def test_a_borrower_list_that_projects_city_emits_no_city_filter() -> None:
+    """`borrower_ids` pins the cohort exactly; a city column broadens nothing."""
+
+    _, filters = _route_from_answer_rows(
+        question="Who are the top cash-out candidates?",
+        rows=[{"borrower_id": "B-0000000000001", "city": "CHICAGO", "state": "IL"}],
+        borrower_ids=["B-0000000000001"],
+        sql_query=_CITY_SQL,
+    )
+
+    assert GENIE_CITY_FILTER_KEY not in filters
+    assert "city_grain_unreplayable" not in filters
+
+
+# --- the canonical pair shape ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("city", "state", "expected"),
+    [
+        ("CHICAGO", "IL", "CHICAGO~IL"),
+        ("Fort Lauderdale", "fl", "FORT LAUDERDALE~FL"),
+        # The one hyphenated value in gold, measured 2026-08-12.
+        ("UNION HILL-NOVELTY HILL", "WA", "UNION HILL-NOVELTY HILL~WA"),
+        ("  SPACED   OUT  ", "TX", "SPACED OUT~TX"),
+        ("CHICAGO", "", ""),
+        ("", "IL", ""),
+        ("CHICAGO", "ILLINOIS", ""),
+        # `~` is the separator; a city containing one would break the key.
+        # Measured: no gold city contains it.
+        ("CHIC~AGO", "IL", ""),
+    ],
+)
+def test_format_city_state_pair_shape(city: str, state: str, expected: str) -> None:
+    assert format_city_state_pair(city, state) == expected
+
+
+def test_the_separator_survives_a_url_encode_literal() -> None:
+    """`~` is RFC-3986 unreserved, which is why it was chosen."""
+
+    from urllib.parse import urlencode
+
+    assert urlencode({GENIE_CITY_FILTER_KEY: "CHICAGO~IL"}) == "cities=CHICAGO~IL"
+
+
+def test_the_pair_regex_and_the_parser_agree() -> None:
+    assert CITY_STATE_PAIR_RE.fullmatch("CHICAGO~IL") is not None
+    assert parse_city_state_pair("CHICAGO~IL") == ("CHICAGO", "IL")
+    assert parse_city_state_pair("CHICAGO") is None
+    assert parse_city_state_pair("~IL") is None
+    assert parse_city_state_pair(None) is None
+
+
+# --- 5. one predicate, three callers, bound --------------------------------
+
+
+class _CapturingClient:
+    """Records the SQL and params each read path actually issued."""
+
+    def __init__(self) -> None:
+        self.calls: dict[str, tuple[str, dict[str, object]]] = {}
+
+    def execute(self, sql: str, params: dict[str, object] | None = None) -> list[dict[str, object]]:
+        self.calls["list"] = (sql, dict(params or {}))
+        return []
+
+    def execute_one(self, sql: str, params: dict[str, object] | None = None) -> dict[str, object]:
+        key = "identity" if "cohort_digest" in sql else "count"
+        self.calls[key] = (sql, dict(params or {}))
+        return {
+            "n": 523010,
+            "ranked_n": 100,
+            "cohort_digest": "a" * 64,
+            "snapshot_id": "snap-1",
+        }
+
+
+_EXPECTED_CITY_PREDICATE = (
+    "AND ((UPPER(b.city) = :city_0 AND b.state = :cstate_0))"
+)
+
+
+def test_list_count_and_identity_emit_the_same_bound_city_predicate() -> None:
+    """A threshold applied to the rows but not the total is the whole defect.
+
+    `X-Total-Matching` comes from `count`, the rows from `list`, and the
+    signed proof from `cohort_identity`. If any one of them omits the city
+    predicate the header lies about the population on screen.
+    """
+
+    client = _CapturingClient()
+    repo = DatabricksLeadRepository(client, cache_ttl_s=0)  # type: ignore[arg-type]
+    kwargs: dict[str, object] = {
+        "segment": None,
+        "portfolio_id": None,
+        "city_states": ["CHICAGO~IL"],
+    }
+
+    repo.list(**kwargs)  # type: ignore[arg-type]
+    repo.count(**kwargs)  # type: ignore[arg-type]
+    repo.cohort_identity(**kwargs)  # type: ignore[arg-type]
+
+    assert set(client.calls) == {"list", "count", "identity"}
+    for name, (sql, params) in client.calls.items():
+        assert _EXPECTED_CITY_PREDICATE in sql, name
+        # Bound, never interpolated: the value must not appear in the text.
+        assert "CHICAGO" not in sql, name
+        assert params["city_0"] == "CHICAGO", name
+        assert params["cstate_0"] == "IL", name
+
+
+def test_two_pairs_compile_to_an_or_of_ands_not_a_cross_product() -> None:
+    """`city IN (...) AND state IN (...)` would also match CYPRESS~TX."""
+
+    client = _CapturingClient()
+    repo = DatabricksLeadRepository(client, cache_ttl_s=0)  # type: ignore[arg-type]
+    repo.count(segment=None, portfolio_id=None, city_states=["CYPRESS~CA", "SUNNYVALE~TX"])
+
+    sql, params = client.calls["count"]
+    assert (
+        "AND ((UPPER(b.city) = :city_0 AND b.state = :cstate_0) "
+        "OR (UPPER(b.city) = :city_1 AND b.state = :cstate_1))"
+    ) in sql
+    assert params["city_0"] == "CYPRESS"
+    assert params["cstate_0"] == "CA"
+    assert params["city_1"] == "SUNNYVALE"
+    assert params["cstate_1"] == "TX"
+
+
+def test_a_malformed_pair_reaches_the_warehouse_as_no_predicate() -> None:
+    """Last line of defence. A bare name must never compile to a city match."""
+
+    client = _CapturingClient()
+    repo = DatabricksLeadRepository(client, cache_ttl_s=0)  # type: ignore[arg-type]
+    repo.count(segment=None, portfolio_id=None, city_states=["CHICAGO"], state_codes=["IL"])
+
+    sql, _ = client.calls["count"]
+    assert "UPPER(b.city)" not in sql
+
+
+# --- 6. the router parses a multi-word city off the URL --------------------
+
+
+class _EchoRepo:
+    """Captures exactly what the router handed the repository."""
+
+    seen: dict[str, object] = {}
+
+    @classmethod
+    def list(cls, **kwargs: object) -> list[LeadSummary]:
+        cls.seen = dict(kwargs)
+        return []
+
+    @classmethod
+    def count(cls, **kwargs: object) -> int:
+        return 0
+
+
+@pytest.fixture
+def echo_repo():
+    prior = app.dependency_overrides.get(get_lead_repository)
+    app.dependency_overrides[get_lead_repository] = lambda: _EchoRepo
+    try:
+        yield _EchoRepo
+    finally:
+        # Snapshot/restore, never pop: conftest registers a session-wide
+        # binding that a pop would delete for every later test.
+        if prior is None:
+            app.dependency_overrides.pop(get_lead_repository, None)
+        else:
+            app.dependency_overrides[get_lead_repository] = prior
+
+
+def test_a_multi_word_city_reaches_the_repository_parsed(echo_repo) -> None:
+    """`parse_csv_filter`'s isalpha()/width check would 422 this.
+
+    4 of the 428 gold city names are 4 words long; reusing that helper would
+    have rejected most of the vocabulary.
+    """
+
+    response = TestClient(app).get("/api/leads?cities=FORT+LAUDERDALE~FL")
+
+    assert response.status_code == 200, response.text
+    assert echo_repo.seen["city_states"] == ["FORT LAUDERDALE~FL"]
+
+
+def test_a_percent_encoded_separator_parses_identically(echo_repo) -> None:
+    """A browser-built link sends `%7E`; both spellings are the same URI."""
+
+    response = TestClient(app).get("/api/leads?cities=CHICAGO%7EIL")
+
+    assert response.status_code == 200, response.text
+    assert echo_repo.seen["city_states"] == ["CHICAGO~IL"]
+
+
+def test_a_bare_city_name_on_the_url_is_refused_not_widened(echo_repo) -> None:
+    response = TestClient(app).get("/api/leads?cities=CHICAGO")
+
+    assert response.status_code == 422
+    assert "CITY~ST" in response.json()["detail"]
+
+
+def test_too_many_pairs_is_refused(echo_repo) -> None:
+    pairs = ",".join(f"CITY{i}~IL" for i in range(MAX_CITY_FILTER_VALUES + 1))
+    response = TestClient(app).get(f"/api/leads?cities={pairs}")
+
+    assert response.status_code == 422
+
+
+# --- 7. the handoff fingerprint ---------------------------------------------
+
+
+def _fingerprint(city_states: list[str] | None) -> dict[str, object]:
+    return normalise_lead_queue_handoff_filters(
+        LeadCohortFilters(segment=None, state_codes=["IL"], city_states=city_states)
+    )
+
+
+def test_the_handoff_fingerprint_moves_when_only_cities_moves() -> None:
+    """Outside the fingerprint, a city cohort signs the same proof as the state.
+
+    `verify_growth_agent_handoff` HMACs these normalized filters, so a key it
+    omits can be edited onto the URL after signing without invalidating it.
+    """
+
+    chicago = _fingerprint(["CHICAGO~IL"])
+    midlothian = _fingerprint(["MIDLOTHIAN~IL"])
+    none_at_all = _fingerprint(None)
+
+    assert chicago[GENIE_CITY_FILTER_KEY] == ["CHICAGO~IL"]
+    assert chicago != midlothian
+    assert chicago != none_at_all
+    assert GENIE_CITY_FILTER_KEY not in none_at_all
+
+
+def test_the_fingerprint_is_order_stable() -> None:
+    assert _fingerprint(["HOUSTON~TX", "CHICAGO~IL"]) == _fingerprint(
+        ["CHICAGO~IL", "HOUSTON~TX"]
+    )

--- a/tests/unit/test_genie_sql_floor_extraction.py
+++ b/tests/unit/test_genie_sql_floor_extraction.py
@@ -1058,19 +1058,19 @@ def test_legitimate_disjunctions_still_replay_exactly(
     assert _segments(sql) == expected
 
 
-# --- A city answer has no cohort dimension, and must say so ----------------
+# --- A city answer hands off a city cohort, or says why it could not -------
 #
-# The Lead Queue cannot filter by city, so `_row_values` never reads one. That
-# alone is survivable -- the cohort is broader. Doing it in SILENCE is not, and
-# measured live on paychex gold 2026-08-11 against an answer stating
-# Chicago = 523,010 cash-out candidates there were TWO shapes:
+# Measured live on paychex gold 2026-08-11 against an answer stating
+# Chicago = 523,010 cash-out candidates, a city-grain answer degraded two ways:
 #
 #   rows [{city}]        -> no geography at all: 3,474,216 opened, 6.6x
 #   rows [{city, state}] -> the STATE substituted for the city: 1,181,043, 2.3x
 #
-# The second is worse because it looks deliberate. A real city filter needs a
-# (city, state) pair parameter -- city alone is ambiguous across states
-# (CYPRESS is CA 14,630 / TX 1) -- threaded through six closed vocabularies.
+# The second was worse because it looked deliberate. It is now EXACT: the row
+# carries both halves of the key, so the cohort opens `cities=CHICAGO~IL` and
+# `states` is absent. The first still cannot be keyed -- a bare name is
+# ambiguous across states (CYPRESS is CA 14,630 / TX 1) -- so it keeps the
+# disclosure and adds no geography at all.
 
 
 _CITY_SQL = (
@@ -1089,20 +1089,32 @@ def test_a_city_only_answer_discloses_that_the_cohort_is_broader() -> None:
 
     assert filters["city_grain_unreplayable"] is True
     assert "states" not in filters
+    # Fail closed: a name with no state beside it is not a key.
+    assert "cities" not in filters
 
 
-def test_a_city_answer_that_also_carries_state_still_discloses() -> None:
-    """The state is NOT a stand-in for the city, even though it is a superset."""
+def test_a_city_answer_that_carries_state_opens_the_city_not_the_state() -> None:
+    """The row carries both halves of the key, so the cohort is exact.
 
-    _, filters = _route_from_answer_rows(
+    This inverts the pre-slice expectation. `states == ["IL"]` used to be
+    asserted here: that is the 2.3x substitution (Chicago's 523,010 opening
+    all 1,181,043 of IL) and it is the shape this filter exists to kill.
+    """
+
+    route, filters = _route_from_answer_rows(
         question="Which city has the most cash-out candidates?",
         rows=[{"city": "CHICAGO", "state": "IL", "n": 523010}],
         borrower_ids=[],
         sql_query=_CITY_SQL,
     )
 
-    assert filters["states"] == ["IL"]
-    assert filters["city_grain_unreplayable"] is True
+    assert filters["cities"] == ["CHICAGO~IL"]
+    # The pair already carries the state. Emitting `states` alongside it is
+    # the substitution, one indirection later.
+    assert "states" not in filters
+    assert "city_grain_unreplayable" not in filters
+    # `~` is RFC-3986 unreserved, so the link stays readable.
+    assert "cities=CHICAGO~IL" in route
 
 
 def test_a_state_answer_is_not_labelled_city_grain() -> None:


### PR DESCRIPTION
## The defect

A city-grain Genie answer could not key a cohort, so the handoff degraded two ways. Measured live on paychex gold against an answer stating **Chicago = 523,010 cash-out candidates**:

| answer rows | route it opened | matched | error |
| --- | --- | --- | --- |
| `[{city}]` | `/lead-queue?product=Cash-out` | 3,474,216 | 6.6x too broad |
| `[{city, state}]` | the **state** substituted | 1,181,043 | 2.3x too broad |

Both were merely **disclosed** (`city_grain_unreplayable`). The second is the worse one, because it looks deliberate.

## The result

`cities=CHICAGO~IL` + cash-out returns **523,010** — the number the answer states. Re-measured live 2026-08-12 by running the repository's own generated SQL against `mip.gold.borrower_360`.

The Lead Queue's own count for that URL is **23,224**, because the queue keeps its fail-closed `Eligible only` default. That is the pre-existing addressable-vs-contactable gap (22.5x here), unchanged by this PR — the geography axis is now exact, which is what the 2.3x was about.

## Design

One plural key, `cities`, whose values are `CITY~ST` pairs.

**A pair, never a bare name.** Gold holds 428 distinct city names but **433 distinct `(city, state)` pairs**, and 5 names span two states with a tiny minority side:

```
CYPRESS          CA 14,630 / TX      1   -> 14,631x wrong on the TX side
MIDLOTHIAN       IL  6,211 / TX     31
SUNNYVALE        TX  3,833 / CA      1
UNIVERSITY PARK  TX     39 / IL      6
HIGHLAND PARK    TX     10 / IL      3
```

Carrying the state also preserves `CLUSTER BY (state, clip)` file pruning. `~` is RFC-3986 unreserved, so `urlencode` leaves it literal and no gold city contains it.

`county_fips_5` is NULL on every row since audit C2, so city is modelled on `state`/`zips` — vocabularies that are alive — and never on the dead county path.

## The six closed vocabularies

`backend/schemas/genie_geo_filters.py` is the single definition. All six **import** the key rather than spelling it out, because a key one accepts and another rejects raises `AuditMetadataValueViolation` (a `RuntimeError`, which `handle_genie_action`'s `except ValueError` does not catch) **after** the Lakebase cohort row is written — the PR #191 write-then-500 shape.

1. `databricks_genie_actions._REPLAYABLE_ROUTE_FILTER_KEYS`
2. `genie_actions._REPLAYABLE_FILTER_KEYS`
3. `genie_actions._LEAD_QUEUE_REPLAY_KEYS`
4. `audit_store._ALLOWED_RESULT_FILTER_KEYS` + a `cities` branch in `_assert_result_filters_value_policy`
5. `campaign_json_projection._GENIE_REPLAY_FILTER_KEYS`
6. `campaign_treatment.cohort_filters_from_campaign_criteria`

Plus `normalise_lead_queue_handoff_filters`, so the filter is inside the HMAC fingerprint rather than editable onto a signed URL.

## Two places this could have gone wrong quietly

- **`_row_pairs` reads both halves from the same row.** Two `_row_values` calls cross-product to `CYPRESS~TX` and `SUNNYVALE~CA` — cohorts the answer never described, on the wrong side of the split.
- **`parse_city_states` is not `parse_csv_filter`.** That helper's `isalpha()` and fixed-width checks reject every multi-word city (`FORT LAUDERDALE`) and every pair.

## Fail-closed behaviour

- A city with no state beside it emits **no** city filter and keeps the disclosure. It never falls through to `states`.
- One unpairable city suppresses the whole filter — partial replay would answer a narrower question under the same heading.
- A Genie city cell links only when its **own row** carries a state; otherwise it stays plain text.

## Verification

All eight required assertions are pinned at the layer that can be wrong, and each was **mutation-checked**: the fix was reverted, the test confirmed red, then restored. **13/13 mutations killed** (10 backend, 3 frontend).

Gates: `pytest tests/unit` 13,556 passed / 1 skipped / 0 failed; `ruff check backend tests tools` clean; `mypy backend` clean (253 files); `check_file_sizes.py` exit 0; frontend lint clean, 1,045 tests passed, build ✓. `openapi_baseline.json` regenerated — the diff is only the new `cities` param on `/api/leads` and `/api/v1/leads`.

Note: `test_genie_sql_floor_extraction.py::test_a_city_answer_that_also_carries_state_still_discloses` asserted `states == ["IL"]`. That assertion *is* the 2.3x substitution, so it is inverted here rather than kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
