### PR TITLE
fix(guards): close the three residuals a 9,677-question re-sweep left standing

### DIFF
--- a/backend/schemas/_validators_person_names.py
+++ b/backend/schemas/_validators_person_names.py
@@ -153,6 +153,11 @@ _NON_PERSON_TITLECASE_SUFFIXES = frozenset(
         # rest are geographic nouns with no attested surname use.
         "area", "basin", "coast", "empire", "peninsula", "sound",
         "corridor", "district", "tract", "zone",
+        # Second pass, same class: "Front Range", "High Desert", "Wasatch
+        # Front" refused (18 prompts, 22 answer-surface blocks), and the
+        # governed display labels "Investor Product" and "Competitor
+        # Recapture" read as people in narrative prose.
+        "range", "desert", "front", "product", "recapture",
         "equity", "heloc", "loan", "mortgage", "offer", "queue", "refi",
         "refinance", "review",
         "candidate", "candidates", "intent", "risk", "sale", "segment", "segments",

--- a/backend/schemas/_validators_unsafe_text.py
+++ b/backend/schemas/_validators_unsafe_text.py
@@ -258,6 +258,7 @@ def contains_unsafe_ai_text(
     assume_reviewed_read_only_analytics: bool = False,
     name_shape_value: str | None = None,
     name_shape_allowed_phrases: Sequence[str] = (),
+    name_shape_guards: Sequence[tuple[str, Sequence[str], Sequence[str]]] = (),
     name_shape_sentence_initial_place_terms: Sequence[str] = (),
     protected_class_allowed_phrases: Sequence[str] = (),
     protected_class_guards: Sequence[tuple[str, Sequence[str], Sequence[str]]] = (),
@@ -310,7 +311,9 @@ def contains_unsafe_ai_text(
         or contains_prompt_injection_text(text)
         or contains_confidential_or_internal_text(text)
         or contains_human_name_shape(
-            mask_governed_phrases(name_shape_text, name_shape_allowed_phrases),
+            mask_governed_phrases(
+                name_shape_text, name_shape_allowed_phrases, name_shape_guards
+            ),
             include_titlecase=include_titlecase,
             sentence_initial_place_terms=name_shape_sentence_initial_place_terms,
         )

--- a/backend/services/genie_message_policy.py
+++ b/backend/services/genie_message_policy.py
@@ -206,8 +206,11 @@ def identity_prompt_match(question: str) -> bool:
     phrases only, and stripping the opening word leaves the name pair intact.
     """
 
+    name_shape_phrases = _governed_name_shape_phrases()
     scannable = mask_governed_phrases(
-        _mask_safe_phrases(question), _governed_name_shape_phrases()
+        _mask_safe_phrases(question),
+        name_shape_phrases,
+        _governed_name_shape_guards(name_shape_phrases),
     )
     return contains_human_name_shape(
         scannable, sentence_initial_place_terms=_sentence_initial_place_terms()
@@ -240,11 +243,7 @@ def _sentence_initial_place_terms() -> tuple[str, ...]:
         governed = tuple(get_governed_place_dimension().known_place_values())
     except Exception:  # noqa: BLE001 — the guard must never fail the request
         governed = ()
-    return tuple(
-        term
-        for term in US_STATE_NAMES + governed
-        if not shares_token_with_person_lexicon(term)
-    )
+    return US_STATE_NAMES + governed
 
 
 def _visible_text_values(value: object) -> list[str]:
@@ -367,6 +366,7 @@ def genie_visible_text_unsafe(
     if structured_value and normalize_place_value(value) in governed_cell_values:
         return False
     name_shape_phrases: tuple[str, ...] = ()
+    name_shape_guards: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = ()
     protected_class_phrases: tuple[str, ...] = ()
     protected_class_guards: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = ()
     if not structured_value:
@@ -376,6 +376,7 @@ def genie_visible_text_unsafe(
         # wasted read — and the resolver probes cells through this very
         # function, so a structured path that resolved them would recurse.
         name_shape_phrases = _governed_name_shape_phrases()
+        name_shape_guards = _governed_name_shape_guards(name_shape_phrases)
         protected_class_phrases, protected_class_guards = (
             _governed_protected_class_mask_args()
         )
@@ -394,6 +395,7 @@ def genie_visible_text_unsafe(
         assume_reviewed_read_only_analytics=True,
         name_shape_value=_name_shape_scan_copy(value),
         name_shape_allowed_phrases=name_shape_phrases,
+        name_shape_guards=name_shape_guards,
         protected_class_guards=protected_class_guards,
         # Prose only, and the same correction the prompt guard opts into: a
         # capitalized word opening a sentence is orthography. Structured cells
@@ -456,6 +458,21 @@ def _governed_name_shape_phrases() -> tuple[str, ...]:
         from backend.services.genie_place_dimension import get_governed_place_dimension
 
         return tuple(get_governed_place_dimension().name_shape_safe_values())
+    except Exception:  # noqa: BLE001 — the guard must never fail the request
+        return ()
+
+
+def _governed_name_shape_guards(
+    values: tuple[str, ...],
+) -> tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...]:
+    """Nesting guards so an exempt place is not erased out of a longer one."""
+
+    try:
+        from backend.services.genie_place_dimension import (
+            governed_name_shape_mask_guards,
+        )
+
+        return governed_name_shape_mask_guards(values)
     except Exception:  # noqa: BLE001 — the guard must never fail the request
         return ()
 

--- a/backend/services/genie_place_dimension.py
+++ b/backend/services/genie_place_dimension.py
@@ -393,6 +393,58 @@ def protected_term_overlap_guards(value: str) -> tuple[tuple[str, ...], tuple[st
     return (tuple(sorted(lefts)), tuple(sorted(rights)))
 
 
+@lru_cache(maxsize=8)
+def _nesting_guards(values: tuple[str, ...], known: tuple[str, ...]) -> tuple[
+    tuple[str, tuple[str, ...], tuple[str, ...]], ...
+]:
+    """Guards stopping an exempt place being erased out of a LONGER place.
+
+    ``HAZEL CREST`` is exempt; ``EAST HAZEL CREST`` is a separate gold city and
+    is not. Masking the short one out of the long one left "Which East
+    borrowers ...", and the hole created a FRESH title-case pair — so the
+    exemption manufactured the refusal it exists to prevent (102 prompts in a
+    47,936-prompt sweep, 2026-08-12). 37 such nestings exist in the live
+    dimension.
+
+    Same guard mechanism as the fair-lending overlap: the surrounding tokens of
+    the longer value become contexts in which the shorter one is left alone.
+    """
+
+    folded = {value: [token.casefold() for token in value.split()] for value in values}
+    guards: list[tuple[str, tuple[str, ...], tuple[str, ...]]] = []
+    for value, value_tokens in folded.items():
+        lefts: set[str] = set()
+        rights: set[str] = set()
+        width = len(value_tokens)
+        for place in known:
+            place_tokens = place.split()
+            if len(place_tokens) <= width:
+                continue
+            folded_place = [token.casefold() for token in place_tokens]
+            for start in range(len(place_tokens) - width + 1):
+                if folded_place[start : start + width] != value_tokens:
+                    continue
+                if start:
+                    lefts.add(" ".join(place_tokens[:start]))
+                if start + width < len(place_tokens):
+                    rights.add(" ".join(place_tokens[start + width :]))
+        if lefts or rights:
+            guards.append((value, tuple(sorted(lefts)), tuple(sorted(rights))))
+    return tuple(guards)
+
+
+def governed_name_shape_mask_guards(
+    values: Sequence[str],
+) -> tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...]:
+    """Nesting guards for the prose/prompt name-shape mask. Never raises."""
+
+    try:
+        known = tuple(get_governed_place_dimension().known_place_values())
+    except Exception:  # noqa: BLE001 — the guard must never fail the request
+        return ()
+    return _nesting_guards(tuple(values), known)
+
+
 def governed_protected_class_mask_guards(
     values: Sequence[str],
 ) -> tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...]:

--- a/tests/unit/test_genie_prompt_guard_geography.py
+++ b/tests/unit/test_genie_prompt_guard_geography.py
@@ -58,6 +58,10 @@ _LIVE_GOLD_CITIES = (
     "TACOMA",
     "HAWAIIAN GARDENS",
     "INDIAN HEAD PARK",
+    # A nested pair: the short one is exempt, the long one is not.
+    "HAZEL CREST",
+    "EAST HAZEL CREST",
+    "ELK GROVE VILLAGE",
     "BLACK DIAMOND",
     "ALISO VIEJO",
     "FEDERAL WAY",
@@ -522,6 +526,100 @@ def test_a_failed_guard_build_skips_the_mask_entirely(
         assert protected_prompt_match("Tell me about Tacoma's in-the-money borrowers") is not None
     finally:
         _reset_governed_place_dimension_for_tests(None)
+
+
+# A 9,677-question corpus re-sweep plus a 47,936-prompt place x leader sweep
+# (2026-08-12) left these three classes standing after #206 landed.
+_RESIDUALS_NOW_CLEARED = (
+    # ELIZABETH is a live gold city. A person-lexicon filter on the strip's
+    # RECOGNITION vocabulary made it unaskable and unrenderable (+102 refusals)
+    # while removing only 2 of 468 terms and addressing none of the shape its
+    # docstring claimed. The filter is gone; the function-word bank is what
+    # keeps "Do Medina" safe.
+    "Which Elizabeth borrowers are in the money?",
+    "Tell me about Elizabeth borrowers",
+    # HAZEL CREST is exempt; EAST HAZEL CREST is a separate gold city and is
+    # not. Masking the short one out of the long one left "Which East
+    # borrowers", and the HOLE created a fresh title-case pair -- the exemption
+    # manufacturing the refusal it exists to prevent (102 prompts).
+    "Which East Hazel Crest borrowers are in the money?",
+    "Which Elk Grove Village borrowers are in the money?",
+    # Geographic and governed-label formants the pair scan still read as people.
+    "Show me Front Range borrowers",
+    "Rank High Desert leads by opportunity score",
+    "What is the Wasatch Front count?",
+)
+
+_RESIDUAL_NARRATIVES_NOW_RENDER = (
+    "Which Elizabeth borrowers have the highest opportunity score?",
+    "The Front Range accounts for 3,214 in-the-money borrowers.",
+    "The Investor Product segment holds 900 borrowers.",
+    "Competitor Recapture leads the list.",
+)
+
+
+@pytest.mark.usefixtures("governed_cities")
+@pytest.mark.parametrize("prompt", _RESIDUALS_NOW_CLEARED)
+def test_swept_residuals_now_reach_genie(prompt: str) -> None:
+    assert protected_prompt_match(prompt) is None
+    assert identity_prompt_match(prompt) is False
+
+
+@pytest.mark.usefixtures("governed_cities")
+@pytest.mark.parametrize("text", _RESIDUAL_NARRATIVES_NOW_RENDER)
+def test_swept_residual_narratives_now_render(text: str) -> None:
+    assert genie_visible_text_unsafe(text) is False
+
+
+def test_the_structured_path_never_resolves_the_dimension() -> None:
+    """Re-entrancy, pinned with a timeout because the symptom is a HANG.
+
+    The resolver probes cells through ``genie_visible_text_unsafe`` while
+    holding its load lock, so any structured-path call that resolves the
+    dimension deadlocks on a non-reentrant Lock — no assertion fires, CI just
+    times out. Wiring the nesting guards in unconditionally did exactly that
+    on 2026-08-12. This runs the structured path INSIDE a live load and would
+    hang rather than fail if the guard is ever dropped.
+    """
+
+    probed: list[str] = []
+
+    def conflict_probe(value: str) -> bool:
+        probed.append(value)
+        return genie_visible_text_unsafe(value, structured_value=True)
+
+    resolver = GovernedPlaceDimensionResolver(
+        dimension_reader=lambda: ["TACOMA", "HAZEL CREST", "EAST HAZEL CREST"],
+        conflict_predicate=conflict_probe,
+    )
+    _reset_governed_place_dimension_for_tests(resolver)
+    try:
+        assert resolver.conflicting_values() is not None
+        assert probed  # the structured path really ran during the load
+    finally:
+        _reset_governed_place_dimension_for_tests(None)
+
+
+def test_nesting_guard_is_what_clears_the_longer_place(
+    governed_cities: GovernedPlaceDimensionResolver,
+) -> None:
+    """Non-vacuity for the nested-mask fix.
+
+    Without the guard the shorter value is erased out of the longer one and
+    the hole pairs with the sentence-opening word, so this asserts the guard
+    exists AND that the exempt short value is still masked on its own.
+    """
+
+    from backend.schemas._validators_unsafe_text import mask_governed_phrases
+    from backend.services.genie_place_dimension import governed_name_shape_mask_guards
+
+    phrases = tuple(governed_cities.name_shape_safe_values())
+    guards = governed_name_shape_mask_guards(phrases)
+    assert any(phrase == "HAZEL CREST" and left for phrase, left, _ in guards)
+    assert mask_governed_phrases("Which East Hazel Crest borrowers", phrases, guards) == (
+        "Which East Hazel Crest borrowers"
+    )
+    assert mask_governed_phrases("Hazel Crest leads", phrases, guards).strip() == "leads"
 
 
 def test_unreachable_dimension_keeps_the_prompt_guard_closed() -> None:


### PR DESCRIPTION
Follow-up to #206, from a 9,677-question corpus re-sweep and a 47,936-prompt place × sentence-leader sweep.

## The one #206 caused

I added a person-lexicon filter to the sentence-initial strip's **recognition** vocabulary and claimed it was what stopped `Do Medina qualifies for a HELOC?` losing its name pair. **It wasn't.** Measured against the live 428-city dimension:

- it removes **2 of 468** terms — `ELIZABETH` and `YORBA LINDA`;
- none of `MEDINA` / `PARKER` / `KENT` (the names my own docstring cited) is in the 39-name reviewed lexicon.

What actually fixes that shape is the function-word bank excluding `Do`/`An`/`No`. The filter's only live effect was making **`Elizabeth`, a real gold city, unaskable and unrenderable** — +102 refusals in the sweep, +1 answer-surface block. Removed; the docstring now states what carries the property.

## Nested governed values

`HAZEL CREST` is exempt. `EAST HAZEL CREST` is a separate gold city and is not. Masking the short one out of the long one left:

```
"Which East Hazel Crest borrowers are in the money?"
  -> "Which East   borrowers are in the money?"
      ^^^^^^^^^^ the HOLE is a fresh title-case pair -> identity refusal
```

The exemption was manufacturing the refusal it exists to prevent — 102 prompts, and **37 such nestings exist live**. Fixed with the same occurrence-guard mechanism the fair-lending overlap uses: the surrounding tokens of the longer place become contexts where the shorter one is left alone.

## Missing formants

`range`, `desert`, `front`, `product`, `recapture` join the non-person suffix bank — "Front Range", "High Desert", "Wasatch Front", and the governed display labels "Investor Product" / "Competitor Recapture" read as people (18 prompts, 22 answer-surface blocks).

## A deadlock, pinned

Wiring the nesting guards in unconditionally reproduced a **re-entrant deadlock**: the resolver probes cells through `genie_visible_text_unsafe` while holding its load lock, so any structured-path call that resolves the dimension hangs on a non-reentrant `Lock`. The symptom is a CI timeout with **no assertion**, which is why it now has a test that runs the structured path inside a live load.

## Verified

Every prior fix re-checked intact: `Do Nguyen`, `Do Medina`, `An Elizabeth`, `Elizabeth Smith`, `Which Kavita Rangan` all still refuse; `native-hawaiian gardens` laundering and `black borrowers in Tacoma` still refuse; Tacoma / Washington-cities / Bellevue / Puget Sound / Owner Link all still pass. ruff · mypy (253 files) · full unit suite green.

## Still open, characterised not guessed

- **~850 x `Break down {City} borrowers by segment`** and the threshold/ranking class refuse as `unreviewed_criterion`. Aligning the analytics flag clears them but removes the only net catching health conditions outside the enumerated bank (21 of 24 probes flipped, incl. `eczema`, ITIN, housing-voucher). The fix is extending the **reviewed segment-signal vocabulary** with the governed Module 0 measures — deliberately not attempted here.
- **`Sonoma` / non-gold `-oma` places** (42). Gold exposes `state` and `county_fips_5`, no county name, so there is no governed dimension to resolve.
- **Any place outside coverage refuses as PII after a sentence-initial leader** (Boise, Reno, Fresno, Tulsa, Omaha). They should get the geography router's honest "outside the current footprint" answer instead.
- **`YORBA LINDA`** stays out of the name-shape exemption (`LINDA` is a reviewed first name) — now the only such value, and a deliberate call worth stating in the talk track rather than leaving emergent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)