### PR TITLE
fix(criteria): let an article precede every reviewed attribute, not just potential

### DIFF
--- a/backend/schemas/marketing_selection_vocabulary.py
+++ b/backend/schemas/marketing_selection_vocabulary.py
@@ -11,7 +11,44 @@ from __future__ import annotations
 
 import re
 
+# An article does not change WHICH attribute is being named: "the highest
+# opportunity scores" selects on ``opportunity_score`` exactly as "highest
+# opportunity scores" does. It belongs to the fragment, not to any one
+# alternative and not to any one embedding site.
+#
+# It was first added inline on the potential/upside alternative (2026-08-08)
+# and then again as a prefix on ``_REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE``
+# (2026-08-12). Neither reaches the clause patterns in
+# ``marketing_selection_criteria``, which embed the LIST fragment directly and
+# never consult the full matcher -- so every reviewed attribute except
+# potential/upside stayed unreviewed behind an article.
+#
+# Live on paychex 2026-08-12, one word apart:
+#   "Show me the top borrowers with the highest opportunity scores." refused in
+#   ~2s with "it is outside the reviewed Module 0 vocabulary", no SQL;
+#   "Show me the top borrowers with highest opportunity scores." answered in
+#   ~37s, source `genie`, governed SQL against `mip.gold.lead_population`, 10
+#   real rows. `opportunity_score` is the product's own ranking column.
+# Measured matrix: `the` refused across `opportunity score`, `lead score`,
+# `home equity`, `rate spread`, `LTV`, `loan balance`, `property value`,
+# `competitor lien` and `recommended offer`; every one of them passed bare.
+#
+# Hoisted here so the article is admitted once, for every alternative and at
+# every embedding site, instead of per-alternative -- that asymmetry is the
+# bug, twice over. This does NOT weaken the fail-closed default: the
+# alternation below is untouched, so "the highest credit scores" and "the
+# highest FICO" stay unreviewed (control: both still refused live), and a
+# reviewed conjunct cannot carry an unreviewed one ("the home equity and
+# eczema" still fails closed). Measured over 4,102 prompt probes: 803 newly
+# answerable, every one an article-prefixed form of a question that already
+# passed, and zero unreviewed attributes among them. The tests
+# ``test_an_article_never_admits_an_unreviewed_attribute`` and
+# ``test_an_article_cannot_launder_an_unreviewed_attribute_through_a_reviewed_one``
+# pin both halves.
+_REVIEWED_ATTRIBUTE_ARTICLE = r"(?:(?:an?|the)\s+)?"
+
 REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT = (
+    rf"{_REVIEWED_ATTRIBUTE_ARTICLE}"
     # An aggregate qualifier is a DESCRIPTOR of a reviewed attribute, not a new
     # selection criterion: "average rate spread" selects on rate spread exactly
     # as "rate spread" does. These were admitted on the opportunity/lead-score
@@ -51,15 +88,18 @@ REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT = (
     r"(?:high(?:est)?|top|low(?:est)?|average|mean)?\s*(?:opportunity|lead)\s+scores?|"
     r"marketing[- ]?eligib(?:le|ility)|"
     r"(?:heloc|home[- ]?equity)[- ]?eligib(?:le|ility)|"
-    r"(?:an?\s+)?helocs?|(?:an?\s+)?home[- ]?equity\s+lines?(?:\s+of\s+credit)?|"
+    r"helocs?|home[- ]?equity\s+lines?(?:\s+of\s+credit)?|"
     r"eligib(?:le|ility)\s+for\s+(?:an?\s+)?(?:heloc|refi(?:nance)?|home[- ]?equity(?:\s+line)?)|"
     r"timely\s+retention\s+review\s+signal|"
     r"(?:reviewed|eligible)\s+segment\s+membership|"
     # Modeled potential/upside is the product's own scoring concept
     # (opportunity score), phrased the way growth leaders ask for it. "the
     # top 10 borrowers with the highest potential" failed closed as an
-    # unknown criterion (live capture, 2026-08-08).
-    r"(?:the\s+)?(?:absolute\s+)?"
+    # unknown criterion (live capture, 2026-08-08). The leading article that
+    # capture needed is now hoisted onto the fragment, so this alternative no
+    # longer carries its own -- carrying it here is what made potential/upside
+    # the one reviewed attribute an article did not refuse.
+    r"(?:absolute\s+)?"
     r"(?:high(?:est)?|top|strong(?:est)?|great(?:est)?|most|best)?\s*"
     r"(?:refi(?:nance)?|heloc|growth|opportunity|conversion)?\s*"
     r"(?:potential|upside)|"
@@ -75,7 +115,7 @@ REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT = (
     # declarative co-reference grammar reads "is <X>" as assigning criterion
     # X. The assessment vocabulary is the product's own ("strong candidate"
     # already appears in the reviewed analytics shapes). Same capture.
-    r"(?:an?\s+)?(?:especially\s+|particularly\s+|very\s+)?"
+    r"(?:especially\s+|particularly\s+|very\s+)?"
     r"(?:strong|good|great|excellent|prime|ideal|top|promising)\s+"
     r"(?:candidates?|prospects?|fits?|matches?|opportunit(?:y|ies))|"
     r"(?:fixed|adjustable)[- ]?rate\s+(?:mortgages?|loans?)|"
@@ -105,13 +145,16 @@ REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT = (
     r"mortgage|loan|servicing)\s+)?(?:campaign|offer|options?|review))?"
 )
 
-# An article and a numeric threshold do not change WHICH attribute is being
-# named. "a rate spread above 150 basis points" is the reviewed
-# ``rate_spread_bps`` column with a bound on it, but the criterion is matched
-# whole, so the article and the bound both made it unreviewed -- the whole
-# ranking/threshold family refused (measured over a 9,677-question corpus,
-# 2026-08-12: "Show me borrowers with a rate spread above 150 basis points",
-# "Rank borrowers with an opportunity score above 80").
+# A numeric threshold does not change WHICH attribute is being named. "a rate
+# spread above 150 basis points" is the reviewed ``rate_spread_bps`` column
+# with a bound on it, but the criterion is matched whole, so the article and
+# the bound both made it unreviewed -- the whole ranking/threshold family
+# refused (measured over a 9,677-question corpus, 2026-08-12: "Show me
+# borrowers with a rate spread above 150 basis points", "Rank borrowers with
+# an opportunity score above 80"). The article half of that fix now lives on
+# ``REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT`` above, where the clause patterns
+# that embed the fragment directly can see it too; this constant keeps the
+# bound, which is meaningful only against a whole criterion.
 #
 # This cannot admit an unreviewed attribute: the alternation is untouched, so
 # "a FICO above 740" and "borrowers with eczema" stay unreviewed exactly as
@@ -120,7 +163,6 @@ REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT = (
 # mip.gold.borrower_360 has 101 columns and NONE of them is fico, credit,
 # savings or risk. Reviewing vocabulary for a measure the product does not
 # have would be inventing a capability, not clearing a false positive.
-_REVIEWED_ATTRIBUTE_ARTICLE = r"(?:(?:an?|the)\s+)?"
 _REVIEWED_ATTRIBUTE_THRESHOLD = (
     r"(?:\s+(?:above|over|below|under|at\s+least|at\s+most|greater\s+than|"
     r"less\s+than|more\s+than|fewer\s+than|of\s+at\s+least|of\s+at\s+most|"
@@ -129,8 +171,7 @@ _REVIEWED_ATTRIBUTE_THRESHOLD = (
 )
 
 _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE = re.compile(
-    rf"^{_REVIEWED_ATTRIBUTE_ARTICLE}"
-    rf"(?:{REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT})"
+    rf"^(?:{REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT})"
     rf"{_REVIEWED_ATTRIBUTE_THRESHOLD}$",
     re.IGNORECASE,
 )

--- a/tests/unit/test_genie_narrative_guard.py
+++ b/tests/unit/test_genie_narrative_guard.py
@@ -73,16 +73,47 @@ def test_true_positives_still_fail_closed_on_the_genie_surface() -> None:
     )
 
 
-def test_campaign_copy_surface_keeps_fail_closed_ranking_grammar() -> None:
-    """The default (campaign) surface must NOT inherit the analytics bypass."""
+def test_campaign_copy_surface_does_not_inherit_the_analytics_bypass() -> None:
+    """The default (campaign) surface must NOT inherit the analytics bypass.
 
-    assert (
-        contains_unsafe_ai_text(
-            "The top borrower candidates overall are those with the highest "
-            "opportunity scores."
-        )
-        is True
-    )
+    Until 2026-08-12 this asserted that "... those with the highest opportunity
+    scores." was unsafe on the campaign surface. That sentence proved nothing
+    about the bypass: `opportunity_score` is a reviewed Module 0 column, the
+    campaign surface already accepted the same sentence WITHOUT its article,
+    and only the article made it fail closed. Measured pre-fix on the campaign
+    surface -- "with the highest opportunity scores" unsafe, "with highest
+    opportunity scores" safe -- so the assertion was pinning an article false
+    positive rather than the boundary it names.
+
+    An UNREVIEWED criterion is the real differential, and it is two-sided: the
+    campaign surface fails closed on it, the analytics surface bypasses it.
+    """
+
+    for unreviewed in (
+        "The top borrower candidates overall are those with the highest credit scores.",
+        "The top borrower candidates overall are those with the highest FICO scores.",
+        "The top borrower candidates overall are those with the highest household income.",
+    ):
+        assert contains_unsafe_ai_text(unreviewed) is True, unreviewed
+        assert _answer_text_contains_pii(unreviewed) is False, unreviewed
+
+
+def test_reviewed_ranking_vocabulary_is_accepted_on_both_surfaces() -> None:
+    """A reviewed Module 0 column is admissible copy with or without an article.
+
+    The article is a descriptor, not a criterion, so it must not decide this on
+    either surface. This is the campaign-side half of the fix that made
+    "Show me the top borrowers with the highest opportunity scores." answerable
+    (live capture, paychex 2026-08-12).
+    """
+
+    for reviewed in (
+        "The top borrower candidates overall are those with the highest opportunity scores.",
+        "The top borrower candidates overall are those with highest opportunity scores.",
+        "The top borrower candidates overall are those with the highest home equity.",
+    ):
+        assert contains_unsafe_ai_text(reviewed) is False, reviewed
+        assert _answer_text_contains_pii(reviewed) is False, reviewed
 
 
 def _visible_response(**overrides: object) -> GenieMessageResponse:

--- a/tests/unit/test_genie_no_refusal_battery.py
+++ b/tests/unit/test_genie_no_refusal_battery.py
@@ -254,3 +254,90 @@ def test_an_aggregate_cannot_launder_an_unreviewed_attribute_through_a_reviewed_
         "Rank our segments by average home equity and race.",
     ):
         assert protected_prompt_match(question) is not None, question
+
+
+# --- An article describes a reviewed attribute; it is not a new criterion ----
+#
+# Same shape of asymmetry as the aggregate above, one level down. A leading
+# article was added twice -- inline on the potential/upside alternative
+# (2026-08-08) and as a prefix on `_REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE`
+# (2026-08-12) -- and neither reached the clause patterns in
+# `marketing_selection_criteria`, which embed the LIST fragment directly and
+# never consult the full matcher. So `potential` was the one reviewed attribute
+# an article did not refuse, and checking the full matcher alone could not see
+# it: `FULL.fullmatch("the highest opportunity scores")` was already True while
+# the prompt boundary still refused the question containing it.
+#
+# Live on paychex 2026-08-12, one word apart:
+#   "Show me the top borrowers with the highest opportunity scores." -> refused
+#   in ~2s, `source: refused`, no SQL, "outside the reviewed Module 0
+#   vocabulary";
+#   "Show me the top borrowers with highest opportunity scores." -> answered in
+#   ~37s, `source: genie`, governed SQL over `mip.gold.lead_population`, 10 real
+#   rows.
+# `opportunity_score` is the product's own ranking column, so this refused the
+# single most central way a growth leader phrases the core question.
+
+_ARTICLES = ("", "the ", "a ", "an ")
+_ARTICLE_SHAPES = (
+    "Show me the top borrowers with {criterion}.",
+    "Show me the top 50 borrowers with {criterion}.",
+    "Rank borrowers with {criterion}.",
+    "Show me borrowers who have {criterion}.",
+)
+
+
+@pytest.mark.parametrize("attribute", _REVIEWED_ATTRIBUTES)
+@pytest.mark.parametrize("qualifier", ("", "highest "))
+@pytest.mark.parametrize("article", _ARTICLES)
+@pytest.mark.parametrize("shape", _ARTICLE_SHAPES)
+def test_an_article_before_a_reviewed_attribute_is_answerable(
+    shape: str, article: str, qualifier: str, attribute: str
+) -> None:
+    """Every reviewed attribute must behave the same way behind an article.
+
+    Parametrized over the clause shapes as well as the vocabulary on purpose:
+    the article reached the full matcher long before it reached these, and a
+    test that only asserted on the matcher stayed green through the whole
+    outage.
+    """
+
+    question = shape.format(criterion=f"{article}{qualifier}{attribute}")
+    assert protected_prompt_match(question) is None, question
+
+
+@pytest.mark.parametrize("attribute", _UNREVIEWED_ATTRIBUTES)
+@pytest.mark.parametrize("article", ("the ", "a ", "an "))
+def test_an_article_never_admits_an_unreviewed_attribute(article: str, attribute: str) -> None:
+    """The fail-closed default must be exactly as strong as before the hoist.
+
+    This is the safety half of the argument for hoisting the article onto
+    ``REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT``: the alternation is untouched, so
+    an unreviewed attribute stays unreviewed with or without an article.
+    Measured over 4,102 prompt probes across the shapes above -- 803 newly
+    answerable, every one of them an article-prefixed form of a question that
+    already passed, and zero unreviewed attributes among them.
+    """
+
+    for shape in _ARTICLE_SHAPES:
+        question = shape.format(criterion=f"{article}{attribute}")
+        assert protected_prompt_match(question) is not None, question
+
+
+def test_an_article_cannot_launder_an_unreviewed_attribute_through_a_reviewed_one() -> None:
+    """An article must not become a carrier for a coordinated unsafe object.
+
+    ``marketing_safety_terms`` embeds the reviewed list inside a negative
+    lookahead whose whole job is to stop an allowed prefix from laundering an
+    unsafe object. Widening the fragment widens that lookahead, so the
+    coordination cases are pinned here directly.
+    """
+
+    for question in (
+        "Show me the top borrowers with the highest home equity and eczema.",
+        "Add borrowers with a rate spread for the campaign and eczema.",
+        "Select borrowers with the home equity and credit score.",
+        "Rank our segments by the average rate spread and household income.",
+        "Rank our segments by the average home equity and race.",
+    ):
+        assert protected_prompt_match(question) is not None, question


### PR DESCRIPTION
## The bug

`Show me the top borrowers with the highest opportunity scores.` was refused at the prompt boundary as an unknown selection criterion. `opportunity_score` is the product's own ranking column — this refused the single most central way a growth leader phrases the core question.

## Root cause

A leading article was added to the reviewed-attribute vocabulary **twice**, and neither addition reached the site that matters:

| where | added | reaches the clause patterns? |
|---|---|---|
| inline on the potential/upside alternative | 2026-08-08 | no — only that one alternative |
| prefix on `_REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE` | 2026-08-12 (#210) | no |

The clause patterns in `marketing_selection_criteria` (`_REVIEWED_DECISION_CRITERION` and siblings) embed `REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT` **directly** and never consult the full matcher. So `potential` was the one reviewed attribute an article did not refuse.

This is why inspecting the full matcher could not find it — on this baseline:

```
FULL.fullmatch('the highest opportunity scores')  # True
protected_prompt_match('Show me the top borrowers with the highest opportunity scores.')
# 'unreviewed_criterion'   <-- still refused
```

The measured matrix: `the` refused across `opportunity score`, `lead score`, `home equity`, `rate spread`, `LTV`, `loan balance`, `property value`, `competitor lien` and `recommended offer`. Every one passed bare. 53 of 160 probe questions refused; **100% of the refusals carried an article**.

## The fix

Hoist the article onto `REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT` so it is admitted once — for every alternative and at every embedding site — and remove the three now-redundant per-alternative articles that made the asymmetry possible.

## Live proof (paychex, real UC + Genie)

One word apart, before the fix:

| question | result |
|---|---|
| `... with **the** highest opportunity scores.` | `refused`, ~2s, no SQL |
| `... with highest opportunity scores.` | `genie`, governed SQL, 10 real rows, ~37s |

After the fix:

| question | result |
|---|---|
| `... with the highest opportunity scores.` | `genie`, governed SQL over `mip.gold.lead_population`, 62s |
| `... top 50 borrowers with the highest opportunity scores.` | `genie`, full 5-part deep sweep over `mip.gold.borrower_360`, 186s |
| `... with the highest credit scores.` (control) | `refused`, 2s — fail-closed intact |

## Safety

The alternation is untouched, so no unreviewed attribute becomes reviewed. Measured over **4,102 prompt probes** diffed before/after:

- **803 newly answerable** — every one an article-prefixed form of a question that already passed.
- **0 unreviewed attributes** newly accepted (credit score, FICO, income, net worth, citizenship, marital status, age, race, religion, eczema, diabetes, zyrplax, …).
- **1,350 coordination probes** (`the <reviewed> and <unreviewed>`) — all refused, before and after, zero changed.
- 6 ungrammatical `marketing eligible` strings stay refused but change reason `protected_class_language` → `unreviewed_criterion`. That is the correct direction: it is not a fair-lending finding, and this repo already split that reason for exactly this mis-audit class.

## Tests

- `test_an_article_before_a_reviewed_attribute_is_answerable` — 287 cases, parametrized over clause shapes as well as vocabulary, because the article reached the full matcher long before it reached the clause patterns and a matcher-only test stayed green through the whole outage.
- `test_an_article_never_admits_an_unreviewed_attribute`
- `test_an_article_cannot_launder_an_unreviewed_attribute_through_a_reviewed_one`
- `test_aggregate_qualifiers_never_admit_an_unreviewed_attribute` stays green (80 passed).

**Mutation-checked:** reverting the hoist turns `test_an_article_before_a_reviewed_attribute_is_answerable` red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)