### PR TITLE
fix(guards): a place the warehouse does not carry is still a place

### DIFF
--- a/backend/schemas/_validators_person_names.py
+++ b/backend/schemas/_validators_person_names.py
@@ -139,6 +139,35 @@ US_STATE_NAMES: tuple[str, ...] = (
 )
 
 
+# Governed population and grain nouns. A title-case run followed by one of
+# these is being used as a SCOPE ("Which Boise borrowers ..."), not named as a
+# person -- nobody writes "Which <person> borrowers".
+#
+# Needed because the place half of the strip can only recognise geography the
+# warehouse actually carries, and users ask about places outside the refreshed
+# footprint constantly. Measured 2026-08-12 over 720 prompts naming 18 real US
+# cities outside the 6-state coverage: 466 refused (64.7%), 412 of them as PII
+# -- "Which Boise borrowers are in the money?" answered with "I do not return
+# borrower names, street-level addresses ...". The honest answer is the
+# geography router's "outside the current refreshed data footprint", which is
+# what the question gets once the guard stops reading it as an identity.
+#
+# Safe by the same argument as the place half: the strip removes only the
+# leading function word, so a real name pair behind it still scans in full
+# ("Which John Smith borrowers" -> "John Smith borrowers" -> caught).
+_GOVERNED_POPULATION_NOUNS: tuple[str, ...] = (
+    # fmt: off
+    "borrowers", "borrower", "homeowners", "homeowner", "customers", "customer",
+    "leads", "lead", "candidates", "candidate", "prospects", "prospect",
+    "households", "household", "clients", "client", "owners", "owner",
+    "cities", "city", "counties", "county", "states", "state", "metros",
+    "metro", "markets", "market", "zips", "zip", "neighborhoods",
+    "segments", "segment", "cohorts", "cohort", "properties", "property",
+    "loans", "loan", "accounts", "account", "opportunities", "opportunity",
+    # fmt: on
+)
+
+
 @lru_cache(maxsize=8)
 def _sentence_initial_place_strip_pattern(place_terms: tuple[str, ...]) -> re.Pattern[str] | None:
     """Strip a sentence-opening function word ONLY before a known place.
@@ -158,12 +187,20 @@ def _sentence_initial_place_strip_pattern(place_terms: tuple[str, ...]) -> re.Pa
     cleaned = sorted({term.strip() for term in place_terms if term.strip()}, key=len, reverse=True)
     if not cleaned:
         return None
+    known_place = r"(?i:" + "|".join(re.escape(term) for term in cleaned) + r")(?![A-Za-z0-9])"
+    # A title-case run used as a SCOPE for a governed population noun.
+    scoped_population = (
+        r"[A-Z][a-z]{1,30}(?:\s+[A-Z][a-z]{1,30}){0,2}\s+"
+        r"(?i:" + "|".join(_GOVERNED_POPULATION_NOUNS) + r")(?![A-Za-z0-9])"
+    )
     return re.compile(
         r"(?:(?<=^)|(?<=[.!?;:\n]))(\s*)(?:"
         + "|".join(_SENTENCE_INITIAL_FUNCTION_WORDS)
-        + r")\s+(?=(?i:"
-        + "|".join(re.escape(term) for term in cleaned)
-        + r")(?![A-Za-z0-9]))"
+        + r")\s+(?=(?:"
+        + known_place
+        + r"|"
+        + scoped_population
+        + r"))"
     )
 # Title-case pairs ending in these words are never person names here:
 # admin/geographic place-name suffixes (Lake Forest, Grand Prairie, Coral

--- a/tests/unit/test_out_of_coverage_place_scope.py
+++ b/tests/unit/test_out_of_coverage_place_scope.py
@@ -1,0 +1,121 @@
+"""A place the warehouse does not carry is still a place, not a person.
+
+The sentence-initial strip could only recognise geography the gold dimension
+actually contains, so any city outside the refreshed footprint read as an
+identity. Measured 2026-08-12 over 720 prompts naming 18 real US cities outside
+the six covered states (IL, CA, FL, TX, WA, CO): **466 refused, 64.7%, and 412
+of those as PII** — "Which Boise borrowers are in the money?" answered with "I
+do not return borrower names, street-level addresses ...". The control on
+governed cities refused 28 of 160.
+
+The honest answer for those questions is the geography router's "outside the
+current refreshed data footprint", which is what they get once the guard stops
+reading them as identities — exactly what "How many in-the-money borrowers are
+in Oklahoma?" already returns.
+
+The strip now also fires when a title-case run is followed by a GOVERNED
+POPULATION NOUN, because nobody writes "Which <person> borrowers". Safe by the
+same argument as the place half: only the leading function word is removed, so
+a real name pair behind it still scans in full.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from backend.services.genie_message_policy import identity_prompt_match
+from backend.services.genie_place_dimension import (
+    GovernedPlaceDimensionResolver,
+    _reset_governed_place_dimension_for_tests,
+)
+
+_GOLD_CITIES = ("SEATTLE", "BELLEVUE", "CHICAGO", "AURORA", "TACOMA", "ALISO VIEJO")
+
+# Real US cities outside the six covered states. Deliberately NOT in the
+# fixture dimension: the point is that the warehouse does not carry them.
+_OUT_OF_COVERAGE = ("Boise", "Reno", "Fresno", "Tulsa", "Omaha", "Nashville", "Phoenix", "Memphis")
+_SCOPED_TEMPLATES = (
+    "{leader} {city} borrowers are in the money?",
+    "{leader} {city} leads have the highest opportunity score?",
+    "{leader} {city} cities lead on HELOC candidates?",
+)
+_LEADERS = ("Which", "What", "The", "Are", "Rank")
+
+_OUT_OF_COVERAGE_SCOPES = tuple(
+    template.format(leader=leader, city=city)
+    for leader, city, template in itertools.product(_LEADERS, _OUT_OF_COVERAGE, _SCOPED_TEMPLATES)
+)
+
+# The scope reading must never rescue a real name pair.
+_IDENTITIES_MUST_REFUSE = (
+    "Which John Smith borrowers are in the money?",
+    "Which Mary Smith borrowers are in the money?",
+    "The Patricia Garcia leads look strong",
+    "Which Kavita Rangan should I call?",
+    "Do Nguyen qualifies for a HELOC?",
+    "Do Medina qualifies for a HELOC?",
+    "An Elizabeth qualifies for a HELOC?",
+    "Elizabeth Smith is the top borrower",
+    "Will Smith qualifies",
+    "Who is Mary Johnson?",
+)
+
+
+@pytest.fixture(autouse=True)
+def _governed_cities():
+    resolver = GovernedPlaceDimensionResolver(dimension_reader=lambda: list(_GOLD_CITIES))
+    _reset_governed_place_dimension_for_tests(resolver)
+    yield resolver
+    _reset_governed_place_dimension_for_tests(None)
+
+
+@pytest.mark.parametrize("prompt", _OUT_OF_COVERAGE_SCOPES)
+def test_a_place_outside_coverage_is_a_scope_not_an_identity(prompt: str) -> None:
+    assert identity_prompt_match(prompt) is False
+
+
+@pytest.mark.parametrize("prompt", _IDENTITIES_MUST_REFUSE)
+def test_a_name_pair_before_a_population_noun_still_refuses(prompt: str) -> None:
+    """The load-bearing half.
+
+    Stripping the leader leaves the pair intact, so "Which John Smith
+    borrowers" is still caught by the pair itself rather than by the leader.
+    """
+
+    assert identity_prompt_match(prompt) is True
+
+
+def test_the_scope_reading_needs_an_actual_population_noun() -> None:
+    """Without one, a title-case run is not treated as a scope.
+
+    Goes red if the noun list is replaced by something permissive: the whole
+    safety of this alternative is that the follower vocabulary is closed.
+    """
+
+    assert identity_prompt_match("Which Kavita Rangan should I call?") is True
+    assert identity_prompt_match("Which Boise borrowers are in the money?") is False
+
+
+def test_a_governed_city_still_clears_without_a_population_noun() -> None:
+    """The place half of the gate is untouched by the new alternative."""
+
+    assert identity_prompt_match("Which Bellevue is largest?") is False
+    assert identity_prompt_match("Which Boise is largest?") is True
+
+
+@pytest.mark.parametrize("leader", ("Do", "An", "No"))
+def test_the_surname_leaders_still_do_not_strip_even_before_a_scope(leader: str) -> None:
+    """The accepted cost of keeping "Do Nguyen" safe, pinned so it stays visible.
+
+    ``Do``, ``An`` and ``No`` are surname-first Vietnamese and Korean family
+    names and are excluded from the word bank entirely, so they never strip --
+    not before a governed place, and not before a population noun either.
+    "Do Boise borrowers are in the money?" therefore still refuses. That is the
+    deliberate trade for "Do Nguyen qualifies for a HELOC?" keeping its pair,
+    and it is documented rather than quietly absorbed.
+    """
+
+    assert identity_prompt_match(f"{leader} Boise borrowers are in the money?") is True
+    assert identity_prompt_match(f"{leader} Bellevue borrowers are in the money?") is True


### PR DESCRIPTION
## The gap

The sentence-initial strip could only recognise geography the **gold dimension actually contains**, so every city outside the refreshed footprint read as an identity.

Measured over 720 prompts naming 18 real US cities outside the six covered states (IL, CA, FL, TX, WA, CO):

| | refused | rate |
|---|---|---|
| **out-of-coverage cities** | **466 / 720** | **64.7%** |
| governed cities (control) | 28 / 160 | 17.5% |

**412 of the 466 are PII refusals.** `Which Boise borrowers are in the money?` answers with *"I do not return borrower names, street-level addresses…"*. This isn't the guard being uniformly strict — it specifically punishes places the warehouse hasn't loaded.

The honest answer already exists: the geography router's *"outside the current refreshed data footprint (IL, CA, FL, TX, WA, CO)"*, which is what `How many in-the-money borrowers are in Oklahoma?` returns today. The guard was preventing the product from giving it.

## The fix

The strip now also fires when a title-case run is followed by a **governed population noun** — `borrowers`, `leads`, `candidates`, `cities`, `segments`, `households`, … a closed list — because nobody writes "Which *&lt;person&gt;* borrowers".

Safe by the same argument as the place half: only the leading function word is removed, so a real name pair behind it still scans in full. `Which John Smith borrowers are in the money?` and `The Patricia Garcia leads look strong` both still refuse — on the pair itself, not on the leader.

**466 → 211 refused.**

## What's deliberately left

- The bare `And <City>?` shape carries neither a known place nor a population noun. Recognising a lone title-case token as a place is exactly the ambiguity this design avoids.
- **`Do`/`An`/`No` still never strip**, before a place or a population noun, because they're surname-first Vietnamese and Korean family names. `Do Boise borrowers are in the money?` therefore still refuses — the accepted trade for `Do Nguyen qualifies for a HELOC?` keeping its pair, now pinned by a test rather than absorbed silently.

## Open question for review

`Which Nguyen borrowers are in the money?` newly passes (main refuses it). A lone surname with no first name isn't a name pair and the sentence shape is a population query — but this is the same family as the `Do Nguyen` regression, so it's going through adversarial review rather than being assumed safe.

## Verified

135-case suite green · ruff · mypy (254 files) · every standing identity negative still refuses · every prior geography fix intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)