### PR TITLE
fix(guards): a governed count is a number, not a national origin

### DIFF
--- a/backend/schemas/_validators_protected_class.py
+++ b/backend/schemas/_validators_protected_class.py
@@ -99,6 +99,97 @@ _STRUCTURAL_AUDIENCE_KEYWORD_PATTERNS = tuple(
 )
 
 
+# Reviewed leetspeak substitutions. One definition, used by both scan-variant
+# builders below; they previously carried four copies of the same two tables.
+_LEET_TABLES: tuple[dict[int, int], ...] = (
+    str.maketrans("013457", "oleast"),
+    str.maketrans("013457", "oieast"),
+)
+_ALNUM_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+_LETTER_RUN_RE = re.compile(r"[A-Za-z]+")
+
+
+def _leet_folded_variants(value: str) -> set[str]:
+    """Leet de-obfuscations of ``value``, skipping tokens that are ALL DIGITS.
+
+    ``w0men``, ``mus1im`` and ``b1ack`` are evasions: the digit sits INSIDE a
+    word, so the token still carries a letter and still folds here. A token
+    with no letter at all is a NUMBER -- a governed count, a ZIP, a year -- and
+    folding it mints letters nobody wrote.
+
+    Measured live on paychex 2026-08-12: "Which Washington cities have between
+    3000 and 4500 total borrowers?" was answered by Genie and then WITHHELD,
+    because NEWCASTLE's count "4,140" separator-folds to the token ``140``,
+    leet-folds to ``lao`` (a member of ``_PROTECTED_NATIONAL_ORIGIN_TERMS``),
+    and "borrowers" sat inside the national-origin proximity window. The
+    governed answer was refused for the VALUE OF A NUMBER, with
+    ``unsafe_field: "answer"`` in the log and nothing else to go on.
+
+    What is given up is the ability to read a protected term out of a string
+    containing NO letters. That is wider than the one term that motivated it:
+    brute-forcing every digit run of length 1-6 over both tables finds ``140``
+    -> ``lao`` and ``1405`` -> ``laos`` in the national-origin bank, ``551``
+    -> ``ssi`` reaching ``(?:ssi|...)\\s+recipients?``, and 37 runs reaching the
+    health bank's open-ended morphology (``415`` -> ``als``; the whole
+    ``-olol`` drug-suffix family via ``010101`` -> ``ololol``). Every one of
+    those was a live false positive too: "Kirkland has 415 borrowers." and
+    "There are 551 recipients in this segment." both blocked before this.
+
+    What is NOT given up is any evasion. An evader writes a word for humans to
+    read, so at least one character is always a letter, and any token carrying
+    a letter still folds in full: ``l40``, ``1ao``, ``la0``, ``x140`` all still
+    match. The split-term joiner is handled separately -- see ``_joiner_tokens``
+    -- because there a lone digit stands in for one letter of a spaced-out
+    term, so skipping it would rejoin ``b 1 a c k`` as ``back``.
+    """
+
+    return {_fold_letter_bearing_tokens(value, table) for table in _LEET_TABLES}
+
+
+def _fold_letter_bearing_tokens(value: str, table: dict[int, int]) -> str:
+    """Apply one leet table to every alphanumeric token that carries a letter.
+
+    ``table`` is a parameter rather than a closed-over loop variable so the
+    substitution cannot pick up a late binding (ruff B023). ``_ALNUM_TOKEN_RE``
+    is ASCII-only and the caller has already NFKC-normalized, so a plain
+    ``isalpha`` is sufficient here.
+    """
+
+    return _ALNUM_TOKEN_RE.sub(
+        lambda match: (
+            match.group(0).translate(table)
+            if any(char.isalpha() for char in match.group(0))
+            else match.group(0)
+        ),
+        value,
+    )
+
+
+def _joiner_tokens(value: str, table: dict[int, int]) -> list[tuple[str, bool]]:
+    """Leet-folded alphanumeric tokens, each flagged as digit-derived or not.
+
+    The flag is the whole point: it lets the split-term joiner reassemble
+    ``b 1 a c k`` (one digit among real letters) while refusing to reassemble
+    ``1,405`` into ``laos`` (every token digit-derived, so the "letters" are an
+    artefact of the fold rather than anything a writer typed).
+    """
+
+    tokens: list[tuple[str, bool]] = []
+    for match in _ALNUM_TOKEN_RE.finditer(value):
+        raw = match.group(0)
+        digit_derived = not any(char.isalpha() for char in raw)
+        # One token per LETTER RUN, not one per alphanumeric run. Only the
+        # digits ``013457`` are in the tables; ``2``, ``6``, ``8`` and ``9``
+        # survive the fold and therefore still SPLIT a word, which is exactly
+        # how ``w2omen`` and ``b8lack`` are caught -- the joiner rebuilds them
+        # from ``w`` + ``omen``. Concatenating the whole run into one token
+        # made those single tokens, and windows start at two, so 160 measured
+        # evasions over the non-table digits went silent.
+        for letter_run in _LETTER_RUN_RE.findall(raw.translate(table)):
+            tokens.append((letter_run, digit_derived))
+    return tokens
+
+
 def _structural_audience_scan_variants(value: str) -> set[str]:
     """Canonicalize only governed audience-claim keywords, preserving sentences."""
 
@@ -120,10 +211,15 @@ def _structural_audience_scan_variants(value: str) -> set[str]:
     variants = {
         value,
         symbol_folded,
-        value.translate(str.maketrans("013457", "oleast")),
-        value.translate(str.maketrans("013457", "oieast")),
-        symbol_folded.translate(str.maketrans("013457", "oleast")),
-        symbol_folded.translate(str.maketrans("013457", "oieast")),
+        # Unscoped fold on purpose. This builder only canonicalizes the eight
+        # audience keywords, and not one of them is reachable from the
+        # digit-fold alphabet ({o,l,i,e,a,s,t}): "may" needs m, "can" needs c
+        # and n, "should" needs h/u/d, "qualify" needs q/u/f/y. So digits
+        # cannot mint an audience claim here, while ``m 4 y benefit`` and
+        # ``c 4 n qualify`` must still canonicalize -- scoping the fold here
+        # silently retired the fail-closed unknown-audience machine.
+        *(value.translate(table) for table in _LEET_TABLES),
+        *(symbol_folded.translate(table) for table in _LEET_TABLES),
     }
     canonical: set[str] = set()
     for variant in variants:
@@ -258,10 +354,7 @@ def protected_class_marketing_reason(
     leet_variants = {
         translated
         for variant in symbol_variants
-        for translated in (
-            variant.translate(str.maketrans("013457", "oleast")),
-            variant.translate(str.maketrans("013457", "oieast")),
-        )
+        for translated in _leet_folded_variants(variant)
     }
 
     # Add only reviewed ASCII lookalike folds. These variants are safety-scan
@@ -291,16 +384,44 @@ def protected_class_marketing_reason(
                 leet_folded,
             )
         )
-        tokenized = re.findall(r"[A-Za-z]+", leet_folded)
-        joined_tokens.update(
-            "".join(tokenized[start:stop])
-            for start in range(len(tokenized))
-            # Only join genuinely split terms. Re-emitting ordinary one-token
-            # windows detaches words such as ``age`` and ``English`` from the
-            # safe context already reviewed above, creating false positives.
-            for stop in range(start + 2, min(len(tokenized), start + 8) + 1)
-            if sum(len(token) for token in tokenized[start:stop]) <= 32
-        )
+    # The SPLIT-TERM joiner needs the UNSCOPED fold, and needs it token-wise.
+    # Skipping all-digit tokens is right for text scanned as-is, but a digit
+    # standing in for one letter of a spaced-out term is itself an all-digit
+    # token: skip it and the joiner rejoins ``b 1 a c k`` as ``back`` and
+    # ``w o m 3 n`` as ``womn``. Sixteen such strings were measured unblocked
+    # before this path existed, on both surfaces.
+    #
+    # So the joiner folds every token, and instead discards any window whose
+    # tokens are ALL digit-derived. That is what keeps ``1,405`` from being
+    # rejoined into ``laos``: both of its tokens come from digits, so the
+    # window carries no letter anyone actually wrote. An evasion always does --
+    # ``b 1 a c k`` still has ``b``, ``a``, ``c``, ``k``.
+    # Unscoped variants, kept for the two consumers that must not change: the
+    # split-term joiner below and the criterion state machine further down.
+    unscoped_leet_variants = {
+        variant.translate(table) for variant in symbol_variants for table in _LEET_TABLES
+    }
+    unscoped_deobfuscated = {
+        re.sub(r"(?<=[A-Za-z])[\-‐-―](?=[A-Za-z])", "", folded)
+        for variant in unscoped_leet_variants
+        for folded in ascii_confusable_folds(variant)
+    }
+    for joiner_source in {
+        folded for variant in symbol_variants for folded in ascii_confusable_folds(variant)
+    }:
+        for table in _LEET_TABLES:
+            tokens = _joiner_tokens(joiner_source, table)
+            joined_tokens.update(
+                "".join(token for token, _ in tokens[start:stop])
+                for start in range(len(tokens))
+                # Only join genuinely split terms. Re-emitting ordinary
+                # one-token windows detaches words such as ``age`` and
+                # ``English`` from the safe context already reviewed above,
+                # creating false positives.
+                for stop in range(start + 2, min(len(tokens), start + 8) + 1)
+                if sum(len(token) for token, _ in tokens[start:stop]) <= 32
+                and not all(digit_derived for _, digit_derived in tokens[start:stop])
+            )
     # Composition order must not reopen the boundary: apply the same bounded
     # folds after punctuation/split-token joining as well as before it.
     ascii_confusable_variants.update(
@@ -328,6 +449,29 @@ def protected_class_marketing_reason(
         mask_protected_health_safe_contexts(part) for part in scannable_parts
     )
     reviewed_analytics = is_reviewed_read_only_analytics_text(mark_folded)
+    # The criterion state machine keeps the UNSCOPED fold, deliberately, and
+    # this is the one place where that matters.
+    #
+    # It is a structural grammar over UNKNOWN tokens, not a vocabulary matcher,
+    # so a number folded into a word-shaped token ("top 50" -> "top so") reads
+    # to it as an unreviewed selection token and refuses. That is how
+    # "Show me the top 50 borrowers with the credit score." and "Identify the
+    # top 10 borrowers with eczema." are refused today: not because the machine
+    # saw "credit score" or "eczema" -- it does not catch either once a numeric
+    # quantifier is present -- but because the fold handed it "so"/"lo".
+    #
+    # Correct outcome, accidental reason. Scoping the fold here removes the
+    # accident and, with it, 31 measured refusals; the underlying hole (a
+    # numeric quantifier blinds the machine) is pre-existing, belongs to the
+    # criterion grammar rather than to the de-obfuscator, and is filed
+    # separately. Feeding this machine the unscoped variants leaves its
+    # behavior bit-for-bit unchanged while the TERM banks above stop reading
+    # numbers as national origins.
+    criterion_semantic_parts = (
+        mark_folded,
+        *sorted(unscoped_leet_variants),
+        *sorted(unscoped_deobfuscated),
+    )
     has_unreviewed_selection_criterion = (
         False
         if (reviewed_analytics or assume_reviewed_read_only_analytics)
@@ -337,7 +481,7 @@ def protected_class_marketing_reason(
                 selection_context_re=PROTECTED_HEALTH_SELECTION_CONTEXT_RE,
             )
             # Separator-folded text is invalid for the clause state machine.
-            for part in health_semantic_parts
+            for part in criterion_semantic_parts
         )
     )
     # Direct protected-class, health, national-origin, and proxy detectors

--- a/tests/unit/test_marketing_safety_digit_leet_fold.py
+++ b/tests/unit/test_marketing_safety_digit_leet_fold.py
@@ -1,0 +1,347 @@
+"""The leetspeak de-obfuscator must not mint a protected term out of a number.
+
+Captured live on paychex 2026-08-12 at sha 7612b021 (deployment 01f19659086f):
+
+    "Which Washington cities have between 3000 and 4500 total borrowers?"
+    -> prompt guard passes, Genie answers, then source=policy_blocked
+       and the server logs genie_output_blocked unsafe_field="answer"
+
+The WA cities in that range are BLACK DIAMOND (3,678), CARNATION (3,174) and
+NEWCASTLE (4,140). The block was caused entirely by ``4,140``: the separator
+fold yields the token ``140``, the leet fold maps ``1->l 4->a 0->o`` to ``lao``,
+``lao`` is a national-origin term, and "borrowers" supplies the population noun
+the proximity window needs. A governed answer was withheld for the VALUE OF A
+NUMBER.
+
+The fix skips the leet fold for tokens carrying no letter. Two things make that
+safe, and both are pinned below because BOTH were wrong in the first attempt:
+
+* An evader writes a word for humans to read, so a real evasion always keeps a
+  letter and still folds (``l40``, ``1ao``, ``la0``).
+* The SPLIT-TERM joiner is the exception. There a lone digit stands in for one
+  letter of a spaced-out term, so skipping it rejoins ``b 1 a c k`` as ``back``.
+  The first version of this fix did exactly that and unblocked 16 protected-
+  class targeting strings; ``_joiner_tokens`` now folds every token and instead
+  discards windows whose tokens are ALL digit-derived.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from backend.schemas._validators_protected_class import (
+    _LEET_TABLES,
+    _joiner_tokens,
+    _leet_folded_variants,
+    protected_class_marketing_reason,
+)
+from backend.schemas._validators_protected_class_patterns import (
+    PROTECTED_AGE_CITIZENSHIP_MARKETING_RE,
+    PROTECTED_CLASS_MARKETING_RE,
+    PROTECTED_CONTEXTUAL_TRAIT_MARKETING_RE,
+    PROTECTED_HEALTH_STATUS_MARKETING_RE,
+    PROTECTED_HEALTH_TERM_MARKETING_RE,
+)
+from backend.schemas.marketing_safety_terms import PROTECTED_NATIONAL_ORIGIN_RE
+from backend.schemas.protected_relationships import PROTECTED_RELIGION_FAMILIAL_RELATION_RE
+
+
+def _analytics(text: str) -> str | None:
+    """The Ask Genie posture: criterion machine bypassed, detectors all on."""
+
+    return protected_class_marketing_reason(text, assume_reviewed_read_only_analytics=True)
+
+
+def _campaign(text: str) -> str | None:
+    """The stricter campaign/outreach posture."""
+
+    return protected_class_marketing_reason(text)
+
+
+# Governed numbers that must render. Every one blocked before the fix; the
+# non-``lao`` entries are the banks the original docstring wrongly excluded.
+_GOVERNED_COUNTS_THAT_MUST_RENDER = (
+    "Newcastle has 4,140 borrowers.",  # the live incident
+    "Seattle has 1,405 borrowers.",  # 1405 -> laos
+    "Kent has 140 households.",
+    "Renton has 3,140 residents.",
+    "Total: 2,140 applicants.",
+    "Kirkland has 415 borrowers.",  # 415 -> als, health bank
+    "There are 551 recipients in this segment.",  # 551 -> ssi recipients
+    "Batch 010101 covers 900 borrowers.",  # -olol drug-suffix family
+    "The 140 borrowers hold $1,405,140 in equity.",
+    "Call 206-140-1405 to reach the 140 borrowers.",
+    "Rank the top 140 borrowers.",
+    "1,405 loans originated in 2015 for borrowers.",
+    # Separator and width variants of the same number.
+    "Seattle has ４,１４０ borrowers.",
+    "Seattle has 4 140 borrowers.",
+    "Seattle has 4.140 borrowers.",
+    "Seattle has 4'140 borrowers.",
+    "Newcastle (4,140) borrowers.",
+)
+
+# Single-token evasions: the digit sits inside a word, so the token keeps a
+# letter and still folds. Includes all six spellings of the one term whose
+# bare-digit form is now exempt.
+_SINGLE_TOKEN_EVASIONS = (
+    "Target w0men borrowers for this campaign.",
+    "Target mus1im homeowners.",
+    "Target b1ack borrowers.",
+    "Target l4tino households.",
+    "Target 4sian families.",
+    "Target wh1te applicants.",
+    "Target j3wish borrowers.",
+    "Target hisp4nic residents.",
+    "Target 3lderly people.",
+    "Target americ4ns.",
+    "Target l4o borrowers.",
+    "Target 1ao borrowers.",
+    "Target la0 borrowers.",
+    "Target l40 borrowers.",
+    "Target 1a0 borrowers.",
+    "Target 14o borrowers.",
+    # The symbol fold runs BEFORE the leet fold, so ``|`` becomes ``l`` and the
+    # token then carries a letter. Verified discriminating: clean with the fold
+    # disabled, blocked with it.
+    "Newcastle has |40 borrowers.",
+)
+
+# Split-token evasions. Every one of these was UNBLOCKED by the first version
+# of this fix, on both surfaces. They are the reason ``_joiner_tokens`` exists.
+_SPLIT_TOKEN_EVASIONS = (
+    "Exclude j 3 w i s h applicants from the mailer.",
+    "Segment h 1 spanic households in Cook County.",
+    "Contact mex 1 can borrowers in Seattle.",
+    "Contact 1 aotian borrowers in Seattle.",
+    "Target the b 1 a c k community in Renton.",
+    "Build a campaign for as 1 an borrowers.",
+    "Exclude mus 1 im applicants from the mailer.",
+    "Target w o m 3 n for this refinance offer.",
+    "Target b 1 a c k homeowners.",
+    "Target b-1-a-c-k homeowners.",
+    "Target b_1_ack homeowners.",
+    "Target mus•1•im homeowners.",
+    "Target 4514 n homeowners.",  # 4514 -> asia
+    "Target 1 a t i n o homeowners.",
+    "Prioritize k 0 rean borrowers in the ranked queue.",
+    "Rank 1 atino borrowers last.",
+)
+
+# Evasions using digits that are NOT in the leet tables. ``2``, ``6``, ``8``
+# and ``9`` survive the fold, so they still split a word into two letter runs
+# and the joiner rebuilds the term from the pieces. Every other case in this
+# file uses a table digit (0,1,3,4,5,7), and that blind spot let a revision
+# ship green while 160 measured evasions over these digits went silent.
+_NON_TABLE_DIGIT_EVASIONS = (
+    "Exclude je8wish applicants from the mailer.",
+    "Build an audience of b8lack homeowners.",
+    "Segment mus6lim households in Cook County.",
+    "Contact mex2ican borrowers in Seattle.",
+    "Target w2omen borrowers for this campaign.",
+    "Target l9atino households.",
+    "Target as6ian families.",
+    "Target wh8ite applicants.",
+)
+
+# The fail-closed unknown-audience machine, reached through the OTHER call
+# site. Scoping the fold there silently retired it.
+_UNREVIEWED_AUDIENCE_CLAIMS = (
+    "Zyrplax borrowers m 4 y benefit from this offer.",
+    "Qwixel households c 4 n qualify today.",
+    "Qwixel households sh 0 uld qualify today.",
+    "Qwixel households c 0 uld be eligible today.",
+)
+
+
+@pytest.mark.parametrize("narrative", _GOVERNED_COUNTS_THAT_MUST_RENDER)
+def test_a_governed_number_is_not_a_protected_term(narrative: str) -> None:
+    assert _analytics(narrative) is None
+
+
+@pytest.mark.parametrize(
+    "text", _SINGLE_TOKEN_EVASIONS + _SPLIT_TOKEN_EVASIONS + _NON_TABLE_DIGIT_EVASIONS
+)
+def test_evasions_are_a_fair_lending_finding_on_the_analytics_surface(text: str) -> None:
+    """Asserts the REASON, not a boolean.
+
+    ``contains_protected_class_marketing_text`` collapses ``protected_class``
+    and ``unreviewed_criterion``, and most of these strings trip the
+    fail-closed criterion machine as well -- so a boolean assertion here passes
+    even with de-obfuscation entirely disabled. The reason is what
+    distinguishes "we detected the evasion" from "we could not parse it".
+    """
+
+    assert _analytics(text) == "protected_class"
+
+
+@pytest.mark.parametrize(
+    "text", _SINGLE_TOKEN_EVASIONS + _SPLIT_TOKEN_EVASIONS + _NON_TABLE_DIGIT_EVASIONS
+)
+def test_evasions_are_a_fair_lending_finding_on_the_campaign_surface(text: str) -> None:
+    assert _campaign(text) == "protected_class"
+
+
+@pytest.mark.parametrize("text", _UNREVIEWED_AUDIENCE_CLAIMS)
+def test_the_unknown_audience_machine_still_fails_closed(text: str) -> None:
+    """Leetspelled modal + claim verb must still canonicalize.
+
+    The audience-claim builder deliberately keeps the UNSCOPED fold: none of
+    its eight keywords is reachable from the digit alphabet, so digits cannot
+    mint a claim there, and ``m 4 y benefit`` must still be read as
+    ``may benefit``.
+    """
+
+    assert _analytics(text) == "unreviewed_criterion"
+
+
+def test_an_interior_digit_never_hides_a_protected_term() -> None:
+    """Systematic sweep, because hand-picked cases missed this twice.
+
+    One digit inserted at every interior position of eight protected terms,
+    over every digit -- both the ones the tables fold and the ones they do not.
+    A table digit becomes a letter and the word survives as one token; a
+    non-table digit stays a digit and splits the word, so the joiner has to
+    rebuild it. Both routes must end at ``protected_class``.
+    """
+
+    terms = ("women", "black", "muslim", "mexican", "latino", "asian", "jewish", "hispanic")
+
+    # (a) INSERT a non-table digit. It survives the fold, so it splits the word
+    # and only the joiner can rebuild it. This is the family that went silent
+    # when ``_joiner_tokens`` concatenated a whole alphanumeric run.
+    inserted = [
+        text
+        for term in terms
+        for position in range(1, len(term))
+        for digit in "2689"
+        for text in (f"Target {term[:position]}{digit}{term[position:]} borrowers.",)
+        if _analytics(text) != "protected_class"
+    ]
+    assert inserted == []
+
+    # (b) REPLACE a letter with the digit that folds back to it. The word stays
+    # one token and the direct fold has to catch it.
+    preimages = {letter: digit for table in _LEET_TABLES for digit, letter in table.items()}
+    replaced = [
+        text
+        for term in terms
+        for position, letter in enumerate(term)
+        if chr(ord(letter)) in {chr(value) for value in preimages}
+        for text in (
+            f"Target {term[:position]}{chr(preimages[ord(letter)])}"
+            f"{term[position + 1:]} borrowers.",
+        )
+        if _analytics(text) != "protected_class"
+    ]
+    assert replaced == []
+
+
+def test_the_fold_skips_all_digit_tokens_and_only_those() -> None:
+    """Exact-set equality, so a dropped table or a widened skip cannot hide."""
+
+    assert _leet_folded_variants("mus1im") == {"muslim", "musiim"}
+    assert _leet_folded_variants("wh1te") == {"white", "whlte"}
+    assert _leet_folded_variants("140") == {"140"}
+    assert _leet_folded_variants("has 4,140 borrowers") == {"has 4,140 borrowers"}
+    assert _leet_folded_variants("x140") == {"xlao", "xiao"}
+    assert len(_leet_folded_variants("mus1im")) == len(_LEET_TABLES)
+
+
+def test_the_joiner_folds_every_token_but_drops_all_digit_windows() -> None:
+    """The mechanism that keeps split-term evasions shut.
+
+    ``b 1 a c k`` must fold the lone ``1`` (otherwise the joiner rebuilds
+    ``back``), while ``1,405`` must not be rejoined into ``laos``.
+    """
+
+    table = _LEET_TABLES[0]
+    assert _joiner_tokens("b 1 a c k", table) == [
+        ("b", False),
+        ("l", True),
+        ("a", False),
+        ("c", False),
+        ("k", False),
+    ]
+    assert _joiner_tokens("1,405", table) == [("l", True), ("aos", True)]
+    # Digit-only windows are discarded, so the scan never sees "laos"...
+    assert _analytics("Seattle has 1,405 borrowers.") is None
+    # ...but a window carrying one real letter is kept.
+    assert _analytics("Target b 1 a c k homeowners.") == "protected_class"
+
+
+def test_no_bank_admits_a_term_spellable_from_digits_alone_without_notice() -> None:
+    """The blast radius, derived from ``_LEET_TABLES`` rather than hardcoded.
+
+    The skip can only ever hide a term composed entirely of fold-produced
+    letters. This enumerates every digit run the tables can produce and reports
+    which banks they reach, so widening the tables or adding a digit-spellable
+    term to any bank shows up here instead of silently going unscanned.
+
+    The recorded set is not "nothing" -- that was the first version's mistaken
+    claim. It is the set whose live counterparts were all false positives.
+    """
+
+    banks = {
+        "national_origin": PROTECTED_NATIONAL_ORIGIN_RE,
+        "protected_class": PROTECTED_CLASS_MARKETING_RE,
+        "age_citizenship": PROTECTED_AGE_CITIZENSHIP_MARKETING_RE,
+        "contextual_trait": PROTECTED_CONTEXTUAL_TRAIT_MARKETING_RE,
+        "religion_familial": PROTECTED_RELIGION_FAMILIAL_RELATION_RE,
+        "health_status": PROTECTED_HEALTH_STATUS_MARKETING_RE,
+        "health_term": PROTECTED_HEALTH_TERM_MARKETING_RE,
+    }
+    digits = sorted({chr(key) for table in _LEET_TABLES for key in table})
+    reached: set[str] = set()
+    for length in range(1, 5):
+        for combo in itertools.product(digits, repeat=length):
+            run = "".join(combo)
+            for table in _LEET_TABLES:
+                folded = run.translate(table)
+                for bank, pattern in banks.items():
+                    if pattern.search(folded):
+                        reached.add(bank)
+    assert reached == {"national_origin", "health_term"}, (
+        "a bank not previously reachable from digits alone now is; the skip "
+        f"would stop scanning it. reached={sorted(reached)}"
+    )
+
+
+def test_the_live_incident_answer_renders_through_the_real_guard() -> None:
+    """End-to-end on the actual surface, with the governed city dimension.
+
+    The raw detector still refuses this sentence -- the UPPERCASE city names
+    trip the protected-class scan, which is what the governed place dimension
+    exists to mask. Pinning it at the guard is the only assertion that matches
+    what a user sees.
+    """
+
+    from backend.services.genie_message_policy import genie_visible_text_unsafe
+    from backend.services.genie_place_dimension import (
+        GovernedPlaceDimensionResolver,
+        _reset_governed_place_dimension_for_tests,
+    )
+
+    live_cities = ("SEATTLE", "BLACK DIAMOND", "CARNATION", "NEWCASTLE", "TACOMA")
+    _reset_governed_place_dimension_for_tests(
+        GovernedPlaceDimensionResolver(dimension_reader=lambda: list(live_cities))
+    )
+    try:
+        assert (
+            genie_visible_text_unsafe(
+                "The Washington cities with between 3,000 and 4,500 total borrowers are "
+                "BLACK DIAMOND (3,678), CARNATION (3,174), and NEWCASTLE (4,140)."
+            )
+            is False
+        )
+        # ...and a protected term beside the same numbers still blocks.
+        assert (
+            genie_visible_text_unsafe(
+                "Target black borrowers in NEWCASTLE (4,140)."
+            )
+            is True
+        )
+    finally:
+        _reset_governed_place_dimension_for_tests(None)


### PR DESCRIPTION
## The bug

Genie answered **"Which Washington cities have between 3000 and 4500 total borrowers?"** and the governed output policy then withheld the answer — `source=policy_blocked`, `genie_output_blocked unsafe_field="answer"`. Measured live on paychex 2026-08-12 at sha `7612b021`.

The WA cities in that range are BLACK DIAMOND (3,678), CARNATION (3,174) and NEWCASTLE (4,140). The block was caused entirely by **`4,140`**:

1. the separator fold collapses non-alphanumerics → the token `140`
2. the leetspeak de-obfuscator maps `1→l 4→a 0→o` → **`lao`**
3. `lao` is in `_PROTECTED_NATIONAL_ORIGIN_TERMS`
4. `borrowers` supplies the population noun the proximity window needs

**A governed answer was refused for the value of a number.** Silent, data-dependent, and indistinguishable to a user from the product refusing at random.

It was never only `lao`:

| text | before |
|---|---|
| `Seattle has 4,140 borrowers.` | refused (`140`→`lao`) |
| `Seattle has 1,405 borrowers.` | refused (`1405`→`laos`) |
| `Kirkland has 415 borrowers.` | refused (`415`→`als`, health bank) |
| `There are 551 recipients in this segment.` | refused (`551`→`ssi recipients`) |
| `Batch 010101 covers 900 borrowers.` | refused (`-olol` drug-suffix family) |

## The fix

The fold now skips alphanumeric tokens carrying **no letter**, for the **term banks only**. An evader writes a word for humans to read, so a real evasion always keeps a letter and still folds: `w0men`, `mus1im`, `l40`, `1ao`, `la0`, `x140`.

## What deliberately does NOT change, and why

Two other consumers read the same folded text. Scoping either is a fair-lending **detection loss**. Both were found by adversarial review — the test suite was green through both.

**The split-term joiner.** A digit standing in for one letter of a spaced-out term is its own all-digit token; skipping it rebuilt `b 1 a c k` as `back` — **16 strings unblocked on both surfaces**. The joiner now folds every token and instead drops windows whose tokens are *all* digit-derived, which stops `1,405`→`laos` without touching the evasion path.

It also emits one token per **letter run**, not per alphanumeric run. Only `013457` are in the tables, so `2,6,8,9` survive the fold and legitimately *split* a word — concatenating the run made `w2omen` a single token, and windows start at two, so **160 further evasions went silent**.

**The criterion state machine.** It is a structural grammar over *unknown* tokens, so a folded number (`top 50` → `top so`) reads as an unreviewed selection token and refuses. That is why `Show me the top 50 borrowers with the credit score.` and `Identify the top 10 borrowers with eczema.` refuse today — **not** because the machine sees `credit score` or `eczema`, which it misses once a numeric quantifier is present. Correct outcome, accidental reason; scoping the fold here removed **31 measured refusals**. It keeps the unscoped variants, so its behaviour is bit-for-bit unchanged. The underlying hole belongs to the criterion grammar and is filed separately.

## Proof

- **6/6 mutations caught** — revert the skip, concatenate the run, skip digits in the joiner, drop the window guard, scope the audience fold, drop a table. Baseline and restored green, git-based restore.
- **Red battery 20/20 refused**, **green battery 12/12 clean**, **186-probe sweep** (insert non-table digit / replace with table digit) 0 misses.
- ruff, mypy, file-size gate, **full unit suite 14,585 passed / 0 failed**.

Also consolidates four copies of the two `maketrans` tables into `_LEET_TABLES`, correctly typed `dict[int, int]` — `str.maketrans` does not return `dict[int, str]`, and the wrong annotation broke `mypy backend`, a CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
