### PR TITLE
fix(criteria): compose the reviewed purpose and CTA tails in either order

### DIFF
--- a/backend/schemas/marketing_selection_vocabulary.py
+++ b/backend/schemas/marketing_selection_vocabulary.py
@@ -256,10 +256,16 @@ REVIEWED_MORTGAGE_ATTRIBUTE_BOUND_LIST_FRAGMENT = (
 # them" is the commonest form of this tail and ``then`` otherwise lands in the
 # modal slot, refusing 143 strings the truncation had been silently accepting
 # ("Only select them by home equity for the campaign and then contact them").
+#
+# ``(?:to\s+)?`` before the pronoun object because "reply TO them" is how that
+# verb is actually written -- the slot took "reply them" and refused 61
+# ordinary strings ("Only select them by home equity and then reply to them").
+# The preposition admits nothing: the object behind it is the same closed
+# pronoun/population list.
 _REVIEWED_ATTRIBUTE_CTA_TAIL = (
     r"(?:\s+(?:and\s+then|and|then)\s+(?:(?:may|can|should)\s+)?"
     r"(?:contact|call|email|text|message|reply)"
-    r"(?:\s+(?:them|us|me|him|her|"
+    r"(?:\s+(?:to\s+)?(?:them|us|me|him|her|"
     r"(?:the\s+)?(?:borrowers?|homeowners?|customers?|leads?|candidates?|"
     r"prospects?|clients?|owners?)))?"
     r"(?:\s+(?:about|regarding|with|on)\s+(?:(?:the|their|an?)\s+)?"
@@ -268,11 +274,40 @@ _REVIEWED_ATTRIBUTE_CTA_TAIL = (
 )
 _REVIEWED_ATTRIBUTE_CLOSING = r"(?:\s+(?:too|as\s+well))?"
 
+# PURPOSE and CTA in either order, because operators write both:
+#
+#     "a rate spread for the campaign and then contact them"   (purpose first)
+#     "rate spread and contact them for the campaign"          (CTA first)
+#
+# The second form reaches this matcher through the passive-selection capture
+# ("Borrowers are selected based on <criterion>") and refused -- 15 measured
+# strings whose only sin was ordering. This is an ALTERNATION of the two
+# sequences, not a loosening: each branch is the same two closed optional
+# groups, so "purpose CTA purpose", a doubled purpose, or any unreviewed
+# remainder after the pair still leaves text unmatched and the criterion
+# unreviewed.
+#
+# Verified for carriers INSIDE the criterion span, and that is the axis this
+# matcher owns: the battery in ``test_cta_tails_and_terse_imperatives``
+# appends "and eczema" / "about a hijab" to both orders and every one refuses
+# (panel-measured fail-closed over 24,892 probes on that axis). What no FULL_RE
+# composition can see is a carrier OUTSIDE the captured span -- the admission
+# grammar's deliberately open verb slot ("Borrowers are hijab-flagged into the
+# campaign based on <reviewed criterion>"). That slot is a pre-existing gap on
+# main, reachable today with any already-reviewed criterion, and every
+# vocabulary restoration (#212's thresholds, #213's articles, #219's bounds,
+# this ordering) adds phrasings that route through it. Tracked as issue #221
+# with the banks-only-entry-point remediation; do not treat this matcher's
+# battery as evidence about that axis.
+_REVIEWED_ATTRIBUTE_TAIL_EITHER_ORDER = (
+    rf"(?:{REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT}{_REVIEWED_ATTRIBUTE_CTA_TAIL}"
+    rf"|{_REVIEWED_ATTRIBUTE_CTA_TAIL}{REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT})"
+)
+
 _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE = re.compile(
     rf"^(?:{REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT})"
     rf"{_REVIEWED_ATTRIBUTE_THRESHOLD}"
-    rf"{REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT}"
-    rf"{_REVIEWED_ATTRIBUTE_CTA_TAIL}"
+    rf"{_REVIEWED_ATTRIBUTE_TAIL_EITHER_ORDER}"
     rf"{_REVIEWED_ATTRIBUTE_CLOSING}$",
     re.IGNORECASE,
 )

--- a/tests/unit/test_cta_tails_and_terse_imperatives.py
+++ b/tests/unit/test_cta_tails_and_terse_imperatives.py
@@ -1,0 +1,177 @@
+"""The CTA tail orderings, and the acceptance battery a bare-directive net must pass.
+
+#212's anchored tails refused two ordinary operator phrasings, found by its
+adversarial review and measured before fixing:
+
+* PURPOSE-then-CTA was the only accepted order, so "Borrowers are selected
+  based on rate spread and contact them for the campaign." refused -- 15
+  strings whose only sin was ordering.
+* The CTA object slot took "reply them" but not "reply TO them" -- 61 strings.
+
+Both are restored here by ``_REVIEWED_ATTRIBUTE_TAIL_EITHER_ORDER`` and the
+``(?:to\\s+)?`` object slot in ``marketing_selection_vocabulary``. Every
+refusal asserts the EXACT reason string: ``is not None`` passes through a
+silent reclassification, and this machine reports through two mechanisms on
+purpose.
+
+The second half of this file is a NO-REFUSAL battery of terse imperative
+commands. A bare-directive net (closing "Prioritize a hijab." -- the
+formation-command-with-no-population hole) was built, panel-reviewed and
+WITHDRAWN on 2026-08-13: its enumerated allow-bank gated on object length
+newly refused 2,443 of 4,378 realistic strings, with the damning asymmetry
+that terser phrasing of a governed attribute earned a fair-lending refusal
+("Sort by equity." refused while "Sort by home equity." passed). These pins
+are the acceptance battery the review demanded be landed FIRST, so the next
+attempt is measured against it rather than after it. Every string here is
+allowed on main today; a net that flips any of them is the same defect again.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from backend.services.genie_message_policy import protected_prompt_match
+from backend.services.genie_place_dimension import (
+    GovernedPlaceDimensionResolver,
+    _reset_governed_place_dimension_for_tests,
+)
+
+_LIVE_GOLD_CITIES = (
+    "BELLEVUE",
+    "SEATTLE",
+    "TACOMA",
+    "HAWAIIAN GARDENS",
+    "BLACK DIAMOND",
+    "ALISO VIEJO",
+    "FEDERAL WAY",
+    "ELIZABETH",
+)
+
+
+@pytest.fixture(autouse=True)
+def governed_cities() -> Iterator[None]:
+    _reset_governed_place_dimension_for_tests(
+        GovernedPlaceDimensionResolver(dimension_reader=lambda: list(_LIVE_GOLD_CITIES))
+    )
+    yield
+    _reset_governed_place_dimension_for_tests(None)
+
+
+# The two phrasings #212's anchored tails refused, restored by making PURPOSE
+# and CTA order-independent and by letting ``reply`` take its preposition.
+_CTA_PHRASINGS_RESTORED = tuple(
+    head.format(attr=attr)
+    for head in (
+        "Borrowers are selected based on {attr} and contact them for the campaign.",
+        "Borrowers are selected based on {attr} and then contact them for the refi campaign.",
+        "Only select them by {attr} and then reply to them.",
+        "Only select them by {attr} and reply to them about the offer.",
+        "Only select them by {attr} and then contact them for the campaign.",
+        # The already-working order rides along as the control.
+        "Only select them by {attr} for the campaign and then contact them.",
+    )
+    for attr in ("rate spread", "home equity")
+)
+
+# The same tails with an unreviewed remainder, in BOTH orders. Reordering an
+# anchored composition is exactly the shape of change that reopened the
+# truncation hole once, so the carrier battery is not optional.
+_CTA_CARRIERS_STILL_REFUSE = tuple(
+    f"{head}{tail}."
+    for head in (
+        "Borrowers are selected based on rate spread and contact them for the campaign",
+        "Only select them by home equity and then reply to them",
+        "Only select them by home equity for the campaign and then contact them",
+        "Only select them by home equity and contact them for the campaign",
+    )
+    for tail in (" and a hijab", " and an ITIN instead of an SSN", " and zyrplax scores")
+) + (
+    "Only select them by home equity and then reply to them about a hijab.",
+    "Borrowers are selected based on a hijab and contact them for the campaign.",
+    "Only select them by home equity and then contact them about a mikveh.",
+)
+
+
+@pytest.mark.parametrize("prompt", _CTA_PHRASINGS_RESTORED)
+def test_purpose_and_cta_compose_in_either_order(prompt: str) -> None:
+    assert protected_prompt_match(prompt) is None, prompt
+
+
+@pytest.mark.parametrize("prompt", _CTA_CARRIERS_STILL_REFUSE)
+def test_neither_ordering_absorbs_an_unreviewed_remainder(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "unreviewed_criterion", prompt
+
+
+# ---------------------------------------------------------------------------
+# The acceptance battery for any future bare-directive net.
+#
+# Terse imperative commands, exactly as operators and Genie users write them.
+# All allowed on main. The withdrawn net refused 78 of 108 ordinary objects
+# because its allow-bank could only bless vocabulary someone had listed; the
+# review's acceptance test is that the short and long spellings of the SAME
+# governed attribute must agree:
+#
+#     Sort by equity.   ==   Sort by home equity.
+#     Rank by score.    ==   Rank by opportunity score.
+#
+# and that "Prioritize a hijab." must still refuse when the net returns. That
+# refusal is deliberately NOT pinned here -- it does not hold on main, and the
+# withdrawn net was the only thing that produced it; pinning it would go red
+# on every tree until the redesign lands (the redesign needs a banks-only
+# carrier entry point, filed as the prerequisite).
+_TERSE_IMPERATIVES_STAY_ANSWERABLE = (
+    # short/long twins of governed attributes
+    "Sort by equity.",
+    "Sort by home equity.",
+    "Rank by score.",
+    "Rank by opportunity score.",
+    "Rank by spread.",
+    "Sort by rate spread.",
+    "Rank by ltv.",
+    "Rank by equity.",
+    "Sort by lien.",
+    "Screen for equity.",
+    # ordinary operator commands
+    "Prioritize speed.",
+    "Add a note.",
+    "Target Q4.",
+    "Advance both.",
+    "Sort ascending.",
+    "Target lien holder.",
+    "Queue the best ones.",
+    # NOT here: "Assign an owner." -- it refuses on main today (pre-existing,
+    # unrelated to any net), so neither verdict is pinnable without lying.
+    "Set a threshold.",
+    "Group by county.",
+    "Group by city.",
+    "Sort by county.",
+    "Rank by state.",
+    "Sort the results.",
+    "Sort the queue.",
+    "Advance the pipeline.",
+    "Group by state.",
+    "Rank the top 10.",
+    "Prioritize in-the-money.",
+    "Target high-equity.",
+    "Prioritize recapture.",
+    "Prioritize retention.",
+    "Prioritize the refi campaign.",
+    "Prioritize the recapture list.",
+    "Prioritize outreach.",
+    "Prioritize them.",
+    "Prioritize borrowers with home equity.",
+    "Prioritize segments with strong equity.",
+    "Advance quarterly business planning according to reviewed targets.",
+    "Prioritize outreach for follow-up next week.",
+    "Please call us; assign this offer to the campaign queue.",
+    "Add refi review to weekly monitoring.",
+    "Select options for comparison in the review.",
+    "Rank the strongest refinance opportunities across the coverage.",
+)
+
+
+@pytest.mark.parametrize("prompt", _TERSE_IMPERATIVES_STAY_ANSWERABLE)
+def test_terse_imperative_commands_stay_answerable(prompt: str) -> None:
+    assert protected_prompt_match(prompt) is None, prompt


### PR DESCRIPTION
#212 absorbed the two tails `_normalize_criterion` used to delete into the ANCHORED vocabulary — the fix that closed the truncation-laundering hole — and its adversarial review measured the cost: **76 ordinary operator phrasings became fail-closed refusals**. Two mechanical causes, both fixed here in `marketing_selection_vocabulary.py`:

- **Order.** PURPOSE-then-CTA was the only accepted order, so `Borrowers are selected based on rate spread and contact them for the campaign.` refused — 15 strings whose only sin was ordering. `_REVIEWED_ATTRIBUTE_TAIL_EITHER_ORDER` is an alternation of the same two closed optional groups, not a loosening: a doubled purpose, "purpose CTA purpose", or any unreviewed remainder still leaves text unmatched.
- **`reply TO them`.** The CTA object slot took "reply them" but not "reply to them" — 61 strings. `(?:to\s+)?` admits nothing: the object behind it is the same closed pronoun/population list.

## Three-reviewer adversarial panel, unanimous approval required

| reviewer | mandate | verdict |
|---|---|---|
| A | fail-open hunting | **APPROVE (converted)** — initially REJECT on 1,544 flips routing through the admission grammar's open verb slot; A then verified its own proposed remedy does not close its own reproduction and that the identical flip class was created by the already-merged #212/#213/#219 restorations. 0 of 1,544 flips novel by A's own shape-matched controls; the real defect is pre-existing and tracked as #221 with A's reproduction as the red-side acceptance test. Clean bill on the diff itself: blast radius exactly FULL_RE, 0 carrier-bearing fail-opens in the intended widening, de-obfuscation closed, no suite regressions. |
| B | restrictive regressions | **APPROVE** — 21,890 corpus cells (4,378 strings × 5 surfaces) identical to main, verdict *and* reason; carrier-bypass sweep on the reorder: 348 real-carrier probes, 0 bypasses |
| C | test integrity + claims | **APPROVE** — criteria module byte-identical to main; mutation table exact (order re-fixed → 6 red, reply-to removed → 4 red, reconciling precisely to the 10 restored strings); zero new suite failures |

## What this PR deliberately does NOT contain: the bare-directive net, withdrawn

`Prioritize a hijab.` / `Target alopecia.` / `Shortlist an ITIN.` are **allowed on every validator surface today** — a formation command with no population noun never reaches the criterion machine. A net closing that hole was built on this branch, panel-reviewed, and **withdrawn on two REJECT verdicts**:

- Reviewer B's 4,378-string corpus: the net newly refused **2,443 realistic terse imperatives**, with the damning asymmetry that the SHORT spelling of a governed attribute refused while the long one passed — `Sort by equity.` refused, `Sort by home equity.` passed; `Rank by score.` refused, `Rank by opportunity score.` passed.
- Reviewer C refuted the net's residual bound (the sweep matrix structurally couldn't see the det-less two-word carrier class) and found the name-shape stand-down verb-dependent (`Prioritize sickle cell.` vs `Queue sickle cell.` differ).
- Four drafts each broke a different pinned corpus (28, then 17 — thirteen by stealing the pinned `human-name-shaped` reason — then B's 2,443). The axis is wrong, not the tuning: an enumerated allow-bank on an open-vocabulary surface can only bless what someone listed, and gating on object length guarantees the reachable set is exactly how operators write.

**The redesign is filed with its prerequisite** — a banks-only carrier entry point (gate on *known carrier*, not on *failing-to-be-known-reviewed*) — and per B's instruction its acceptance battery lands FIRST, in this PR: `_TERSE_IMPERATIVES_STAY_ANSWERABLE` pins ~44 terse imperatives (short/long twins included) as answerable. B proved the battery is a true differential: red on the archived withdrawn-net tree on exactly the 14 strings it found, green on main and here. `Prioritize a hijab.` refusing is deliberately NOT pinned (false on main; only the withdrawn net produced it), and `Assign an owner.` is pinnable in neither direction (refuses on main today, pre-existing — filed separately).

## Measurements (final head, base f9328b96)

- CTA matrix, 3 surfaces: **15/15/3 newly allowed** — every one a restored phrasing — 0 newly refused, **0 carrier leaks in either order** (carriers pinned with the exact reason string).
- Full `tests/unit`: zero new failures vs main (failure-ID set identical); the intermediate size-gate break is gone (criteria module untouched).
- Live on real paychex UC + Genie (local :8126, `mode: live`, port ownership verified): both restored phrasings plan a governed Home Equity workflow (**200**, `mip.gold.*` source assets) — the same prompt 422s as `unreviewed_criterion` on a live main server; carrier controls refuse on both the growth surface (422 + audit_event_id) and the Genie surface (`source: "refused"`, ~1s); `Which Washington cities have the most in-the-money borrowers?` answers live with governed rows from `mip.gold.borrower_360`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


