### PR TITLE
fix(criteria): an indefinite article before a population noun is a determiner, not a criterion

### DIFF
--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -462,9 +462,16 @@ _REVIEWED_AUDIENCE_DECISION_PATTERNS: tuple[re.Pattern[str], ...] = (
         re.IGNORECASE,
     ),
 )
+# The determiner slot takes ``a``/``an`` exactly as it takes ``the``: the
+# object either way is the same closed population/audience reference, so the
+# article names no criterion. Without it, "Assign an owner." fell past this
+# branch and the bound-population capture below read the bare article itself
+# as an unreviewed criterion, while "Assign the owner." and "Assign owners."
+# were answered (measured 2026-08-13; same family: "Queue a borrower.",
+# "Target a customer.", "Prioritize a lead.", "Shortlist an applicant.").
 _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE = re.compile(
     rf"^{_AUDIENCE_DIRECTIVE_PREFIX_FRAGMENT}"
-    rf"{_AUDIENCE_FORMATION_COMMAND_FRAGMENT}\s+(?:the\s+)?"
+    rf"{_AUDIENCE_FORMATION_COMMAND_FRAGMENT}\s+(?:(?:the|an?)\s+)?"
     rf"(?:(?:reviewed|eligible|qualified|marketing[- ]eligible|highest[- ]scoring)\s+){{0,2}}"
     rf"{_AUDIENCE_DECISION_REFERENCE}"
     r"(?:\s+for\s+(?:(?:this|the|a|an)\s+)?(?:reviewed\s+)?"
@@ -560,9 +567,13 @@ def _is_reviewed_pre_population_binding(value: str) -> bool:
         # Interrogative determiners ("Which/What [of the] borrowers are
         # eligible ...") ask about selection state and bind no criterion
         # (live turn 2026-08-07: "Which borrowers are eligible for a HELOC?").
-        # Only the determiner is transparent: whatever remains after stripping
-        # must still full-match the reviewed vocabulary below.
-        r"^(?:(?:the|these|those|all|any|our|your|only|reviewed|eligible|qualified|"
+        # ``a``/``an`` joins the list because the bound-population capture
+        # hands this function the bare article: "assign an owner" captured
+        # criterion "an" and refused while the ``the`` twin was answered
+        # (measured 2026-08-13). Only the determiner is transparent: whatever
+        # remains after stripping must still full-match the reviewed
+        # vocabulary below.
+        r"^(?:(?:the|an?|these|those|all|any|our|your|only|reviewed|eligible|qualified|"
         r"marketing[- ]eligible|highest[- ]scoring|prospective|current|"
         r"(?:which|what)(?:\s+of)?)(?:\s+|$))+",
         "",

--- a/tests/unit/test_cta_tails_and_terse_imperatives.py
+++ b/tests/unit/test_cta_tails_and_terse_imperatives.py
@@ -141,8 +141,16 @@ _TERSE_IMPERATIVES_STAY_ANSWERABLE = (
     "Sort ascending.",
     "Target lien holder.",
     "Queue the best ones.",
-    # NOT here: "Assign an owner." -- it refuses on main today (pre-existing,
-    # unrelated to any net), so neither verdict is pinnable without lying.
+    # Answerable since the population-article parity fix (2026-08-13): the
+    # bare-directive branch took only ``the`` before a population noun, so
+    # these refused while their ``the``/bare twins answered. Pinned here so a
+    # future net cannot re-break the indefinite-article spelling of the same
+    # command (see test_population_article_parity for the full family).
+    "Assign an owner.",
+    "Queue a borrower.",
+    "Target a customer.",
+    "Prioritize a lead.",
+    "Shortlist an applicant.",
     "Set a threshold.",
     "Group by county.",
     "Group by city.",

--- a/tests/unit/test_population_article_parity.py
+++ b/tests/unit/test_population_article_parity.py
@@ -1,0 +1,125 @@
+"""Article parity on the population-determiner slots of the criterion machine.
+
+"Assign an owner." refused as ``unreviewed_criterion`` while "Assign the
+owner." and "Assign owners." were answered (pre-existing false positive,
+measured 2026-08-13). Two determiner slots spelled themselves ``the``-only:
+
+* ``_REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE`` -- the allow branch for
+  criterion-free formation commands -- admitted only ``the`` before the
+  population noun, so the ``a``/``an`` form fell past it; and
+* ``_AUDIENCE_FORMATION_BOUND_POPULATION_RE`` then captured the bare article
+  ITSELF as the criterion ("assign an owner" -> criterion "an"), and
+  ``_is_reviewed_pre_population_binding``'s transparent-determiner list had
+  ``the``/``these``/``those``/``all``/``any`` but not ``a``/``an``.
+
+Same family, all measured: "Queue a borrower.", "Target a customer.",
+"Prioritize a lead.", "Shortlist an applicant.". This is the same defect
+shape as the attribute-side article fix (#213), one vocabulary over: the
+article is a determiner slot, not vocabulary, and admitting it names no new
+criterion.
+
+Fix battery, 2,355 probes x three surfaces (prompt, marketing reason,
+campaign copy): 258 gains, every one an ``a``/``an`` form of an
+already-allowed ``the``/bare twin; 0 losses; 0 reason shifts among
+still-refused probes; 0 gains carrying a banked or unreviewed token.
+
+Every refusal below asserts the EXACT reason string: ``is not None`` passes
+through a silent reclassification, and the banked twins here are refused by
+a different machine (the term banks) on purpose.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.schemas._validators_unsafe_text import contains_unsafe_ai_text
+from backend.schemas.marketing_selection_criteria import (
+    _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE,
+    _is_reviewed_pre_population_binding,
+)
+from backend.services.genie_message_policy import protected_prompt_match
+
+# The restored family: an indefinite article before a closed population noun
+# in a formation directive. Each has a ``the`` or bare twin that already
+# answered on the pre-fix tree.
+_ARTICLE_DIRECTIVES_ANSWERABLE = (
+    "Assign an owner.",
+    "Assign an owner for the campaign.",
+    "Assign a reviewer.",
+    "Queue a borrower.",
+    "Target a customer.",
+    "Prioritize a lead.",
+    "Shortlist an applicant.",
+    "Add an owner.",
+    "Rank a candidate.",
+    # The bound-population capture reached the article even without a
+    # clause-initial directive; the mid-sentence form refused too.
+    "Please review the file and assign an owner.",
+)
+
+
+@pytest.mark.parametrize("prompt", _ARTICLE_DIRECTIVES_ANSWERABLE)
+def test_an_indefinite_article_before_a_population_is_answerable(prompt: str) -> None:
+    assert protected_prompt_match(prompt) is None, prompt
+
+
+def test_the_bare_directive_branch_owns_the_allow() -> None:
+    """Branch attribution: reroutes of this family should be visible, not silent."""
+
+    assert _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE.fullmatch("assign an owner") is not None
+    assert _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE.fullmatch("assign the owner") is not None
+    assert _is_reviewed_pre_population_binding("an") is True
+    assert _is_reviewed_pre_population_binding("the") is True
+
+
+# ---------------------------------------------------------------------------
+# Invariants -- green on BOTH sides of the fix. They pin what a transparent
+# determiner must never do, independent of the change.
+
+_ARTICLE_NEVER_LAUNDERS = (
+    # Whatever remains after stripping a determiner must still full-match the
+    # reviewed vocabulary; an unreviewed modifier keeps the clause refused.
+    "Assign a zyrplax borrower to the campaign.",
+    "Assign the zyrplax borrower to the campaign.",
+)
+
+
+@pytest.mark.parametrize("prompt", _ARTICLE_NEVER_LAUNDERS)
+def test_an_article_cannot_launder_an_unreviewed_modifier(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "unreviewed_criterion", prompt
+
+
+_BANKED_TWINS_KEEP_THEIR_REASON = (
+    # The term banks fire above this machine and must keep owning these.
+    "Assign a patient.",
+    "Assign a diabetic.",
+    "Assign an owner with eczema.",
+)
+
+
+@pytest.mark.parametrize("prompt", _BANKED_TWINS_KEEP_THEIR_REASON)
+def test_the_term_banks_still_own_the_banked_twins(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "protected_class_language", prompt
+
+
+# The destination-tailed command refuses for EVERY determiner -- an
+# article-independent, pre-existing family (the active admission command
+# proves no relation, so the affirmative-directive branch fails closed).
+# Article parity must not move it, and the battery measured it unchanged.
+_TAILED_FORMS_STILL_REFUSE = (
+    "Assign an owner to this campaign.",
+    "Assign the owner to this campaign.",
+    "Assign owners to this campaign.",
+)
+
+
+@pytest.mark.parametrize("prompt", _TAILED_FORMS_STILL_REFUSE)
+def test_the_destination_tailed_family_is_untouched(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "unreviewed_criterion", prompt
+
+
+def test_campaign_copy_surface_moves_with_the_prompt_surface() -> None:
+    """The strict surface keeps refusing the laundering form, not the command."""
+
+    assert contains_unsafe_ai_text("Assign a zyrplax borrower to the campaign.") is True
+    assert contains_unsafe_ai_text("Assign an owner.") is False


### PR DESCRIPTION
## The false positive

`protected_prompt_match("Assign an owner.")` returned `unreviewed_criterion` — a pre-existing false positive on an ordinary operator command (assigning a reviewer/owner to a campaign or queue item), reproducing identically on main, the withdrawn-net branch, and `claude/guard-residual-closures`. It was deliberately excluded from `_TERSE_IMPERATIVES_STAY_ANSWERABLE` because neither verdict was pinnable without lying.

## Root cause (measured, not inferred)

Two population-determiner slots spelled themselves `the`-only:

1. `_REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE` — the allow branch for criterion-free formation commands — admitted only `the` before the population noun (`owner` is in `_COREFERENCE_POPULATION` for property-owner populations), so `Assign the owner.` and `Assign owners.` answered while `Assign an owner.` fell through;
2. it then hit `_AUDIENCE_FORMATION_BOUND_POPULATION_RE`, which captured the bare article **itself** as the criterion (`'an'`), and `_is_reviewed_pre_population_binding`'s transparent-determiner list had `the/these/those/all/any/our/your/only` but not `a`/`an`.

Same family, all measured with allowed twins: `Queue a borrower.`, `Target a customer.`, `Prioritize a lead.`, `Shortlist an applicant.`, and the mid-sentence form `Please review the file and assign an owner.` (that one is the case only slot 2 covers). This is the population-side twin of #213's attribute-side article fix.

## The fix

Article parity on those two determiner slots, nothing else. No allow-bank, no object-shape gating (per the withdrawn-net panel), no new content vocabulary: the bare directive's object stays the closed population/audience list, and whatever remains after stripping a transparent determiner must still full-match the reviewed vocabulary.

## Differential battery (2,355 probes × 3 surfaces: prompt, marketing reason, campaign copy)

- **0 losses** (allowed→refused) on every surface
- **0 reason shifts** among still-refused probes (no silent reclassification)
- **258 gains**, every one an `a`/`an` form of an already-allowed `the`/bare twin; **0 carry a banked or unreviewed token**
- Banked twins keep their exact reason: `Assign a patient.` / `Assign a diabetic.` / `Assign an owner with eczema.` → `protected_class_language` (term banks fire above this machine, unchanged)
- The article cannot launder: `Assign a/the zyrplax borrower to the campaign.` → `unreviewed_criterion` both sides
- The article-independent destination-tailed family (`Assign … to this campaign.` — refuses for **every** determiner, separate pre-existing case) is untouched
- `Prioritize a hijab.` (the tracked bare-object hole, #221 prerequisite) byte-identical to base

## Tests

- `tests/unit/test_population_article_parity.py`: the answerable family (defect pins), branch attribution, and both-sides invariants (laundering, banked twins, tailed family, strict campaign-copy surface)
- `Assign an owner.` + the four siblings join `_TERSE_IMPERATIVES_STAY_ANSWERABLE` per the withdrawn-net review's instruction
- **Mutation-checked**: reverting slot 1 fails the whole terse family; reverting slot 2 fails exactly the mid-sentence probe + branch attribution — each edit is load-bearing with distinct named coverage

Gates: ruff clean, mypy clean (254 files), file-size gate passes (899 lines, warn-only), full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)