### PR TITLE
fix(criteria): a loan program is a reviewed attribute, like a loan rate

### DIFF
--- a/backend/schemas/marketing_selection_vocabulary.py
+++ b/backend/schemas/marketing_selection_vocabulary.py
@@ -149,6 +149,23 @@ REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT = (
     r"(?:strong|good|great|excellent|prime|ideal|top|promising)\s+"
     r"(?:candidates?|prospects?|fits?|matches?|opportunit(?:y|ies))|"
     r"(?:fixed|adjustable)[- ]?rate\s+(?:mortgages?|loans?)|"
+    # Loan PROGRAM, the sibling of the rate-structure alternative above. It was
+    # missing while `fixed-rate loans` was reviewed, which is an asymmetry
+    # rather than a decision: `loan_product_type` is a governed
+    # ``mip.gold.borrower_360`` column with its own canonical UC function
+    # (``fn_loan_product_type``), and it is populated -- measured live on
+    # paychex 2026-08-12: conventional 2,306,974, fha 303,977, jumbo 278,900,
+    # va 68,071, other 96,187. So "Break down borrowers by loan type." and
+    # "Show borrowers with VA loans in Texas." failed closed as unknown
+    # criteria against a column the product models and Genie can query.
+    #
+    # Both halves are anchored on a loan/mortgage noun on purpose. A bare
+    # ``va`` is the USPS abbreviation for Virginia and a bare ``conventional``
+    # is an ordinary adjective; requiring the noun keeps this to the product's
+    # own program vocabulary and cannot admit a geography or a stray modifier.
+    r"(?:conventional|conforming|non[- ]?conforming|jumbo|fha|va|usda|"
+    r"government[- ]backed)\s+(?:loans?|mortgages?)|"
+    r"(?:loan|mortgage)\s+(?:type|program|product)s?|"
     # Bare "home equity" / "equity percentage". Every other equity alternative
     # above REQUIRES a qualifier ("strong equity", "substantial equity"), so
     # "Rank our segments by home equity" -- a plain analytics question about

--- a/tests/unit/test_genie_loan_program_vocabulary.py
+++ b/tests/unit/test_genie_loan_program_vocabulary.py
@@ -1,0 +1,93 @@
+"""Loan PROGRAM is a reviewed Module 0 attribute, like loan rate structure.
+
+``(?:fixed|adjustable)-rate loans`` was reviewed and the loan program was not,
+which is an asymmetry rather than a decision: ``loan_product_type`` is a
+governed ``mip.gold.borrower_360`` column with its own canonical UC function
+(``sql/uc_functions/fn_loan_product_type.sql``), and it is populated. Measured
+live on paychex 2026-08-12:
+
+    conventional 2,306,974 | fha 303,977 | jumbo 278,900 | va 68,071
+    other 96,187           | NULL 2,102,075 (no first lien / unknown)
+
+So "Break down borrowers by loan type." failed closed as an unknown criterion
+against a column the product models, Genie can query, and the CNV work in
+#179/#185 was specifically about.
+
+The alternation is anchored on a loan/mortgage noun. That is load-bearing: a
+bare ``va`` is the USPS abbreviation for Virginia and a bare ``conventional``
+is an ordinary adjective, so requiring the noun keeps this to the product's own
+program vocabulary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.genie_deterministic import _protected_prompt_match
+
+# Live-shaped asks against the governed column.
+_ANSWERABLE = (
+    "Break down borrowers by loan type.",
+    "Break down borrowers by loan product.",
+    "Rank borrowers by loan program.",
+    "Show borrowers with conventional loans.",
+    "Show me borrowers with a VA loan.",
+    "How many borrowers have jumbo loans?",
+    "Show borrowers with FHA mortgages.",
+    "Which borrowers have conforming loans?",
+    "Show me the average opportunity score by loan type.",
+)
+
+# The fail-closed default has to be exactly as strong as before. None of these
+# names a governed column; gold has 101 columns and none is fico/credit/income.
+_STILL_UNREVIEWED = (
+    "Show borrowers with a credit score above 740.",
+    "Break down borrowers by FICO.",
+    "Rank borrowers by household income.",
+    "Show borrowers by citizenship.",
+    "Break down borrowers by employment length.",
+    "Show borrowers with a net worth above 1 million.",
+)
+
+# The bare tokens the anchor exists to keep out. A US state abbreviation and an
+# ordinary adjective must not become selection vocabulary.
+_ANCHOR_HOLDS = (
+    "Show borrowers in VA.",
+    "How many borrowers are in Virginia?",
+    "Compare VA and MD on cash-out candidates.",
+    "Which states have conventional wisdom about refinancing?",
+)
+
+
+@pytest.mark.parametrize("question", _ANSWERABLE)
+def test_loan_program_questions_are_answerable(question: str) -> None:
+    assert _protected_prompt_match(question) is None, question
+
+
+@pytest.mark.parametrize("question", _STILL_UNREVIEWED)
+def test_unreviewed_attributes_stay_unreviewed(question: str) -> None:
+    assert _protected_prompt_match(question) == "unreviewed_criterion", question
+
+
+@pytest.mark.parametrize("question", _ANCHOR_HOLDS)
+def test_the_loan_noun_anchor_admits_no_bare_token(question: str) -> None:
+    """These must not be refused, and must not be refused *for this reason*.
+
+    ``Show borrowers in VA.`` is a geography question and passes either way;
+    what this pins is that adding ``va`` to the vocabulary did not do it by
+    making a bare ``VA`` a reviewed criterion — the fragment requires a
+    loan/mortgage noun after it.
+    """
+
+    import re
+
+    from backend.schemas.marketing_selection_vocabulary import (
+        REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT,
+    )
+
+    fragment = re.compile(REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT, re.IGNORECASE)
+    assert fragment.fullmatch("va") is None
+    assert fragment.fullmatch("conventional") is None
+    assert fragment.fullmatch("fha") is None
+    assert fragment.fullmatch("va loans") is not None
+    assert _protected_prompt_match(question) is None, question


### PR DESCRIPTION
## The gap

`(?:fixed|adjustable)-rate loans` was a reviewed Module 0 attribute. The loan **program** was not — an asymmetry rather than a decision.

`loan_product_type` is a governed `mip.gold.borrower_360` column with its own canonical UC function (`sql/uc_functions/fn_loan_product_type.sql`), and it is populated. Measured live on paychex 2026-08-12:

| loan_product_type | borrowers |
|---|---|
| conventional | 2,306,974 |
| fha | 303,977 |
| jumbo | 278,900 |
| va | 68,071 |
| other | 96,187 |

So these failed closed as **unknown criteria** against a column the product models, Genie can query, and the CNV work in #179/#185 was specifically about:

```
Break down borrowers by loan type.
Break down borrowers by loan product.
Show borrowers with conventional loans.
Show me borrowers with a VA loan.
How many borrowers have jumbo loans?
```

## How it was found

Swept **64 realistic Module 0 questions** through `_protected_prompt_match`. 8 refused; these were the 4 that were both wrong and in scope. Of the rest:

- 3 city questions (`Tacoma`, `Hawaiian Gardens`, `Indian Head Park`) were the **degraded fail-closed path** — no governed dimension locally. With a dimension present they pass, and the deployed app warms it at startup. Not a bug.
- `What is the average FICO of our borrowers?` → `source_gap:FICO`, which is **correct**. Gold has 101 columns and none is fico.

## The anchor is load-bearing

Both alternatives require a loan/mortgage noun. A bare `va` is the USPS abbreviation for Virginia and a bare `conventional` is an ordinary adjective:

```python
REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT.fullmatch("va")        is None
REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT.fullmatch("conventional") is None
REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT.fullmatch("va loans")  is not None
```

`test_the_loan_noun_anchor_admits_no_bare_token` pins all four, and `Show borrowers in VA.` / `Compare VA and MD.` are verified unaffected.

## Fail-closed default unchanged

`credit score`, `FICO`, `household income`, `employment length`, `net worth` and `citizenship` all still refuse as `unreviewed_criterion`; `race` / `national origin` / `disability` still refuse as protected terms, matched before this fragment is consulted.

Green: ruff, mypy, 19 new tests, and 3,607 tests across `test_genie_no_refusal_battery`, `test_genie_prompt_guard_geography`, `test_deep_analysis_question_family` and `test_marketing_safety`.

## Not fixed here — filed separately

A trailing **geography scope refuses every reviewed attribute**: `Show borrowers with a rate spread in Seattle` and **48 other combinations of 63 measured**. It predates this change (it hits `fixed-rate loans` too); the criterion is captured whole by `_CRITERION_TAIL`, so the scope suffix makes the whole tail unreviewed. Closing it needs a place gazetteer plus a differential battery, so it has its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
