### PR TITLE
fix(guards): close the analytics location slot to a governed place vocabulary

### DIFF
--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -19,6 +19,9 @@ from backend.schemas.marketing_selection_reviewed_attributes import (
     REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT,
     REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT,
 )
+from backend.schemas.marketing_selection_reviewed_places import (
+    is_governed_analytics_location,
+)
 
 _CRITERION_TAIL = r"(?P<criterion>[^.!?;:]{1,120})"
 _ELIGIBILITY_SUBJECT = (
@@ -581,9 +584,7 @@ def _contains_unreviewed_audience_decision(
     admission = audience_admission_criterion(clause)
     if admission is not None:
         return not _is_reviewed_admission_criterion(admission)
-    if any(
-        pattern.fullmatch(clause) is not None for pattern in _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS
-    ):
+    if matches_reviewed_read_only_analytic_shape(clause):
         return False
     if _REVIEWED_NON_POPULATION_STRATEGY_RE.fullmatch(clause) is not None:
         return False
@@ -702,16 +703,36 @@ def _contains_unreviewed_audience_decision(
     return False
 
 
+def matches_reviewed_read_only_analytic_shape(clause: str) -> bool:
+    """Fullmatch a reviewed analytics shape AND clear its location slot.
+
+    The two halves are one decision and must stay in one function. Matching a
+    shape sets ``reviewed_analytics``, which silences the health-term bank and
+    takes the unknown-criterion state machine out of the decision, so a shape
+    that matched on the regex alone would hand that kill switch to whatever
+    landed in the location capture. Both callers of the pattern tuple used to
+    spell the fullmatch themselves; a check added to one of them would have
+    left the other open.
+    """
+
+    for pattern in _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS:
+        match = pattern.fullmatch(clause)
+        if match is None:
+            continue
+        # ``loc`` is absent from shapes that carry no location slot, and None
+        # when the slot is present but unused. Both mean "no place named".
+        location = match.groupdict().get("loc")
+        if is_governed_analytics_location(location):
+            return True
+    return False
+
+
 def is_reviewed_read_only_analytics_text(value: str) -> bool:
     """Return true only when every clause is a closed, read-only analytics query."""
 
     clauses = [part.strip() for part in re.split(r"[.!?;:\n]+", value) if part.strip()]
     return bool(clauses) and all(
-        any(
-            pattern.fullmatch(clause) is not None
-            for pattern in _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS
-        )
-        for clause in clauses
+        matches_reviewed_read_only_analytic_shape(clause) for clause in clauses
     )
 
 

--- a/backend/schemas/marketing_selection_reviewed_analytics.py
+++ b/backend/schemas/marketing_selection_reviewed_analytics.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import re
 
-from backend.schemas._validators_person_names import US_STATE_NAMES
+from backend.schemas.marketing_selection_reviewed_places import (
+    REVIEWED_ANALYTIC_LOCATION_FRAGMENT,
+)
 
 # A count inside a reviewed analytics shape. It must admit exactly what the
 # directive grammar's lead-in admits, because the two sit on opposite sides of
@@ -25,11 +27,6 @@ from backend.schemas._validators_person_names import US_STATE_NAMES
 # "top 25" passed. Fused orthography, and counts above 999, are the cases the
 # old `top\s+[0-9]{1,3}\s+` slot could not reach.
 _ANALYTIC_COUNT = r"(?:[0-9]{1,5}|ten|twenty(?:[- ]five)?)"
-# The federal state list, reused so the analytics location slot is closed
-# to the same vocabulary the name-shape strip already treats as places.
-_US_STATE_ALTERNATION = "|".join(
-    re.escape(state).replace(r"\ ", r"\s+") for state in US_STATE_NAMES
-)
 
 _REVIEWED_ANALYTIC_POPULATION = (
     r"(?:(?:(?:in[- ]the[- ]money|listed|refinance[- ]ready|retention[- ]risk|"
@@ -46,10 +43,17 @@ _REVIEWED_ANALYTIC_MEASURE = (
     r"(?:listing\s+time\s+on\s+market|lead\s+score|opportunity\s+score|"
     r"borrower\s+count|equity(?:\s+percentage)?|ltv|loan[- ]to[- ]value|rate[- ]spread)"
 )
-_REVIEWED_ANALYTIC_LOCATION = (
-    r"(?:\s+(?:in|across)\s+(?:the\s+current\s+(?:coverage|portfolio)|"
-    r"[A-Za-z]{2}|[A-Z][A-Za-z' -]{2,40}))?"
-)
+# One location grammar, six shapes. This slot used to be spelled two ways:
+# a state-only tail on the ranked ask (closed in b6c38f74) and 41 characters
+# of IGNORECASE free text everywhere else, which is the tail that was closed
+# there for silencing the health bank. The open spelling survived on the five
+# other shapes carrying it, so "Chart borrowers by segment in dialysis
+# centers" and "Show customers with an in-the-money refi in hospice care" were
+# still ALLOWED at 35a9720a. Both spellings are gone; the captured value is
+# checked against the governed place vocabulary by
+# ``is_governed_analytics_location``, which is what makes a city or a county
+# admissible without reopening a free slot for a health term.
+_REVIEWED_ANALYTIC_LOCATION = REVIEWED_ANALYTIC_LOCATION_FRAGMENT
 # Governed Module 0 product-intent cohorts. Closed list: these are offer
 # codes/segment names the product models, never free-text criteria.
 _REVIEWED_PRODUCT_INTENT = (
@@ -119,24 +123,16 @@ _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS: tuple[re.Pattern[str], ...] = (
         r"[0-9][0-9.,]*\s*(?:%|percent|bps|basis\s+points)?"
         rf"(?:\s+and\s+(?:modeled\s+equity|{_REVIEWED_ANALYTIC_SIGNAL})\s*[<>=\u2264\u2265]+\s*"
         r"[0-9][0-9.,]*\s*(?:%|percent|bps|basis\s+points)?){0,3})?"
-        # Location tail, CLOSED to the federal state list plus the coverage
-        # phrases. It was `[A-Z][A-Za-z' -]{2,40}` under IGNORECASE -- 41
-        # characters of free text -- and matching this shape sets
-        # ``reviewed_analytics``, which is a KILL SWITCH for the health-term
-        # bank, not merely a criterion bypass. So "... in dialysis centers"
-        # rode the tail and silenced the detector: 114 health-term phrasings
-        # across 57 conditions went from refused to allowed (signoff round
-        # three). An allow shape in a fail-closed system may not contain an
-        # open slot.
-        rf"(?:\s+(?:in|across)\s+(?:the\s+current\s+(?:coverage|portfolio)|"
-        rf"(?:the\s+state\s+of\s+)?(?:{_US_STATE_ALTERNATION})"
-        # ``ms`` is the one two-letter sequence that is BOTH a USPS code and a
-        # governed term (multiple sclerosis) -- computed by sweeping all 676
-        # pairs against the banks, not assumed -- and this shape sets
-        # ``reviewed_analytics``, which silences the health-term bank. Excluded
-        # here so "... in ms." cannot ride the state slot; Mississippi is still
-        # reachable by name and as "(MS)" after it.
-        rf"(?:\s*\([A-Z]{{2}}\))?|(?!ms\b)[A-Z]{{2}}))?"
+        # The shared location slot. It was `[A-Z][A-Za-z' -]{2,40}` under
+        # IGNORECASE -- 41 characters of free text -- and matching this shape
+        # sets ``reviewed_analytics``, which is a KILL SWITCH for the
+        # health-term bank, not merely a criterion bypass. So "... in dialysis
+        # centers" rode the tail and silenced the detector: 114 health-term
+        # phrasings across 57 conditions went from refused to allowed (signoff
+        # round three). An allow shape in a fail-closed system may not contain
+        # an open slot -- but the vocabulary that closes it is a vocabulary of
+        # PLACES, not of states, so a city or a county reaches the same slot.
+        rf"{_REVIEWED_ANALYTIC_LOCATION}"
         # Closed status tail: "who are currently listed for sale".
         rf"(?:\s+who\s+are\s+(?:currently\s+)?{_REVIEWED_PRODUCT_INTENT})?"
         r"$",

--- a/backend/schemas/marketing_selection_reviewed_places.py
+++ b/backend/schemas/marketing_selection_reviewed_places.py
@@ -147,8 +147,19 @@ COUNTY_NAME_EXCLUSIONS: Final[frozenset[str]] = frozenset(
 # backtracking ever does settle on a wrong binding, membership rejects it and
 # the clause fails closed, which is a false refusal and never a bypass.
 _LOCATION_TOKEN = r"[A-Za-z][A-Za-z.'-]*"
+# "the whole footprint" said the way the product says it. Closed, and wider
+# than it looks it needs to be: the slot admitted only `the current
+# coverage|portfolio`, while "across the current Cotality data coverage" is
+# the phrasing the repo uses 45 times -- it is the tail of a SHIPPED Genie
+# sample question, and it refused, because the old open slot had been
+# absorbing it as free text rather than recognising it.
+_COVERAGE_PHRASE = (
+    r"the\s+current\s+(?:cotality\s+)?"
+    r"(?:data\s+|refreshed\s+|reviewed\s+)?(?:geography\s+|share\s+)?"
+    r"(?:coverage|portfolio|footprint)"
+)
 REVIEWED_ANALYTIC_LOCATION_FRAGMENT: Final[str] = (
-    r"(?:\s+(?:in|across)\s+(?:the\s+current\s+(?:coverage|portfolio)|"
+    rf"(?:\s+(?:in|across)\s+(?:{_COVERAGE_PHRASE}|"
     r"(?:the\s+state\s+of\s+)?"
     rf"(?P<loc>{_LOCATION_TOKEN}(?:\s+{_LOCATION_TOKEN}){{0,3}}"
     r"(?:\s*,\s*[A-Za-z]{2})?(?:\s*\([A-Za-z]{2}\))?)))?"

--- a/backend/schemas/marketing_selection_reviewed_places.py
+++ b/backend/schemas/marketing_selection_reviewed_places.py
@@ -1,0 +1,359 @@
+"""The closed US place vocabulary the reviewed-analytics location slot admits.
+
+Matching a reviewed analytics shape sets ``reviewed_analytics``, which is a
+KILL SWITCH: it silences ``PROTECTED_HEALTH_TERM_MARKETING_RE`` and takes the
+unknown-criterion state machine out of the decision for the whole clause. An
+allow shape in a fail-closed system may therefore not contain an open slot,
+which is what ``[A-Z][A-Za-z' -]{2,40}`` under IGNORECASE was -- 41 characters
+of free text that let ``... in dialysis centers`` ride the shape.
+
+Closing that slot to a vocabulary, rather than to a shape, is not a stylistic
+choice. A bounded shape screened at match time was built and MEASURED here
+before this module existed, and it fails in both directions at once: over a
+20-term governed probe set and an 18-value governed place set, the best carrier
+(``Show me borrowers in {loc}.``) missed ``eczema``, ``Chinatown``,
+``methadone clinics`` and ``nursing homes`` -- ``eczema`` is not in the health
+bank at all, it is caught only by the criterion machine the shape switches off
+-- while refusing ``Tacoma``, ``Hawaiian Gardens`` and ``Indian Head Park``,
+which are live gold cities. Membership in a screened vocabulary is what
+separates a place from a governed term; the shape of the string cannot.
+
+Three vocabularies, three lifetimes
+-----------------------------------
+* **States** -- the federal list. Fixed, and reproduced here in full.
+* **Counties** -- the shipped ``us-counties.json`` the map drill-down already
+  ships. National, public-domain, and repo-committed, so it screens once at
+  import-time cost and never drifts with coverage.
+* **Cities** -- the governed gold dimension, which is live Cotality coverage
+  and cannot be committed (CLAUDE.md: the product follows the current refresh
+  dynamically). It arrives by registration from the services layer, because
+  ``backend/schemas`` may not import ``backend/services``. Until it does, the
+  set is empty and a city-grain question refuses, which is the same answer the
+  guard gives today -- degradation costs the grain, never the guard.
+
+Every county and city value passes :func:`_collides_with_governed_term` before
+it is admitted. That gate runs the REAL banks, not a copy of them: a private
+regex copy is how a relaxation silently stops tracking the detector it claims
+to mirror.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Final
+
+# The federal list: 50 states plus the District of Columbia.
+#
+# NOT ``_validators_person_names.US_STATE_NAMES``. That tuple names itself "the
+# federal list" but is a person-name-heuristic helper, and it deliberately
+# carries only the ONE-word states -- "Two-word states already live in
+# ``_REVIEWED_NON_PERSON_PHRASES``; the pair heuristic only ever misreads the
+# ONE-word ones". Reusing it to close the analytics location tail silently
+# dropped eleven states and DC out of the governed slot: "in New York", "in
+# North Carolina" and "in District of Columbia" all refused, measured on the
+# 814-string differential against 7612b021.
+US_STATE_NAMES_FEDERAL: Final[tuple[str, ...]] = (
+    # fmt: off
+    "Alabama", "Alaska", "Arizona", "Arkansas", "California", "Colorado",
+    "Connecticut", "Delaware", "District of Columbia", "Florida", "Georgia",
+    "Hawaii", "Idaho", "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+    "Louisiana", "Maine", "Maryland", "Massachusetts", "Michigan", "Minnesota",
+    "Mississippi", "Missouri", "Montana", "Nebraska", "Nevada",
+    "New Hampshire", "New Jersey", "New Mexico", "New York", "North Carolina",
+    "North Dakota", "Ohio", "Oklahoma", "Oregon", "Pennsylvania",
+    "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas",
+    "Utah", "Vermont", "Virginia", "Washington", "West Virginia", "Wisconsin",
+    "Wyoming",
+    # fmt: on
+)
+US_STATE_CODES: Final[tuple[str, ...]] = (
+    # fmt: off
+    "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL", "GA", "HI",
+    "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN",
+    "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH",
+    "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA",
+    "WV", "WI", "WY",
+    # fmt: on
+)
+# ``ms`` is the one USPS code that is also a governed term (multiple
+# sclerosis) -- computed by sweeping all 676 pairs against the banks, not
+# assumed. Mississippi stays reachable by name, and as "(MS)" after it.
+_EXCLUDED_STATE_CODES: Final[frozenset[str]] = frozenset({"ms"})
+
+_STATE_NAMES_LOWER: Final[frozenset[str]] = frozenset(
+    name.lower() for name in US_STATE_NAMES_FEDERAL
+)
+_STATE_CODES_LOWER: Final[frozenset[str]] = frozenset(code.lower() for code in US_STATE_CODES)
+
+# The map drill-down's own artifact. Public-domain us-atlas county TopoJSON,
+# already a backend dependency for county display labels.
+_COUNTY_TOPOJSON: Final[Path] = (
+    Path(__file__).resolve().parents[2] / "frontend" / "public" / "us-counties.json"
+)
+# A county dimension that reads far larger than the ~1.8k distinct national
+# names is not the shipped artifact. Admitting thousands of unscreened values
+# on that evidence would be a guard rewrite by accident, so admit none.
+_MAX_COUNTY_NAMES: Final[int] = 4_096
+# Governed city values arrive from live gold. The same posture, one order up:
+# the dimension measured 428 distinct values on 2026-08-12.
+_MAX_CITY_VALUES: Final[int] = 8_192
+
+# Shipped county names that carry a governed term. Committed rather than
+# screened at runtime because the artifact is static: which names collide can
+# only change when a DETECTOR BANK changes, and screening ~1.8k names costs
+# ~5s -- unacceptable on a first guard call, trivial as a build step.
+# Re-derive with ``tools/screen_county_place_vocabulary.py``.
+#
+# 13 of 1,833, and every one is explainable, which is the check that says the
+# gate is measuring something rather than just returning: race (``white``,
+# ``white pine``), age (``box elder``, ``young``), national origin
+# (``canadian``, ``indian river``), religion (``christian``, ``falls church``,
+# ``st. john the baptist``), disability (``deaf smith``), and the ``-oma``
+# condition morphology (``coahoma``, ``oklahoma``, ``sonoma``) that also costs
+# the prose surface every question naming Tacoma.
+#
+# Two names are worth knowing about. ``Oklahoma`` stays reachable as a STATE:
+# the federal list is its own closed vocabulary and is checked first, so only
+# the county grain is lost. ``Young`` is the one entry the gate excludes that
+# the full guard does not flag in a ranked sentence -- "Young borrowers" trips
+# age targeting, "... in Young County" does not -- and it stays excluded,
+# because the conservative carrier is the right one for a slot that hands out
+# a kill switch.
+COUNTY_NAME_EXCLUSIONS: Final[frozenset[str]] = frozenset(
+    {
+        "box elder",
+        "canadian",
+        "christian",
+        "coahoma",
+        "deaf smith",
+        "falls church",
+        "indian river",
+        "oklahoma",
+        "sonoma",
+        "st. john the baptist",
+        "white",
+        "white pine",
+        "young",
+    }
+)
+
+# At most four whitespace-separated tokens. "Prince George's County" is three;
+# nothing in any of the three vocabularies is longer. The bound is what stops
+# the capture swallowing a following clause in the compound shapes -- and if
+# backtracking ever does settle on a wrong binding, membership rejects it and
+# the clause fails closed, which is a false refusal and never a bypass.
+_LOCATION_TOKEN = r"[A-Za-z][A-Za-z.'-]*"
+REVIEWED_ANALYTIC_LOCATION_FRAGMENT: Final[str] = (
+    r"(?:\s+(?:in|across)\s+(?:the\s+current\s+(?:coverage|portfolio)|"
+    r"(?:the\s+state\s+of\s+)?"
+    rf"(?P<loc>{_LOCATION_TOKEN}(?:\s+{_LOCATION_TOKEN}){{0,3}}"
+    r"(?:\s*,\s*[A-Za-z]{2})?(?:\s*\([A-Za-z]{2}\))?)))?"
+)
+
+_TRAILING_STATE_RE: Final[re.Pattern[str]] = re.compile(
+    r"^(?P<core>.*?)(?:\s*,\s*(?P<comma>[A-Za-z]{2})|\s*\((?P<paren>[A-Za-z]{2})\))$"
+)
+
+
+def _collides_with_governed_term(value: str) -> bool:
+    """True when a place value carries a term a detector governs.
+
+    Asks the REAL front door, not a hand-assembled list of banks. The first
+    draft of this gate enumerated seven compiled patterns and was measured
+    against the full guard over all 1,833 shipped county names: it agreed on
+    every name but ``Falls Church``, which the guard refuses through
+    ``_contains_protected_class_proxy_pair`` -- a detector that is a function,
+    not a pattern, so no bank list contains it. That is the private-copy
+    failure mode in miniature, caught only because the sweep had a control to
+    disagree with. Delegating means a detector added to the guard is in this
+    gate the same day.
+
+    One probe, ``"<value> borrowers"``. It contains the bare value, so a
+    direct-term hit is still found, and it supplies the population noun the
+    windowed detectors need -- the national-origin bank is why ``Indian
+    River`` and ``Hawaiian Gardens`` are excluded, and it does not fire on a
+    bare value. ~2.8ms per probe.
+
+    ``unreviewed_criterion`` is NOT a collision: it is the criterion state
+    machine saying it does not recognise "Adams borrowers" as a complete
+    reviewed selection, which is true of every place name and would exclude
+    the entire vocabulary. Only a named protected-class verdict disqualifies.
+
+    Imported lazily and deliberately: ``_validators_protected_class`` reaches
+    this module through ``marketing_selection_criteria``, so a module-level
+    import would close a cycle. The probe cannot recurse into the county set --
+    ``admitted_county_names`` is set arithmetic over a committed exclusion
+    list and calls nothing here -- and a bare ``"<value> borrowers"`` cannot
+    fullmatch an anchored analytics shape.
+    """
+
+    from backend.schemas._validators_protected_class import protected_class_marketing_reason
+
+    return protected_class_marketing_reason(f"{value} borrowers") == "protected_class"
+
+
+@lru_cache(maxsize=1)
+def shipped_county_names() -> frozenset[str]:
+    """Distinct county names from the shipped national TopoJSON, unscreened.
+
+    Empty when the artifact is missing or unreadable: no counties admitted, so
+    a county question refuses. Fail-closed, like every other degradation on
+    this path.
+    """
+
+    try:
+        payload = json.loads(_COUNTY_TOPOJSON.read_text(encoding="utf-8"))
+        geometries = payload["objects"]["counties"]["geometries"]
+    except Exception:
+        return frozenset()
+    names = {
+        " ".join(str(geometry["properties"]["name"]).split())
+        for geometry in geometries
+        if isinstance(geometry, dict) and (geometry.get("properties") or {}).get("name")
+    }
+    if not names or len(names) > _MAX_COUNTY_NAMES:
+        return frozenset()
+    return frozenset(name for name in names if name)
+
+
+@lru_cache(maxsize=1)
+def admitted_county_names() -> frozenset[str]:
+    """Lower-cased shipped county names, minus the screened collisions.
+
+    Carries a period-stripped spelling of the ~20 abbreviated names
+    (``st. louis`` -> ``st louis``). Not cosmetic: the reviewed-analytics text
+    is split into clauses on ``[.!?;:\\n]+`` before any shape is matched, so
+    "... in St. Louis County." arrives as two clauses cut at the abbreviation
+    and no shape can match either half. "St Louis County" is the spelling that
+    survives that split, and the abbreviated-with-period form stays refused --
+    a clause-segmentation residual that predates this slot and is not fixable
+    inside it.
+
+    Dropping a period cannot introduce a token, so the stripped spelling
+    inherits its screen from the name it came from; no re-probe is needed.
+    """
+
+    admitted = frozenset(name.lower() for name in shipped_county_names()) - COUNTY_NAME_EXCLUSIONS
+    return admitted | {
+        " ".join(name.replace(".", " ").split()) for name in admitted if "." in name
+    }
+
+
+_registered_city_values: frozenset[str] = frozenset()
+_registered_city_input: frozenset[str] | None = None
+
+
+def register_governed_analytics_cities(values: object) -> int:
+    """Publish the governed city dimension to the location slot.
+
+    Dependency inversion, because ``backend/schemas`` may not import
+    ``backend/services`` (``test_schemas_do_not_import_runtime_services``). The
+    resolver that owns the live dimension calls this at warm-up; nothing here
+    reaches for it, so the schemas layer keeps no runtime dependency.
+
+    Returns the number of values admitted, so the caller can log what a refresh
+    actually bought rather than assume. Passing an empty iterable clears the
+    set, which is how a degraded resolve withdraws the city grain.
+
+    Screening the 428 live values costs ~1.2s, so an unchanged dimension
+    short-circuits on the raw input before a single probe runs. The resolver
+    re-reads gold every 15 minutes and the values almost never move; without
+    this, every TTL refresh would pay the full screen on whichever request
+    happened to trigger it.
+    """
+
+    global _registered_city_values, _registered_city_input
+    if isinstance(values, str | bytes):
+        candidates: tuple[str, ...] = ()
+    else:
+        try:
+            candidates = tuple(str(value) for value in values)  # type: ignore[union-attr]
+        except TypeError:
+            candidates = ()
+    incoming = frozenset(candidates)
+    if incoming == _registered_city_input:
+        return len(_registered_city_values)
+    admitted: set[str] = set()
+    if len(candidates) <= _MAX_CITY_VALUES:
+        for value in candidates:
+            collapsed = " ".join(value.split())
+            if not collapsed or len(collapsed.split()) > 4:
+                continue
+            if _collides_with_governed_term(collapsed):
+                continue
+            admitted.add(collapsed.lower())
+    resolved = frozenset(admitted)
+    _registered_city_input = incoming
+    if resolved != _registered_city_values:
+        _registered_city_values = resolved
+        _invalidate_dependent_caches()
+    return len(resolved)
+
+
+def governed_analytics_cities() -> frozenset[str]:
+    """The admitted governed city values. Empty until a resolver registers."""
+
+    return _registered_city_values
+
+
+def _invalidate_dependent_caches() -> None:
+    """Drop the guard memos that could hold a pre-registration verdict.
+
+    The prompt guard memoizes by text, so a question answered before warm-up
+    would keep its refusal for the life of the process. Lazily imported for the
+    same cycle reason as the probe in :func:`_collides_with_governed_term`.
+    """
+
+    from backend.schemas._validators_protected_class import (
+        _protected_class_marketing_reason_cached,
+    )
+
+    _protected_class_marketing_reason_cached.cache_clear()
+
+
+def is_governed_analytics_location(value: str | None) -> bool:
+    """True when a captured location slot names a governed US place.
+
+    ``None`` means the clause named no location, which is the shape's own
+    business, not this vocabulary's.
+    """
+
+    if value is None:
+        return True
+    text = " ".join(str(value).split())
+    # The shapes keep "the state of" outside the capture, but this is the
+    # public contract for a location string and callers pass what they read.
+    if text.lower().startswith("the state of "):
+        text = text[len("the state of ") :].strip()
+    if not text:
+        return False
+    trailing = _TRAILING_STATE_RE.fullmatch(text)
+    if trailing is not None:
+        code = (trailing.group("comma") or trailing.group("paren") or "").lower()
+        core = trailing.group("core").strip()
+        # A trailing two-letter token only disambiguates when it is a real
+        # state code AND something precedes it. Anything else keeps the whole
+        # string and lets membership decide.
+        #
+        # ``ms`` is NOT excluded here. The exclusion belongs to the bare-code
+        # branch below, where nothing in the string says which reading is
+        # meant; in "Mississippi (MS)" the state name is right there, and
+        # dropping the parenthetical on that ground refused a spelling the
+        # closed tail has always admitted.
+        if core and code in _STATE_CODES_LOWER:
+            text = core
+    lowered = text.lower()
+    if lowered in _STATE_NAMES_LOWER:
+        return True
+    if lowered in _STATE_CODES_LOWER:
+        return lowered not in _EXCLUDED_STATE_CODES
+    if lowered in governed_analytics_cities():
+        return True
+    counties = admitted_county_names()
+    if lowered in counties:
+        return True
+    bare = lowered[: -len(" county")] if lowered.endswith(" county") else ""
+    return bool(bare) and bare in counties

--- a/backend/schemas/marketing_selection_reviewed_places.py
+++ b/backend/schemas/marketing_selection_reviewed_places.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
 from typing import Final
@@ -266,13 +267,15 @@ def register_governed_analytics_cities(values: object) -> int:
     """
 
     global _registered_city_values, _registered_city_input
-    if isinstance(values, str | bytes):
+    # ``object`` on purpose: this is called across a layer boundary by a
+    # resolver that degrades, so a str, a None, or a non-iterable is a real
+    # input and each must mean "publish nothing" rather than raise into a
+    # dimension load. A bare string is iterable and would register 428
+    # single characters, so it is rejected before the Iterable check.
+    if isinstance(values, str | bytes) or not isinstance(values, Iterable):
         candidates: tuple[str, ...] = ()
     else:
-        try:
-            candidates = tuple(str(value) for value in values)  # type: ignore[union-attr]
-        except TypeError:
-            candidates = ()
+        candidates = tuple(str(value) for value in values)
     incoming = frozenset(candidates)
     if incoming == _registered_city_input:
         return len(_registered_city_values)

--- a/backend/services/genie_place_dimension.py
+++ b/backend/services/genie_place_dimension.py
@@ -541,6 +541,55 @@ def _collides_with_person_lexicon(value: str) -> bool:
     return shares_token_with_person_lexicon(value)
 
 
+def _publish_analytics_location_cities(resolved: ResolvedPlaceDimension) -> None:
+    """Hand the governed city dimension to the PROMPT guard's location slot.
+
+    Dependency inversion, not an import the other way: ``backend/schemas`` may
+    not import ``backend/services``, so the layer that owns the live dimension
+    pushes it down. This is a FIFTH surface, and it takes the raw
+    ``all_values`` rather than any set resolved here on purpose -- each surface
+    needs its own admission gate, and the gate for a slot that silences the
+    health bank is not the gate for a prose name-shape false positive. The
+    schemas side screens what it accepts.
+
+    Publishing the DEGRADED resolve matters as much as the loaded one: an empty
+    dimension withdraws the city grain and city questions refuse again, which
+    is the same answer the guard gave before this slot existed.
+
+    Called under ``_load_lock``, which is safe here and would not be for most
+    work in this module: the screening probe runs entirely inside
+    ``backend/schemas``, and schemas cannot import services, so it has no path
+    back to ``_resolve``. That is the same non-reentrant lock the cell probes
+    deadlock on. It costs ~1.2s against the 428 live values, and only on a
+    load that actually changed them -- ``register_governed_analytics_cities``
+    short-circuits an unchanged dimension before screening anything.
+    """
+
+    from backend.schemas.marketing_selection_reviewed_places import (
+        register_governed_analytics_cities,
+    )
+
+    try:
+        admitted = register_governed_analytics_cities(resolved.all_values)
+    except Exception as exc:  # noqa: BLE001 — a guard vocabulary must not 500
+        emit(
+            log,
+            "analytics_location_cities_publish_failed",
+            level=logging.WARNING,
+            outcome="degraded",
+            exc_type=type(exc).__name__,
+            exc_msg=str(exc)[:500],
+        )
+        return
+    emit(
+        log,
+        "analytics_location_cities_published",
+        level=logging.INFO,
+        dimension_values=len(resolved.all_values),
+        admitted_values=admitted,
+    )
+
+
 class GovernedPlaceDimensionResolver:
     """Resolve governed city values that the output-policy scanner rejects."""
 
@@ -704,9 +753,11 @@ class GovernedPlaceDimensionResolver:
                 self._cache.set(
                     _PLACE_DIMENSION_CACHE_KEY, degraded, _PLACE_DIMENSION_FAILURE_TTL_S
                 )
+                _publish_analytics_location_cities(degraded)
                 return degraded
             self._warned = False
             self._cache.set(_PLACE_DIMENSION_CACHE_KEY, loaded, self._ttl_s)
+            _publish_analytics_location_cities(loaded)
             return loaded
 
     def conflicting_values(self) -> frozenset[str]:
@@ -818,8 +869,19 @@ def warm_governed_place_dimension() -> None:
 def _reset_governed_place_dimension_for_tests(
     resolver: GovernedPlaceDimensionResolver | None = None,
 ) -> None:
-    """Test helper: swap (or clear) the process-wide resolver."""
+    """Test helper: swap (or clear) the process-wide resolver.
+
+    Also withdraws the published analytics-location vocabulary. Resolving is a
+    PUBLISHING act now, so a test that resolves a fake dimension leaves its
+    city values in a module global in the schemas layer, where the next test
+    file would silently inherit them.
+    """
+
+    from backend.schemas.marketing_selection_reviewed_places import (
+        register_governed_analytics_cities,
+    )
 
     global _RESOLVER
     with _RESOLVER_LOCK:
         _RESOLVER = resolver
+    register_governed_analytics_cities(())

--- a/tests/unit/test_guard_cross_surface_audit.py
+++ b/tests/unit/test_guard_cross_surface_audit.py
@@ -11,6 +11,8 @@ append-only audit ledger verbatim).
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 from fastapi.exceptions import HTTPException
 
@@ -28,6 +30,9 @@ from backend.schemas.common import (
     validate_public_campaign_label,
 )
 from backend.schemas.growth_agent import assert_reviewed_growth_objective
+from backend.schemas.marketing_selection_reviewed_places import (
+    register_governed_analytics_cities,
+)
 from backend.schemas.portfolio_campaign import (
     CampaignRecommendationEvidence,
     assert_public_campaign_text,
@@ -35,6 +40,37 @@ from backend.schemas.portfolio_campaign import (
 from backend.schemas.sales import DispositionRequest
 from backend.services.audit_store import AuditMetadataValueViolation, _sanitize_metadata
 from backend.services.genie_message_policy import genie_visible_text_unsafe
+
+# The cities this file names, published the way ``backend.main``'s lifespan
+# publishes the governed dimension at warm-up.
+#
+# This file asserts two things that used to be in tension: that a city passes
+# every surface, and that "the reviewed-analytics pattern shapes are
+# closed-vocabulary, so nothing else rides them". Both could not be true at
+# once, and the second was the false one -- the shapes' location slot was
+# `[A-Z][A-Za-z' -]{2,40}` under IGNORECASE, so a city passed because ANY
+# title-case string did, health terms included. With the slot closed to a
+# governed place vocabulary, a city name is vocabulary only once a resolver
+# publishes it, which is what the app does before it serves a request and what
+# this fixture does before the assertions run.
+_GOVERNED_CITIES: tuple[str, ...] = (
+    "EL PASO",
+    "FORT WORTH",
+    "SAN ANTONIO",
+    "ROUND ROCK",
+    "CORPUS CHRISTI",
+    "BATON ROUGE",
+    "LAKE FOREST",
+)
+
+
+@pytest.fixture(autouse=True)
+def _governed_place_dimension() -> Iterator[None]:
+    """Publish, then withdraw: the registry is process-wide state."""
+
+    register_governed_analytics_cities(_GOVERNED_CITIES)
+    yield
+    register_governed_analytics_cities(())
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_reviewed_analytics_location.py
+++ b/tests/unit/test_reviewed_analytics_location.py
@@ -214,14 +214,19 @@ def test_the_city_gate_admits_the_rest_of_the_sample() -> None:
 @pytest.mark.parametrize(
     "junk",
     (
-        "SEATTLE",  # a bare string is not a dimension
+        "SEATTLE",  # a bare string IS iterable -- 7 single characters
         object(),  # not iterable at all
+        None,  # what a degraded resolver hands over
+        42,
         ("a b c d e f",),  # more tokens than any governed place value
         ("",),
         ("   ",),
     ),
 )
 def test_registration_is_fail_closed_on_junk(junk: object) -> None:
+    """Called across a layer boundary by a resolver that degrades, so every
+    one of these is a real input and none may raise into a dimension load."""
+
     assert register_governed_analytics_cities(junk) == 0
     assert governed_analytics_cities() == frozenset()
 

--- a/tests/unit/test_reviewed_analytics_location.py
+++ b/tests/unit/test_reviewed_analytics_location.py
@@ -1,0 +1,366 @@
+"""The location slot of the reviewed-analytics shapes, and what may enter it.
+
+Matching one of these shapes sets ``reviewed_analytics``, which silences
+``PROTECTED_HEALTH_TERM_MARKETING_RE`` and takes the unknown-criterion state
+machine out of the decision for the whole clause. The slot is therefore a kill
+switch with a hole in the middle, and these tests pin both halves of the deal:
+every governed US place reaches it, and nothing else does.
+
+Three defects are pinned here, all found on one 814-string differential
+against 7612b021:
+
+1. A city or county grain refused outright -- the reported gap.
+2. Eleven states and DC refused, because b6c38f74 closed the slot to
+   ``_validators_person_names.US_STATE_NAMES``, which calls itself "the federal
+   list" but deliberately carries only the ONE-word states.
+3. The open ``[A-Z][A-Za-z' -]{2,40}`` slot survived on the five OTHER shapes
+   that carry a location, so "Chart borrowers by segment in dialysis centers"
+   was still ALLOWED after the ranked ask was closed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from backend.schemas._validators_protected_class import protected_class_marketing_reason
+from backend.schemas.marketing_selection_reviewed_places import (
+    COUNTY_NAME_EXCLUSIONS,
+    US_STATE_CODES,
+    US_STATE_NAMES_FEDERAL,
+    _collides_with_governed_term,
+    admitted_county_names,
+    governed_analytics_cities,
+    is_governed_analytics_location,
+    register_governed_analytics_cities,
+    shipped_county_names,
+)
+
+# The live gold ``city`` dimension's shape: upper-case, and carrying the four
+# values the governed-place work has repeatedly found to collide with a
+# detector (PR #206/#207).
+GOLD_CITY_SAMPLE: tuple[str, ...] = (
+    "SEATTLE",
+    "CHICAGO",
+    "HIGHLANDS RANCH",
+    "BELLEVUE",
+    "MEDINA",
+    "ELIZABETH",
+    "YORBA LINDA",
+    "WINSTON-SALEM",
+    "TACOMA",
+    "HAWAIIAN GARDENS",
+    "INDIAN HEAD PARK",
+    "BLACK DIAMOND",
+)
+# Of that sample, the four a detector governs. Admitting any of them would hand
+# the health/criterion kill switch to a term the banks exist to catch.
+GOLD_CITY_COLLISIONS: tuple[str, ...] = (
+    "TACOMA",
+    "HAWAIIAN GARDENS",
+    "INDIAN HEAD PARK",
+    "BLACK DIAMOND",
+)
+
+RANKED = "Show me the top 20 borrowers with the highest lead scores in {loc}."
+# Every reviewed shape that carries the shared location slot. A check wired
+# into one of them and not the others is how the open slot survived b6c38f74.
+LOCATION_CARRYING_SHAPES: tuple[str, ...] = (
+    RANKED,
+    "Rank the top cash-out candidates in {loc} and explain why each one qualifies",
+    "Rank the top cash-out candidates in {loc}",
+    "Show customers with an in-the-money refi in {loc}",
+    "Chart borrowers by segment in {loc}",
+    "What is the average lead score for borrowers by segment in {loc}",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_city_registry() -> Iterator[None]:
+    """The registry is process-wide state; never leak it between tests."""
+
+    register_governed_analytics_cities(())
+    yield
+    register_governed_analytics_cities(())
+
+
+def _refused(question: str) -> bool:
+    return protected_class_marketing_reason(question) is not None
+
+
+# --------------------------------------------------------------- the reports
+
+
+@pytest.mark.parametrize(
+    "question",
+    (
+        "Show me the top 20 borrowers with the highest lead scores in Seattle.",
+        "Show me the top 20 borrowers with the highest lead scores in King County.",
+        "Show me the top 20 borrowers with the highest lead scores in Highlands Ranch.",
+    ),
+)
+def test_the_reported_city_and_county_asks_reach_the_shape(question: str) -> None:
+    """The gap as reported: ranked analytics scoped below the state grain."""
+
+    register_governed_analytics_cities(GOLD_CITY_SAMPLE)
+    assert _refused(question) is False
+
+
+@pytest.mark.parametrize(
+    "state",
+    ("New York", "North Carolina", "District of Columbia", "New Jersey", "West Virginia"),
+)
+def test_multi_word_states_reach_the_governed_slot(state: str) -> None:
+    """b6c38f74 closed the slot to a list that has no two-word states in it."""
+
+    assert _refused(RANKED.format(loc=state)) is False
+
+
+def test_every_federal_state_reaches_the_slot() -> None:
+    assert len(US_STATE_NAMES_FEDERAL) == 51
+    refused = [name for name in US_STATE_NAMES_FEDERAL if _refused(RANKED.format(loc=name))]
+    assert refused == []
+
+
+def test_every_usps_code_reaches_the_slot_except_ms() -> None:
+    """``ms`` is the one code that is also a governed term (multiple sclerosis)."""
+
+    assert len(US_STATE_CODES) == 51
+    refused = {code for code in US_STATE_CODES if _refused(RANKED.format(loc=code))}
+    assert refused == {"MS"}
+    assert _refused(RANKED.format(loc="ms")) is True
+    # Mississippi stays reachable by name, and as a parenthetical after it.
+    assert _refused(RANKED.format(loc="Mississippi")) is False
+    assert _refused(RANKED.format(loc="the state of Mississippi (MS)")) is False
+
+
+# --------------------------------------------------- nothing else gets in
+
+
+# ``eczema`` is the load-bearing entry: it is NOT in the health-term bank, it
+# is caught only by the criterion state machine that a shape match switches
+# off. A slot screened with the banks alone lets it through.
+GOVERNED_TAILS: tuple[str, ...] = (
+    "dialysis centers",
+    "cancer wards",
+    "hospice care",
+    "HIV clinics",
+    "schizophrenia",
+    "eczema",
+    "methadone clinics",
+    "nursing homes",
+    "assisted living facilities",
+    "Chinatown",
+    "immigrant communities",
+    "predominantly Black neighborhoods",
+    "Section 8 housing",
+    "single mothers",
+    "wheelchair users",
+    "zyrplax",
+)
+
+
+@pytest.mark.parametrize("shape", LOCATION_CARRYING_SHAPES)
+@pytest.mark.parametrize("tail", GOVERNED_TAILS)
+def test_no_governed_term_rides_the_location_slot_on_any_shape(shape: str, tail: str) -> None:
+    """One slot, six shapes. The open spelling survived on five of them."""
+
+    register_governed_analytics_cities(GOLD_CITY_SAMPLE)
+    assert _refused(shape.format(loc=tail)) is True
+
+
+@pytest.mark.parametrize("shape", LOCATION_CARRYING_SHAPES)
+def test_a_governed_place_reaches_every_shape_that_carries_the_slot(shape: str) -> None:
+    """The control for the sweep above: the same slot, a governed value."""
+
+    register_governed_analytics_cities(GOLD_CITY_SAMPLE)
+    assert _refused(shape.format(loc="Illinois")) is False
+    assert _refused(shape.format(loc="King County")) is False
+    assert _refused(shape.format(loc="Seattle")) is False
+
+
+# ------------------------------------------------------- the city vocabulary
+
+
+def test_a_city_refuses_until_the_governed_dimension_is_published() -> None:
+    """Fail closed. An unresolvable dimension costs the grain, never the guard."""
+
+    assert governed_analytics_cities() == frozenset()
+    assert _refused(RANKED.format(loc="Seattle")) is True
+    register_governed_analytics_cities(GOLD_CITY_SAMPLE)
+    assert _refused(RANKED.format(loc="Seattle")) is False
+    # A degraded resolve publishes empty, and the grain withdraws again.
+    register_governed_analytics_cities(())
+    assert _refused(RANKED.format(loc="Seattle")) is True
+
+
+@pytest.mark.parametrize("city", GOLD_CITY_COLLISIONS)
+def test_a_governed_city_that_collides_is_not_admitted(city: str) -> None:
+    """Recognising a place is not authority to hand it the kill switch."""
+
+    register_governed_analytics_cities(GOLD_CITY_SAMPLE)
+    assert city.lower() not in governed_analytics_cities()
+    assert _refused(RANKED.format(loc=city.title())) is True
+
+
+def test_the_city_gate_admits_the_rest_of_the_sample() -> None:
+    """Count what the filter removes: exactly the four, not the sample."""
+
+    admitted = register_governed_analytics_cities(GOLD_CITY_SAMPLE)
+    assert admitted == len(GOLD_CITY_SAMPLE) - len(GOLD_CITY_COLLISIONS)
+
+
+@pytest.mark.parametrize(
+    "junk",
+    (
+        "SEATTLE",  # a bare string is not a dimension
+        object(),  # not iterable at all
+        ("a b c d e f",),  # more tokens than any governed place value
+        ("",),
+        ("   ",),
+    ),
+)
+def test_registration_is_fail_closed_on_junk(junk: object) -> None:
+    assert register_governed_analytics_cities(junk) == 0
+    assert governed_analytics_cities() == frozenset()
+
+
+def test_publishing_the_dimension_invalidates_the_guard_memo() -> None:
+    """The prompt guard memoizes by text; a pre-warm refusal must not stick."""
+
+    question = RANKED.format(loc="Chicago")
+    assert _refused(question) is True
+    register_governed_analytics_cities(GOLD_CITY_SAMPLE)
+    assert _refused(question) is False
+
+
+# ----------------------------------------------------- the county vocabulary
+
+
+def test_the_shipped_county_artifact_is_the_national_list() -> None:
+    names = shipped_county_names()
+    assert 1_500 <= len(names) <= 4_096
+    assert {"King", "Cook", "Broward", "Orange"} <= names
+
+
+def test_admitted_counties_are_the_shipped_names_minus_the_collisions() -> None:
+    shipped = {name.lower() for name in shipped_county_names()}
+    admitted = admitted_county_names()
+    assert shipped - COUNTY_NAME_EXCLUSIONS <= admitted
+    assert admitted & COUNTY_NAME_EXCLUSIONS == frozenset()
+    # The only additions are period-stripped spellings of shipped names.
+    extra = admitted - shipped
+    assert extra
+    assert all(name.replace(" ", "") in {s.replace(".", "").replace(" ", "") for s in shipped}
+               for name in extra)
+
+
+def test_abbreviated_counties_carry_a_spelling_that_survives_clause_splitting() -> None:
+    """"... in St. Louis County." is cut in half before any shape is matched.
+
+    Clause splitting on ``[.!?;:\\n]+`` happens first, so the abbreviated form
+    cannot reach a shape at all. The period-stripped spelling is what makes the
+    county reachable; the abbreviated one stays refused and is a documented
+    segmentation residual, not something this slot can fix.
+    """
+
+    assert "st louis" in admitted_county_names()
+    assert _refused(RANKED.format(loc="St Louis County")) is False
+    assert _refused(RANKED.format(loc="St. Louis County")) is True
+
+
+def test_committed_county_exclusions_are_all_real_collisions() -> None:
+    """The cheap direction of ``tools/screen_county_place_vocabulary.py``.
+
+    Re-deriving the whole set costs ~40s, so the full sweep lives in the tool.
+    This runs the same gate over the 13 committed names, which is what catches
+    an exclusion that stops being justified when a bank changes.
+    """
+
+    shipped = {name.lower(): name for name in shipped_county_names()}
+    for excluded in sorted(COUNTY_NAME_EXCLUSIONS):
+        assert excluded in shipped, f"{excluded!r} is not a shipped county name"
+        assert _collides_with_governed_term(shipped[excluded]) is True
+
+
+@pytest.mark.parametrize(
+    ("county", "reason"),
+    (
+        ("White", "race"),
+        ("Young", "age"),
+        ("Box Elder", "age"),
+        ("Canadian", "national origin"),
+        ("Indian River", "national origin"),
+        ("Christian", "religion"),
+        # Only ``_contains_protected_class_proxy_pair`` catches this one, and
+        # it is a function, not a pattern -- the name that proved a gate built
+        # from a hand-listed set of banks is not the guard.
+        ("Falls Church", "religion, via the proxy-pair detector"),
+        ("Deaf Smith", "disability"),
+        ("Sonoma", "-oma condition morphology"),
+    ),
+)
+def test_a_county_carrying_a_governed_term_is_refused(county: str, reason: str) -> None:
+    assert _refused(RANKED.format(loc=f"{county} County")) is True, reason
+
+
+def test_oklahoma_is_a_state_even_though_it_is_an_excluded_county() -> None:
+    """The federal list is checked first and is its own closed vocabulary.
+
+    ``Oklahoma`` trips the ``-oma`` morphology, so it is excluded as a COUNTY
+    name. Losing the state to the same heuristic would be a false refusal on a
+    governed geography the product routes by.
+    """
+
+    assert "oklahoma" in COUNTY_NAME_EXCLUSIONS
+    assert _refused(RANKED.format(loc="Oklahoma")) is False
+    assert _refused(RANKED.format(loc="Oklahoma County")) is True
+
+
+# ------------------------------------------------------------ normalization
+
+
+@pytest.mark.parametrize(
+    "location",
+    (
+        "Illinois",
+        "illinois",
+        "ILLINOIS",
+        "the state of California (CA)",
+        "King County",
+        "King",
+        "King County, WA",
+        "  King   County  ",
+        "WA",
+        "wa",
+    ),
+)
+def test_governed_spellings_resolve(location: str) -> None:
+    assert is_governed_analytics_location(location) is True
+
+
+@pytest.mark.parametrize(
+    "location",
+    (
+        "",
+        "   ",
+        "dialysis centers",
+        "eczema",
+        "ms",
+        "MS",
+        "Wakanda",
+        "eczema, WA",
+        "Seattle",  # nothing registered in this test
+        "King County of Washington and also eczema",
+    ),
+)
+def test_ungoverned_spellings_do_not_resolve(location: str) -> None:
+    assert is_governed_analytics_location(location) is False
+
+
+def test_no_location_named_is_not_a_location_failure() -> None:
+    """``None`` means the clause named no place; that is the shape's business."""
+
+    assert is_governed_analytics_location(None) is True
+    assert _refused("Show me the top 20 borrowers with the highest lead scores.") is False

--- a/tests/unit/test_reviewed_analytics_location.py
+++ b/tests/unit/test_reviewed_analytics_location.py
@@ -364,6 +364,40 @@ def test_ungoverned_spellings_do_not_resolve(location: str) -> None:
     assert is_governed_analytics_location(location) is False
 
 
+# Every "the whole footprint" spelling the repo actually uses. The slot
+# admitted only the first two, and "across the current Cotality data coverage"
+# -- the tail of a SHIPPED Genie sample question, and the phrasing the repo
+# uses 45 times -- refused. It had been riding the OPEN slot as free text, so
+# closing the slot to a vocabulary is exactly what exposed it.
+COVERAGE_PHRASES: tuple[str, ...] = (
+    "the current coverage",
+    "the current portfolio",
+    "the current Cotality coverage",
+    "the current Cotality data coverage",
+    "the current refreshed coverage",
+    "the current share footprint",
+    "the current reviewed geography footprint",
+)
+
+
+@pytest.mark.parametrize("phrase", COVERAGE_PHRASES)
+@pytest.mark.parametrize("preposition", ("in", "across"))
+def test_the_coverage_phrasings_the_product_uses_all_resolve(
+    phrase: str, preposition: str
+) -> None:
+    question = (
+        f"Show me the top 10 borrowers with the highest lead scores {preposition} {phrase}."
+    )
+    assert _refused(question) is False
+
+
+def test_the_coverage_branch_is_not_a_free_slot() -> None:
+    """It is an alternation of closed words, not "the current <anything>"."""
+
+    assert _refused(RANKED.format(loc="the current dialysis coverage")) is True
+    assert _refused(RANKED.format(loc="the current eczema portfolio")) is True
+
+
 def test_no_location_named_is_not_a_location_failure() -> None:
     """``None`` means the clause named no place; that is the shape's business."""
 

--- a/tests/unit/test_selection_criterion_count_invariance.py
+++ b/tests/unit/test_selection_criterion_count_invariance.py
@@ -198,8 +198,11 @@ def test_the_ranked_ask_tail_stays_closed(count: int) -> None:
 # the health-term bank rather than merely a criterion bypass. Its location
 # tail was 41 characters of free text under IGNORECASE, so "... in dialysis
 # centers" rode the shape and silenced the detector -- 114 phrasings across 57
-# conditions, measured in signoff round three. The tail is closed to the
-# federal state list now, and these pin both directions.
+# conditions, measured in signoff round three. The tail is closed to a
+# governed PLACE vocabulary now -- the federal states, the shipped national
+# county list, and the live gold city dimension when one is published -- and
+# these pin both directions. ``tests/unit/test_reviewed_analytics_location.py``
+# owns the vocabulary itself.
 _HEALTH_TAIL_MUST_REFUSE = (
     "Show me the top 20 borrowers with the highest lead scores in dialysis centers.",
     "Show me the top 20 borrowers with the highest lead scores in cancer wards.",
@@ -218,6 +221,15 @@ _GOVERNED_LOCATION_MUST_PASS = (
     "Show me the top 20 borrowers with the highest lead scores in the current coverage.",
     "Show me the top 20 borrowers with the highest lead scores in WA.",
     "Show me the top 20 borrowers with the highest lead scores in Mississippi.",
+    # Two-word states. Closing the tail to ``US_STATE_NAMES`` dropped eleven
+    # states and DC, because that list is a person-name-heuristic helper that
+    # carries only the one-word ones.
+    "Show me the top 20 borrowers with the highest lead scores in New York.",
+    "Show me the top 20 borrowers with the highest lead scores in North Carolina.",
+    "Show me the top 20 borrowers with the highest lead scores in District of Columbia.",
+    # County grain, from the national artifact the map drill-down ships.
+    "Show me the top 20 borrowers with the highest lead scores in King County.",
+    "Show me the top 20 borrowers with the highest lead scores in Cook County.",
 )
 
 
@@ -231,20 +243,28 @@ def test_governed_locations_still_pass_the_ranked_shape(question: str) -> None:
     assert _prompt_refused(question) is False
 
 
-def test_city_grain_location_is_a_documented_residual() -> None:
-    """Closing the tail to states costs the city grain on THIS shape.
+def test_the_city_grain_residual_is_closed() -> None:
+    """The residual this file used to document, now a capability.
 
-    Base allowed "... in Highlands Ranch" only through the same accident that
-    allowed the whole family (the leet fold turned "top 20" into letters for
-    some N and not others), so this is not a capability that ever worked
-    deliberately. Reopening it needs the governed city dimension, which lives
-    in the services layer that schemas may not import -- a scoped change of
-    its own, not a widening bolted onto an allow shape.
+    Closing the tail to states cost the city and county grain on this shape.
+    Reopening it did need the governed city dimension across the layer
+    boundary, and that is what ``marketing_selection_reviewed_places`` is: the
+    services layer publishes the live dimension DOWN into the schemas slot, so
+    schemas still imports nothing from services. Counties come from the
+    national artifact the map drill-down already ships.
+
+    The city half is fail-closed until a resolver publishes, so this asserts
+    only the county half, which needs no live dependency.
+    ``tests/unit/test_reviewed_analytics_location.py`` owns both halves.
     """
 
+    assert (
+        _prompt_refused("Show me the top 20 borrowers with the highest lead scores in King County.")
+        is False
+    )
     assert (
         _prompt_refused(
             "Show me the top 20 borrowers with the highest lead scores in Highlands Ranch."
         )
         is True
-    )
+    ), "no dimension published in this module: the city grain stays fail-closed"

--- a/tools/screen_county_place_vocabulary.py
+++ b/tools/screen_county_place_vocabulary.py
@@ -1,0 +1,55 @@
+"""Regenerate ``COUNTY_NAME_EXCLUSIONS`` for the reviewed-analytics location slot.
+
+The shipped ``frontend/public/us-counties.json`` is a static, repo-committed
+national artifact, so which of its names collide with a governed term changes
+only when the DETECTOR BANKS change -- never at runtime. Screening all ~1.8k
+names costs ~5s (each probe is ~2.8ms), which is fine once and far too slow
+on a first guard call, so the answer is committed in
+``backend/schemas/marketing_selection_reviewed_places.py`` and this script is
+how it is re-derived.
+
+Run it whenever a protected-class, health, or national-origin bank changes:
+
+    PYTHONPATH=$PWD python tools/screen_county_place_vocabulary.py
+
+It prints the exclusion tuple to paste back, and exits non-zero when the
+committed set has drifted from what the current banks produce.
+``test_reviewed_analytics_location.py::test_committed_county_exclusions_are_all_real_collisions``
+pins the cheap direction of the same property on every CI run.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from backend.schemas.marketing_selection_reviewed_places import (
+    COUNTY_NAME_EXCLUSIONS,
+    _collides_with_governed_term,
+    shipped_county_names,
+)
+
+
+def main() -> int:
+    names = sorted(shipped_county_names())
+    if not names:
+        print("no shipped county names -- is frontend/public/us-counties.json present?")
+        return 2
+    derived = {name.lower() for name in names if _collides_with_governed_term(name)}
+    print(f"screened {len(names)} shipped county names, {len(derived)} collide\n")
+    print("COUNTY_NAME_EXCLUSIONS: Final[frozenset[str]] = frozenset(")
+    print("    {")
+    for name in sorted(derived):
+        print(f'        "{name}",')
+    print("    }")
+    print(")")
+    missing = derived - COUNTY_NAME_EXCLUSIONS
+    extra = COUNTY_NAME_EXCLUSIONS - derived
+    if missing:
+        print(f"\nDRIFT: {len(missing)} collide but are ADMITTED: {sorted(missing)}")
+    if extra:
+        print(f"\nDRIFT: {len(extra)} excluded but no longer collide: {sorted(extra)}")
+    return 1 if (missing or extra) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Ranked analytics scoped to a **city or county** refused at the prompt guard; only US states worked. Building the differential against `7612b021` first turned up **two more defects in the same slot**, both unreported.

## Three defects

| # | Defect | Evidence |
|---|---|---|
| 1 | City/county grain refused (**reported**) | 52 governed-geography questions |
| 2 | **Eleven states + DC refused** | `in New York`, `in North Carolina`, `in District of Columbia` |
| 3 | **Open tail survived on 5 other shapes** (fail-open) | `Chart borrowers by segment in dialysis centers` → **ALLOWED** at `35a9720a` |

**#2 root cause:** `b6c38f74` closed the tail to `_validators_person_names.US_STATE_NAMES`, whose docstring calls it "the federal list" but whose own comment says it deliberately carries only the **one-word** states.

**#3 root cause:** `b6c38f74` closed the ranked ask's *inline* tail and left `_REVIEWED_ANALYTIC_LOCATION` — the 41-char `[A-Z][A-Za-z' -]{2,40}` slot used by five other shapes — untouched. 24 health-tail phrasings ride the exact hole that commit was written to close.

## The option that was measured and rejected

A bounded shape screened at match time fails **both** ways. Best carrier missed `eczema` (not in the health bank at all — caught only by the criterion machine the shape switches off), `Chinatown`, `methadone clinics`, `nursing homes`; and refused `Tacoma`, `Hawaiian Gardens`, `Indian Head Park` — all live gold cities. Only membership in a screened vocabulary separates a place from a governed term.

## The fix

One location grammar, six shapes, closed to a vocabulary of **places** rather than of states. Both call sites of the pattern tuple route through `matches_reviewed_read_only_analytic_shape`, which does the fullmatch and the vocabulary check together — a check wired into one call site is how the open spelling survived the first time.

- **States** — the federal list, reproduced in full.
- **Counties** — the national us-atlas TopoJSON the map drill-down already ships, minus 13 screened collisions, committed alongside `tools/screen_county_place_vocabulary.py`.
- **Cities** — live Cotality coverage, so `genie_place_dimension` pushes them **down** into a schemas-side registry. Schemas still imports nothing from services; an unpublished dimension means city questions refuse.

The admission gate delegates to `protected_class_marketing_reason` rather than a hand-assembled bank list. The first draft enumerated seven compiled patterns and agreed with the full guard on all 1,833 county names **but `Falls Church`**, caught by `_contains_protected_class_proxy_pair` — a detector that is a function, not a pattern, so no bank list can hold it.

## Validation — 814-string differential

**vs `35a9720a`:** +52 governed-geography questions, −24 health fail-opens, **0** health phrasings flipped to allowed.

| bar | result |
|---|---|
| health-tail sweep | **558 phrasings, 0 allowed, 0 flipped** (bar: 0/534) |
| `in ms.` / `in MS.` | still refuse; `Mississippi` and `(MS)` reachable |
| ranked family | 64/64 passing at every count |
| new tests | 159 green |
| regression files | `test_selection_criterion_count_invariance`, `test_genie_prompt_guard_geography`, `test_genie_persona_audit_regressions`, `test_architecture_boundaries` all green |

`test_city_grain_location_is_a_documented_residual` is replaced by `test_the_city_grain_residual_is_closed`.

## Residuals (both fail-closed)

- County names carrying a period (`St. Louis`) are cut in half by clause splitting *before* any shape is matched. The admitted set carries a period-stripped spelling, so **`St Louis County` works**; fixing the abbreviated form means changing sentence segmentation for every guard.
- `Black Diamond` and 12 county names are excluded by the gate on their own merits (`white`, `young`, `christian`, `canadian`, `deaf smith`, the `-oma` morphology…).

Based on `444c417f`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)