### PR TITLE
fix(criteria): a criterion-free admission command may name its destination

### DIFF
--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -462,6 +462,27 @@ _REVIEWED_AUDIENCE_DECISION_PATTERNS: tuple[re.Pattern[str], ...] = (
         re.IGNORECASE,
     ),
 )
+# A criterion-free admission command may also name WHERE the population goes:
+# "Assign an owner to this campaign.", "Add these borrowers to the campaign.",
+# "Move the selected borrowers into the queue." Every slot of the tail is a
+# closed literal alternation -- preposition, determiner, optional ``reviewed``,
+# destination noun -- so no open vocabulary can ride inside the span and the
+# command still names no criterion. The admission grammar itself proves this
+# family carries none (``audience_admission_criterion`` returns None: there is
+# no criterion connector to capture), yet the ``for``-only tail below made the
+# verdict hinge on the preposition: "Assign an owner for the campaign."
+# answered while "Assign an owner to this campaign." fell to the
+# affirmative-directive fail-closed tail for EVERY determiner (measured
+# 2026-08-13). Criterion-carrying twins are not this branch's to allow and
+# keep their owners, which all run BEFORE this branch: "... with eczema to
+# this campaign" and "... to this campaign because they rent" parse in
+# ``marketing_audience_admission``, banked populations ("patients") stay with
+# the term banks, and an unreviewed word anywhere else -- "zyrplax borrowers",
+# "the zyrplax campaign" -- breaks the closed shape and still fails closed.
+_REVIEWED_BARE_DIRECTIVE_DESTINATION_TAIL = (
+    r"(?:to|in|into|onto)\s+(?:(?:this|that|the|a|an)\s+)?(?:reviewed\s+)?"
+    r"(?:campaign|cohort|audience|segment|list|(?:lead\s+)?queue|offer|review)"
+)
 # The determiner slot takes ``a``/``an`` exactly as it takes ``the``: the
 # object either way is the same closed population/audience reference, so the
 # article names no criterion. Without it, "Assign an owner." fell past this
@@ -474,8 +495,9 @@ _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE = re.compile(
     rf"{_AUDIENCE_FORMATION_COMMAND_FRAGMENT}\s+(?:(?:the|an?)\s+)?"
     rf"(?:(?:reviewed|eligible|qualified|marketing[- ]eligible|highest[- ]scoring)\s+){{0,2}}"
     rf"{_AUDIENCE_DECISION_REFERENCE}"
-    r"(?:\s+for\s+(?:(?:this|the|a|an)\s+)?(?:reviewed\s+)?"
-    r"(?:campaign|offer|review))?$",
+    r"(?:\s+(?:for\s+(?:(?:this|the|a|an)\s+)?(?:reviewed\s+)?"
+    r"(?:campaign|offer|review)|"
+    rf"{_REVIEWED_BARE_DIRECTIVE_DESTINATION_TAIL}))?$",
     re.IGNORECASE,
 )
 _REVIEWED_PRENOMINAL_AUDIENCE_DIRECTIVE_RE = re.compile(

--- a/tests/unit/test_bare_directive_destination_tail.py
+++ b/tests/unit/test_bare_directive_destination_tail.py
@@ -1,0 +1,180 @@
+"""A criterion-free admission command answers; its criterion twins keep their owners.
+
+"Assign an owner to this campaign." refused as ``unreviewed_criterion`` for
+EVERY determiner (pre-existing, measured 2026-08-13 during #222). The
+admission grammar itself proves the family names no criterion --
+``audience_admission_criterion`` returns None because there is no connector
+to capture -- but the bare-directive allow branch admitted only a
+``for the campaign|offer|review`` tail, so the clause fell to the
+affirmative-directive fail-closed tail. The verdict hinged on the
+preposition: "Assign an owner for the campaign." answered, and so did the
+mid-sentence form "Please review the file and assign an owner to this
+campaign." (the anchored affirmative branch never fires there).
+
+Fix: ``_REVIEWED_BARE_DIRECTIVE_DESTINATION_TAIL`` -- a closed transfer
+preposition into a closed determiner-plus-noun destination, appended as a
+tail alternative on the bare-directive branch. Every slot is a literal
+alternation, so no open vocabulary can ride inside the allowed span.
+
+Differential battery, 1,482 probes x four surfaces (prompt, marketing
+reason, campaign copy, identity): 893 gains, every one criterion-free with
+a base-allowed stripped twin (trigger-removal attribution); 0 losses;
+0 reason shifts among still-refused probes; 0 gains carrying a banked or
+unreviewed token.
+
+Every refusal below asserts the EXACT reason string: ``is not None`` passes
+through a silent reclassification, and each refusing family here is owned
+by a DIFFERENT machine on purpose -- the admission grammar, the term banks,
+the closed-shape anchor, or the identity scan.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.schemas._validators_unsafe_text import contains_unsafe_ai_text
+from backend.schemas.marketing_selection_criteria import (
+    _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE,
+)
+from backend.services.genie_message_policy import (
+    identity_prompt_match,
+    protected_prompt_match,
+)
+
+# The admitted family: command verb + closed population reference + closed
+# destination tail. Sampled across verbs, populations, prepositions,
+# determiners, and destination nouns; each slot's full alternation was
+# exercised by the battery.
+_DESTINATION_TAILED_ANSWERABLE = (
+    "Assign an owner to this campaign.",
+    "Assign the owner to this campaign.",
+    "Assign owners to this campaign.",
+    "Assign an owner to a campaign.",
+    "Assign an owner to the reviewed campaign.",
+    "Add these borrowers to the campaign.",
+    "Add borrowers to the lead queue.",
+    # The hyphenated twin ("highest-scoring") refuses on BOTH sides of this
+    # change, tail or no tail: the hyphen-removal de-obfuscation fold hands
+    # the criterion machine ``highestscoring``, a joined token outside every
+    # premodifier vocabulary. Pre-existing fold-image gap, filed separately.
+    "Add the highest scoring leads to the campaign.",
+    "Move the selected borrowers into the queue.",
+    "Move everyone in the list to the campaign.",
+    "Transfer those leads to that segment.",
+    "Put borrowers onto the list.",
+    "Enroll customers in the campaign.",
+    "Route prospects to the audience.",
+    "Queue a borrower into this cohort.",
+    "Please assign an owner to this campaign.",
+)
+
+
+@pytest.mark.parametrize("prompt", _DESTINATION_TAILED_ANSWERABLE)
+def test_a_criterion_free_admission_command_is_answerable(prompt: str) -> None:
+    assert protected_prompt_match(prompt) is None, prompt
+
+
+def test_the_bare_directive_branch_owns_the_allow() -> None:
+    """Branch attribution: reroutes of this family should be visible, not silent."""
+
+    for clause in (
+        "assign an owner to this campaign",
+        "add these borrowers to the campaign",
+        "move the selected borrowers into the queue",
+        "add borrowers to the lead queue",
+    ):
+        assert _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE.fullmatch(clause) is not None, clause
+    # The closed shape, not a general class: a criterion between population
+    # and tail, an unreviewed destination modifier, or an unknown destination
+    # noun each break the anchor.
+    for clause in (
+        "assign borrowers with eczema to this campaign",
+        "assign borrowers to the zyrplax campaign",
+        "move borrowers to this crowd",
+        "add borrowers to the campaigns",
+    ):
+        assert _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE.fullmatch(clause) is None, clause
+
+
+# ---------------------------------------------------------------------------
+# Invariants -- green on BOTH sides of the fix. The refusal this change
+# removed bought nothing these machines do not already own.
+
+_ADMISSION_GRAMMAR_KEEPS_THE_CRITERION_FORMS = (
+    # A connector binds a criterion; ``marketing_audience_admission`` parses
+    # it BEFORE the bare-directive branch is consulted.
+    "Add borrowers to this campaign because they rent.",
+    "Add borrowers with zyrplax to this campaign.",
+    # Passives and nominal relations are unproved-relation forms, not
+    # commands; ``_UNREVIEWED_RELATION_PATTERNS`` owns them.
+    "Borrowers are assigned to this campaign.",
+    "The admission of borrowers to the campaign.",
+)
+
+
+@pytest.mark.parametrize("prompt", _ADMISSION_GRAMMAR_KEEPS_THE_CRITERION_FORMS)
+def test_the_admission_grammar_still_owns_criterion_and_relation_forms(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "unreviewed_criterion", prompt
+
+
+_CLOSED_SHAPE_KEEPS_FAILING_CLOSED = (
+    # An unreviewed word anywhere breaks the anchor: destination modifier,
+    # unknown destination noun, plural destination, trailing purpose clause,
+    # a second stacked tail, or an unreviewed population modifier.
+    "Assign borrowers to the zyrplax campaign.",
+    "Move borrowers to this crowd.",
+    "Add borrowers to the campaigns.",
+    "Assign owners to this campaign to exclude renters.",
+    "Add borrowers to the queue to hide the audit trail.",
+    "Assign an owner to this campaign for the review.",
+    "Assign a zyrplax borrower to the campaign.",
+    "Add the top 50 borrowers to the campaign.",
+)
+
+
+@pytest.mark.parametrize("prompt", _CLOSED_SHAPE_KEEPS_FAILING_CLOSED)
+def test_anything_outside_the_closed_shape_still_fails_closed(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "unreviewed_criterion", prompt
+
+
+_TERM_BANKS_KEEP_THE_BANKED_TWINS = (
+    # The banks fire above this machine, in either the population or the
+    # destination slot, in the same clause or a following one.
+    "Add borrowers with eczema to this campaign.",
+    "Assign borrowers to the eczema campaign.",
+    "Add patients to this campaign.",
+    "Assign an owner to this patient.",
+    "Add borrowers to this campaign because they have eczema.",
+    "Add borrowers to the campaign. They all have eczema.",
+)
+
+
+@pytest.mark.parametrize("prompt", _TERM_BANKS_KEEP_THE_BANKED_TWINS)
+def test_the_term_banks_still_own_the_banked_twins(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "protected_class_language", prompt
+
+
+def test_reviewed_criterion_admissions_still_answer() -> None:
+    """The admission grammar's reviewed-vocabulary allow is untouched."""
+
+    assert protected_prompt_match("Add borrowers with a competitor lien to this campaign.") is None
+    # A following clause may bind a REVIEWED mortgage attribute through the
+    # contextual coreference net; the eczema twin above keeps refusing.
+    assert protected_prompt_match("Add borrowers to the campaign. They all have a rate spread.") is None
+
+
+def test_person_names_stay_with_the_identity_scan() -> None:
+    """The fair-lending machine never owned names; the identity scan does."""
+
+    assert identity_prompt_match("Assign Maria Garcia to this campaign.") is True
+    assert protected_prompt_match("Assign Maria Garcia to this campaign.") is None
+    assert identity_prompt_match("Assign an owner to this campaign.") is False
+
+
+def test_campaign_copy_surface_moves_with_the_prompt_surface() -> None:
+    """The strict surface admits the command and keeps refusing the launder."""
+
+    assert contains_unsafe_ai_text("Assign an owner to this campaign.") is False
+    assert contains_unsafe_ai_text("Add these borrowers to the campaign.") is False
+    assert contains_unsafe_ai_text("Assign borrowers to the zyrplax campaign.") is True
+    assert contains_unsafe_ai_text("Add borrowers with eczema to this campaign.") is True

--- a/tests/unit/test_population_article_parity.py
+++ b/tests/unit/test_population_article_parity.py
@@ -102,20 +102,23 @@ def test_the_term_banks_still_own_the_banked_twins(prompt: str) -> None:
     assert protected_prompt_match(prompt) == "protected_class_language", prompt
 
 
-# The destination-tailed command refuses for EVERY determiner -- an
-# article-independent, pre-existing family (the active admission command
-# proves no relation, so the affirmative-directive branch fails closed).
-# Article parity must not move it, and the battery measured it unchanged.
-_TAILED_FORMS_STILL_REFUSE = (
+# The destination-tailed command once refused for EVERY determiner -- an
+# article-independent family that #222 measured unchanged and deliberately
+# left pinned refusing. The closed destination tail on the bare-directive
+# branch (``_REVIEWED_BARE_DIRECTIVE_DESTINATION_TAIL``) now admits it for
+# every determiner alike; the family battery and its fail-closed twins live
+# in test_bare_directive_destination_tail.py. Article parity still holds:
+# all three determiners carry the same verdict.
+_TAILED_FORMS_NOW_ANSWERABLE = (
     "Assign an owner to this campaign.",
     "Assign the owner to this campaign.",
     "Assign owners to this campaign.",
 )
 
 
-@pytest.mark.parametrize("prompt", _TAILED_FORMS_STILL_REFUSE)
-def test_the_destination_tailed_family_is_untouched(prompt: str) -> None:
-    assert protected_prompt_match(prompt) == "unreviewed_criterion", prompt
+@pytest.mark.parametrize("prompt", _TAILED_FORMS_NOW_ANSWERABLE)
+def test_the_destination_tailed_family_is_admitted_for_every_determiner(prompt: str) -> None:
+    assert protected_prompt_match(prompt) is None, prompt
 
 
 def test_campaign_copy_surface_moves_with_the_prompt_surface() -> None:


### PR DESCRIPTION
## What

`protected_prompt_match("Assign an owner to this campaign.")` refused as `unreviewed_criterion` for **every** determiner ("an owner" / "the owner" / "owners"), while the same command with `for` ("Assign an owner for the campaign.") and the mid-sentence form ("Please review the file and assign an owner to this campaign.") both answered. The verdict hinged on the preposition, not on any criterion — pre-existing FP measured during #222 and deliberately left pinned there.

This PR decides the question #222 deferred: **a criterion-free admission command ("assign/move/add \<population\> to \<destination\>") is answerable**, and fixes it on axis (a) — a closed destination tail on the bare-directive allow branch — without touching the admission grammar or fail-closed defaults.

## Why it is safe

- The admission grammar itself proves the family names no criterion: `audience_admission_criterion` returns `None` — there is no connector to capture.
- `_REVIEWED_BARE_DIRECTIVE_DESTINATION_TAIL` is a closed shape end to end: preposition `(to|in|into|onto)` × determiner `(this|that|the|a|an)?` × optional `reviewed` × destination noun `(campaign|cohort|audience|segment|list|(lead )?queue|offer|review)`. No open-vocabulary slot exists inside the allowed span.
- Every machine that owns a criterion-carrying twin runs **before** this branch and is untouched:
  - admission grammar: "…to this campaign **because they rent**", "…**with zyrplax** to this campaign", passives ("Borrowers **are assigned** to this campaign."), nominal relations — still `unreviewed_criterion`;
  - term banks: "…with **eczema**…", "Add **patients**…", "…to this **patient**", "…to the **eczema** campaign", following-clause "They all have eczema." — still `protected_class_language`;
  - closed-shape anchor: "to the **zyrplax** campaign", "to this **crowd**", plural "campaign**s**", trailing purpose ("…to exclude renters", "…to hide the audit trail"), stacked tails — still `unreviewed_criterion`;
  - identity scan: "Assign **Maria Garcia** to this campaign." — still refused by `identity_prompt_match` (the fair-lending machine never owned names).
- Axis (b) was rejected: widening `marketing_audience_admission` would couple into `remove_audience_admission_clauses_for_identity_scan`, which deletes parsed admission clauses before the person-name detector reads them (the `_MODIFIERS` widening previously cost 106 name detections). This fix never touches that module.

## Measurement

Differential battery, 1,482 probes × four surfaces (`protected_prompt_match`, `protected_class_marketing_reason`, `contains_unsafe_ai_text`, `identity_prompt_match`), base `b3007754` vs fix (distinct file hashes recorded in both runs):

- **893 distinct probes gained** (refused→allowed), **0 carrying a banked or unreviewed token**
- **0 losses** (allowed→refused), **0 reason shifts** among still-refused probes
- Trigger-removal attribution: every gain's destination-tail-stripped twin was allowed at base (890 via corpus twins; the two `Please`/`Could you` prefix forms measured directly at base; the one multi-clause gain composes the family with the **reviewed** attribute "a rate spread" through the contextual net — its eczema twin still refuses)
- Fail-closed controls verified refused on **both** sides, so no control was dead at base

## Tests

- `tests/unit/test_bare_directive_destination_tail.py` (new): the admitted family, branch attribution on `_REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE`, and one invariant block per owning machine (admission grammar, closed-shape anchor, term banks, identity scan, campaign-copy surface), all asserting exact reason strings.
- `tests/unit/test_population_article_parity.py`: the `_TAILED_FORMS_STILL_REFUSE` pin documented today's behavior, not doctrine — updated to pin the new verdict (same three determiners, still parity).

## Residuals filed as follow-up chips (all pre-existing, measured unchanged by this diff)

1. "Add **diabetics** to this campaign." was already reaching Genie at base (singular "a diabetic" is banked; the plural population noun is not).
2. "Add the **highest-scoring** leads…" refuses tail-independently: the hyphen-removal fold hands the machine `highestscoring`, outside every premodifier vocabulary (space twin answers).
3. "Add the **top 50** borrowers to the campaign." refuses while its criterion-carrying #218 twin answers — the quantifier is not transparent to the bare branch / pre-population binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
