### PR TITLE
fix(guards): the two-letter MS is a state code unless a health carrier says otherwise

### DIFF
--- a/backend/schemas/marketing_safety_terms.py
+++ b/backend/schemas/marketing_safety_terms.py
@@ -198,7 +198,84 @@ _PROTECTED_HEALTH_NAMED_CONDITIONS = (
     "substance use disorder",
 )
 
-_PROTECTED_HEALTH_ABBREVIATIONS = ("adhd", "aids", "als", "copd", "hiv", "ms", "ocd")
+# Each of these is unambiguous in ordinary mortgage prose, so each matches
+# standalone. ``ms`` is deliberately NOT here: it is the one entry that is also
+# a USPS state code, and it is handled by ``_TWO_LETTER_MS_RE_FRAGMENT`` below.
+_PROTECTED_HEALTH_ABBREVIATIONS = ("adhd", "aids", "als", "copd", "hiv", "ocd")
+
+# ``MS`` is both multiple sclerosis and the USPS code for Mississippi. Matching
+# it standalone made every governed per-state rollup that named Mississippi a
+# fair-lending finding -- "Borrowers in MS.", "State rollup: 70 MS borrowers
+# and 20 LA borrowers." -- on all of the co-pilot, plan, Genie prompt/planner,
+# visible-prose and visible-cell surfaces at once, and it kept ``MS`` out of the
+# governed place dimension that geography drill-down reads. Mississippi was the
+# only state code affected; the other 50 values were already clean.
+#
+# So the two-letter form is admitted to the bank only beside a health carrier:
+# a relationship phrase immediately before it, or a health noun immediately
+# after it. That is the same shape several other banks already use, and it
+# narrows the TERM rather than exempting the PLACE -- recognizing a place is
+# not authority to strip it, and a place exemption here would have had to hold
+# on every surface separately.
+#
+# Place prepositions are deliberately absent from the carrier list: "borrowers
+# in MS" is Mississippi. Where a relationship ends in a preposition that is
+# ambiguous on its own (``from``, ``by``, ``for``) the whole phrase is listed,
+# so that preposition can never admit the term by itself.
+#
+# Nothing else about multiple sclerosis is relaxed: the spelled-out
+# ``multiple sclerosis`` stays in ``_PROTECTED_HEALTH_NAMED_CONDITIONS`` and
+# still matches unconditioned, and the dotted evasion (``M.S.``, ``m s``) is
+# kept unconditioned below because it has no legitimate geography reading.
+_TWO_LETTER_MS_LEADING_CARRIERS: tuple[str, ...] = (
+    "affected by",
+    "battles",
+    "battling",
+    "experiencing",
+    "facing",
+    "had",
+    "has",
+    "have",
+    "manages",
+    "managing",
+    "prescribed",
+    "recovering from",
+    "remission from",
+    "suffering from",
+    "treated for",
+    "undergoing",
+    # Covers ``diagnosed with``, ``living with``, ``dealing with``,
+    # ``coping with``, ``afflicted with`` and ``treated with`` as well.
+    "with",
+)
+
+_TWO_LETTER_MS_TRAILING_NOUNS: str = (
+    r"(?:affected|care|clinics?|diagnos(?:is|es|ed)|drugs?|flares?|flare[- ]ups?|"
+    r"history|lesions?|meds?|medications?|nurses?|patients?|progression|related|"
+    r"relapses?|remission|specialists?|status|sufferers?|survivors?|symptoms?|"
+    r"therap(?:y|ies)|treatments?)"
+)
+
+
+def _two_letter_ms_fragment() -> str:
+    """Two-letter ``MS`` -- only next to a health carrier, plus dotted forms.
+
+    Python requires each look-behind to be fixed width, so the carrier list is
+    compiled as an alternation OF look-behinds rather than one look-behind of
+    an alternation.
+    """
+
+    leading = "|".join(
+        rf"(?<=\b{re.escape(phrase)}\s)" for phrase in _TWO_LETTER_MS_LEADING_CARRIERS
+    )
+    return (
+        rf"(?:{_dotted_spelling('ms')}|"
+        rf"(?:{leading})\bms\b|"
+        rf"\bms(?=[-\s]+{_TWO_LETTER_MS_TRAILING_NOUNS}\b))"
+    )
+
+
+_TWO_LETTER_MS_RE_FRAGMENT: str = _two_letter_ms_fragment()
 
 _PROTECTED_HEALTH_TREATMENTS = (
     "cancer treatment",
@@ -285,9 +362,16 @@ def _build_health_trait_fragments(
 
     named_conditions = _phrase_fragment(_PROTECTED_HEALTH_NAMED_CONDITIONS)
     condition_abbreviations = "|".join(
-        fragment
-        for term in _PROTECTED_HEALTH_ABBREVIATIONS
-        for fragment in (re.escape(term), _dotted_spelling(term))
+        (
+            *(
+                fragment
+                for term in _PROTECTED_HEALTH_ABBREVIATIONS
+                for fragment in (re.escape(term), _dotted_spelling(term))
+            ),
+            # Carries its own carrier requirement, so every composite that
+            # embeds a medical condition inherits it without restating it.
+            _TWO_LETTER_MS_RE_FRAGMENT,
+        )
     )
     dotted_medical_conditions = "|".join(
         _dotted_spelling(term) for term in ("asthma", "asthmatic", "cancer", "diabetes", "diabetic")

--- a/tests/unit/test_marketing_safety_two_letter_ms.py
+++ b/tests/unit/test_marketing_safety_two_letter_ms.py
@@ -1,0 +1,183 @@
+"""The two-letter ``MS`` is Mississippi as well as multiple sclerosis.
+
+A direct health-bank entry matched the bare token ``MS``, so every governed
+per-state rollup that named Mississippi came back as a fair-lending finding --
+"Borrowers in MS.", "State rollup: 70 MS borrowers and 20 LA borrowers." --
+and geography drill-down is a hero surface per CLAUDE.md. Mississippi was the
+only USPS code affected: the other 50 were already clean, which is what makes
+this a term-shaped defect rather than a geography-shaped one.
+
+The repair narrows the TERM instead of exempting the PLACE. Recognizing a place
+is not authority to strip it, and a place exemption would have had to hold on
+each surface separately -- the collision reached the co-pilot, the plan
+objective, the Genie prompt/planner screens, the visible prose and cell scans,
+AND the governed place dimension's admission gate, which refused ``MS`` exactly
+the way it refuses ``BLACK`` and ``CANCER``.
+
+So the tests below are mostly INVARIANTS rather than fix-pins: multiple
+sclerosis must still refuse through every reviewed carrier, the other
+abbreviations must still refuse standalone, and the admission gate must still
+reject a genuinely protected value. Those hold on both sides of the change. The
+one behavioral pin is stated as a cross-state equivalence -- ``MS`` must be
+indistinguishable from ``TX`` -- so it cannot be satisfied by special-casing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from backend.schemas._validators_protected_class import protected_class_marketing_reason
+from backend.schemas.agent_plan import ComposePlanRequest
+from backend.schemas.growth_agent import GrowthAgentPromptRunRequest
+from backend.schemas.usps import USPS_STATE_CODES
+from backend.services.genie_message_policy import (
+    genie_visible_text_unsafe,
+    protected_prompt_match,
+)
+from backend.services.genie_place_dimension import _disarms_a_protected_class_canary
+
+# Governed per-state rollup shapes the product actually renders.
+_GEOGRAPHY_TEMPLATES = (
+    "{code} 70 borrowers.",
+    "State rollup: 70 {code} borrowers and 20 LA borrowers.",
+    "Borrowers in {code}.",
+    "How many borrowers are in {code}?",
+    "Show the top counties in {code}.",
+    "State rollup by {code}.",
+    "{code} leads the refinance funnel.",
+    "What is the average rate spread in {code}?",
+    "Which {code} counties have the most HELOC candidates?",
+    "Show me {code} borrowers with high equity.",
+    "Total UPB for {code}.",
+)
+
+# Every reviewed way the corpus binds a condition to a person.
+_HEALTH_CARRIERS = (
+    "Target borrowers with {term} for a refinance offer.",
+    "Select homeowners who have {term}.",
+    "Build a cohort of borrowers diagnosed with {term}.",
+    "People living with {term} were selected for this offer.",
+    "Homeowners suffering from {term} qualify for this offer.",
+    "Borrowers managing {term} are the intended audience.",
+    "Contact borrowers battling {term}.",
+    "The campaign is for homeowners with {term}.",
+    "Borrowers affected by {term} should receive this offer.",
+    "Select applicants recovering from {term}.",
+    "Homeowners treated for {term} are qualified.",
+    "Borrowers dealing with {term} are eligible.",
+    "Homeowners afflicted with {term} were selected for this offer.",
+    "Applicants undergoing treatment who have {term} are eligible.",
+    "{term} patients are eligible for this offer.",
+    "{term}-affected homeowners were selected for this offer.",
+    "{term} survivors are the intended audience.",
+    "{term} sufferers were selected for this offer.",
+    "{term} symptoms determine eligibility.",
+    "Eligibility depends on the {term} diagnosis.",
+)
+
+
+@pytest.mark.parametrize("code", sorted(USPS_STATE_CODES))
+@pytest.mark.parametrize("template", _GEOGRAPHY_TEMPLATES)
+def test_governed_state_rollup_is_not_a_fair_lending_finding(code: str, template: str) -> None:
+    """No USPS code turns a governed rollup into a protected-class refusal."""
+
+    assert protected_class_marketing_reason(template.format(code=code)) != "protected_class"
+
+
+@pytest.mark.parametrize("template", _GEOGRAPHY_TEMPLATES)
+def test_mississippi_matches_a_state_with_no_health_collision(template: str) -> None:
+    """``MS`` is indistinguishable from ``TX``, so nothing special-cases it."""
+
+    assert protected_class_marketing_reason(template.format(code="MS")) == (
+        protected_class_marketing_reason(template.format(code="TX"))
+    )
+
+
+@pytest.mark.parametrize(
+    "term",
+    ("MS", "ms", "M.S.", "multiple sclerosis", "COPD", "ADHD", "HIV", "OCD", "ALS", "AIDS"),
+)
+@pytest.mark.parametrize("carrier", _HEALTH_CARRIERS)
+def test_health_carriers_still_refuse(term: str, carrier: str) -> None:
+    """A condition bound to a person is a fair-lending finding, ``MS`` included."""
+
+    assert protected_class_marketing_reason(carrier.format(term=term)) == "protected_class"
+
+
+@pytest.mark.parametrize("term", ("COPD", "ADHD", "HIV", "OCD", "ALS", "AIDS"))
+def test_unambiguous_abbreviations_still_refuse_standalone(term: str) -> None:
+    """Only the two-letter ``MS`` gained a carrier requirement."""
+
+    assert protected_class_marketing_reason(f"{term} 70 borrowers.") == "protected_class"
+    assert protected_class_marketing_reason(f"Borrowers in {term}.") == "protected_class"
+
+
+@pytest.mark.parametrize("term", ("multiple sclerosis", "M.S.", "m.s.", "M-S"))
+def test_spelled_out_and_dotted_forms_stay_unconditioned(term: str) -> None:
+    """Neither the full phrase nor a dotted evasion has a geography reading."""
+
+    assert protected_class_marketing_reason(f"Rank {term} borrowers.") == "protected_class"
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "State rollup: 70 MS borrowers and 20 LA borrowers.",
+        "Borrowers in MS.",
+        "Which MS counties have the most HELOC candidates?",
+    ),
+)
+def test_state_rollup_clears_every_guard_surface(text: str) -> None:
+    """The collision reached all of these surfaces, so all of them are pinned."""
+
+    assert protected_prompt_match(text) is None
+    assert genie_visible_text_unsafe(text) is False
+    assert genie_visible_text_unsafe(text, structured_value=True) is False
+    assert GrowthAgentPromptRunRequest(prompt=text).prompt == text
+    assert ComposePlanRequest(objective=text).objective == text
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "Target borrowers with MS for a refinance offer.",
+        "MS patients are eligible for this offer.",
+        "Target borrowers with multiple sclerosis.",
+    ),
+)
+def test_health_carrier_still_refused_on_every_guard_surface(text: str) -> None:
+    """Narrowing the term must not open the surfaces it was protecting."""
+
+    assert protected_prompt_match(text) is not None
+    assert genie_visible_text_unsafe(text) is True
+    with pytest.raises(ValidationError):
+        GrowthAgentPromptRunRequest(prompt=text)
+    with pytest.raises(ValidationError):
+        ComposePlanRequest(objective=text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        # The honorific, in the loan-officer copy the product actually renders.
+        "Ms. Johnson is the loan officer.",
+        # Milliseconds -- the other real-world collision the bare token had.
+        "Response time was 250 ms on average.",
+        "The p95 latency is 40 ms.",
+    ),
+)
+def test_other_two_letter_ms_collisions_are_not_findings(text: str) -> None:
+    """Mississippi was not the only thing the bare token was misreading."""
+
+    assert protected_class_marketing_reason(text) is None
+
+
+def test_place_dimension_admits_mississippi_but_not_a_protected_value() -> None:
+    """``MS`` was refused as a governed place value the way ``BLACK`` is."""
+
+    assert _disarms_a_protected_class_canary("MS") is False
+    assert _disarms_a_protected_class_canary("LA") is False
+    # The gate itself is unchanged: a genuinely protected value still fails it.
+    assert _disarms_a_protected_class_canary("BLACK") is True
+    assert _disarms_a_protected_class_canary("CANCER") is True


### PR DESCRIPTION
## The defect

`ms` sat in `_PROTECTED_HEALTH_ABBREVIATIONS`, which is a **direct** bank — its entries match with no population noun. So the bare token `MS` was a fair-lending finding, and every governed per-state rollup naming Mississippi refused:

```
r("LA 20 borrowers, MS 70 borrowers, AL 5 borrowers.")   # protected_class
r("State rollup: 70 MS borrowers and 20 LA borrowers.")  # protected_class
```

Geography drill-down is a hero surface per CLAUDE.md. Pre-existing — base `7612b021` refuses both identically — and deliberately left out of scope by `444c417f`, which fixed the adjacent joined-window class (`LA 20` → `lao`).

## Why narrow the term rather than exempt the place

Sweeping **all 51 USPS codes × 15 rollup templates** showed Mississippi was the *only* affected code — `ms` is the only entry in that bank short enough to collide. That makes this a **term**-shaped defect, not a geography-shaped one. Recognizing a place is not authority to strip it, and a place exemption would have had to hold on each surface separately; conditioning the term means every composite that embeds a medical condition inherits the requirement from one edit.

The two-letter form is now admitted only beside a **health carrier** — a relationship phrase immediately before it, or a health noun immediately after. Place prepositions are deliberately not carriers (`borrowers in MS` is Mississippi), and where a health relationship ends in an ambiguous preposition (`from`, `by`, `for`) the whole phrase is listed so the preposition never admits the term alone.

`multiple sclerosis` and the dotted evasions (`M.S.`, `m s`) stay unconditioned — which also makes the new fragment a strict **subset** of the old, so the change *can only relax, never tighten*.

## Measured, not asserted

Corpus rebuilt from the repo itself (AST string literals from `tests/`, Genie question banks, eval JSONL, plus generated USPS and MS-carrier batteries) — **14,514 texts**, reproducible.

| differential | weakenings | in intended class | **outside** |
|---|---|---|---|
| `protected_class_marketing_reason`, both flags, full corpus | 57 | 57 | **0** |
| 11 surfaces (reason ×2, co-pilot, plan, 7 Genie screens, visible prose, visible cell), 927 targeted + 2,000 control | 225 | 225 | **0** |

The identity, PII, instruction-override, scope-bypass and cross-lender screens changed on **nothing**.

Also verified:
- All **32** relationships in the code's own `health_relationship`/`ambiguous_relationship` grammars still refuse.
- The governed **place dimension** now admits `MS` — it was previously refused the way `BLACK` and `CANCER` are. `BLACK`/`CANCER` still refused, so the gate is intact.
- Residual: `Target MS borrowers for this campaign.` is allowed — but so is the `TX` twin, identically. State-scoped campaigns are a core legitimate use; making that refuse would re-introduce the very false-positive class being fixed.

Collateral false positives also closed: `Ms. Johnson is the loan officer.` and `The p95 latency is 40 ms.` were both `protected_class`.

## Tests

New module `tests/unit/test_marketing_safety_two_letter_ms.py` (792 cases). The load-bearing test is an **equivalence** — `MS` must give the same verdict as `TX` on every template — so a special-case cannot satisfy it. It fails **26 ways** against the pre-change tree, so it is not vacuous.

Gates: `ruff check` ✓ · `ruff format --check` ✓ · `mypy backend` ✓ (254 files) · `pytest tests/unit` ✓ (16,848 collected, exit 0 under `-x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)