### PR TITLE
refactor(criteria): split the reviewed workflow grammars out of the 900-line gate

### DIFF
--- a/backend/schemas/_validators_protected_class.py
+++ b/backend/schemas/_validators_protected_class.py
@@ -34,9 +34,11 @@ from backend.schemas.marketing_safety_terms import (
 )
 from backend.schemas.marketing_selection_criteria import (
     contains_unreviewed_selection_criterion,
+    is_reviewed_read_only_analytics_text,
+)
+from backend.schemas.marketing_selection_reviewed_workflows import (
     is_reviewed_campaign_audience_description_text,
     is_reviewed_campaign_audience_summary_text,
-    is_reviewed_read_only_analytics_text,
 )
 from backend.schemas.marketing_text_normalization import ascii_confusable_folds
 from backend.schemas.protected_relationships import PROTECTED_RELIGION_FAMILIAL_RELATION_RE

--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -13,6 +13,12 @@ from backend.schemas.marketing_selection_reviewed_analytics import (
     _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS,
     _REVIEWED_WHY_ASSESSMENT_PREAMBLE_RE,
 )
+from backend.schemas.marketing_selection_reviewed_workflows import (
+    _REVIEWED_CAMPAIGN_AUDIENCE_SUMMARY_RE,
+    _REVIEWED_NAMED_LENDER_RATE_QUERY_RE,
+    _REVIEWED_NON_POPULATION_STRATEGY_RE,
+    _REVIEWED_SCREEN_GATE_WORKFLOW_RE,
+)
 from backend.schemas.marketing_selection_vocabulary import (
     _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE,
     POPULATION_QUANTIFIER_DIGITS,
@@ -212,27 +218,6 @@ _REVIEWED_SEGMENT_SIGNAL_BINDING_RE = re.compile(
     r"^\s+with\s+(?P<criterion>.+)$",
     re.IGNORECASE,
 )
-_REVIEWED_NON_POPULATION_STRATEGY_RE = re.compile(
-    # This grammar allocates aggregate outreach capacity; it does not select
-    # people or define an audience predicate. Keep both the allocatable object
-    # and every grouping dimension closed so a health criterion cannot hide in
-    # a canonical strategy-board sentence.
-    r"^(?:(?:prioritize|allocate|sequence|rank|order)\s+(?:the\s+)?(?:next\s+)?"
-    r"(?:[0-9]{1,9}\s+)?(?:outreach\s+)?(?:touches|capacity|budget)\s+"
-    r"(?:by|across)\s+"
-    r"(?:states?|count(?:y|ies)|markets?|metros?|segments?|offer\s+lanes?)"
-    r"(?:\s*,\s*(?:states?|count(?:y|ies)|markets?|metros?|segments?|"
-    r"offer\s+lanes?))*"
-    r"(?:\s*,?\s+and\s+(?:states?|count(?:y|ies)|markets?|metros?|segments?|"
-    r"offer\s+lanes?))?|"
-    # Internal queue ownership is an operating instruction, not an audience
-    # criterion. Keep the reviewed object and terminal role closed.
-    r"(?:review|inspect|confirm)\s+(?:the\s+)?"
-    r"(?:priority|queue|workload|capacity|ownership)\s+distribution\s+and\s+"
-    r"(?:assign|confirm)\s+(?:the\s+)?next\s+"
-    r"(?:owner|operator|reviewer))$",
-    re.IGNORECASE,
-)
 _SAFE_CHANNEL_CONSENT_REROUTE_RE = re.compile(
     r"^(?:create|build|prepare)\s+(?:a|the)\s+"
     r"(?:(?:refi|refinance|heloc|home[- ]equity|retention|mortgage)\s+)?campaign\s+"
@@ -242,47 +227,6 @@ _SAFE_CHANNEL_CONSENT_REROUTE_RE = re.compile(
     r"(?:call|email|text|message)\s+(?:them|the\s+(?:borrower|recipient|customer))"
     r"(?:\s+instead)?$",
     re.IGNORECASE,
-)
-_REVIEWED_SCREEN_GATE_WORKFLOW_RE = re.compile(
-    r"^(?:compose\s+(?:a\s+)?(?:reviewed\s+)?(?:growth\s+)?plan\s+to\s+)?"
-    r"screen\s+(?:prime\s+)?(?:refi|refinance|mortgage)\s+economics"
-    r"(?:\s*,\s*|\s+)(?:then\s+)?gate\s+to\s+eligible(?:\s+leads?)?"
-    r"(?:\s*,?\s*(?:and|then)\s+(?:"
-    r"prepare\s+(?:a\s+)?lead\s+queue\s+handoff\s+for\s+review|"
-    r"hand\s+off\s+for\s+review))?$",
-    re.IGNORECASE,
-)
-_REVIEWED_CAMPAIGN_AUDIENCE_DESCRIPTION = (
-    r"(?:borrowers\s+whose\s+current\s+property\s+and\s+listing\s+signals\s+support\s+"
-    r"a\s+next[ -]?home\s+conversation|"
-    r"borrowers\s+with\s+refinance\s+economics\s+and\s+usable\s+home\s+equity|"
-    r"borrowers\s+whose\s+equity\s+and\s+heloc\s+propensity\s+support\s+an\s+"
-    r"equity[ -]?access\s+review|"
-    r"borrowers\s+whose\s+current\s+lien\s+economics\s+support\s+a\s+refinance\s+review|"
-    r"borrowers\s+with\s+substantial\s+modeled\s+equity\s+for\s+a\s+cash[ -]?out\s+review|"
-    r"multi[ -]?property\s+borrowers\s+whose\s+financing\s+needs\s+may\s+span\s+more\s+"
-    r"than\s+one\s+property|"
-    r"existing\s+or\s+former\s+customers\s+with\s+a\s+timely\s+retention\s+review\s+signal|"
-    r"borrowers\s+who\s+should\s+receive\s+education\s+rather\s+than\s+a\s+"
-    r"product[ -]?specific\s+claim)"
-)
-_REVIEWED_CAMPAIGN_AUDIENCE_DESCRIPTION_RE = re.compile(
-    rf"^{_REVIEWED_CAMPAIGN_AUDIENCE_DESCRIPTION}$",
-    re.IGNORECASE,
-)
-_REVIEWED_CAMPAIGN_AUDIENCE_SUMMARY_RE = re.compile(
-    rf"^the\s+selected\s+audience\s+is\s+led\s+by\s+"
-    rf"{_REVIEWED_CAMPAIGN_AUDIENCE_DESCRIPTION}\s+and\s+is\s+ready\s+for\s+a\s+"
-    r"controlled\s+message\s+test\.?$",
-    re.IGNORECASE,
-)
-_REVIEWED_NAMED_LENDER_RATE_QUERY_RE = re.compile(
-    r"^(?:[Ll]ist|[Ss]how|[Cc]ount)\s+(?:[A-Z][A-Za-z0-9&.'-]*\s+){1,3}"
-    r"(?:borrowers?|customers?|homeowners?|applicants?)\s+whose\s+"
-    r"(?:mortgage\s+)?(?:rate|payment|ltv|loan[- ]to[- ]value|equity)\s+"
-    r"(?:is\s+)?(?:above|below|over|under|at\s+least|no\s+more\s+than)\s+"
-    r"[0-9olieast]{1,3}(?:\.[0-9olieast]{1,3})?"
-    r"(?:\s*(?:%|percent|bps?|basis\s+points?))?$",
 )
 _AUDIENCE_DIRECTIVE_PREFIX_FRAGMENT = (
     r"(?:(?:could|would|can|will)\s+you\s+)?"
@@ -809,18 +753,6 @@ def is_reviewed_read_only_analytics_text(value: str) -> bool:
         )
         for clause in clauses
     )
-
-
-def is_reviewed_campaign_audience_summary_text(value: str) -> bool:
-    """Return true only for the closed server-rendered offer-audience summary."""
-
-    return _REVIEWED_CAMPAIGN_AUDIENCE_SUMMARY_RE.fullmatch(str(value).strip()) is not None
-
-
-def is_reviewed_campaign_audience_description_text(value: str) -> bool:
-    """Return true only for one closed server-owned offer-audience description."""
-
-    return _REVIEWED_CAMPAIGN_AUDIENCE_DESCRIPTION_RE.fullmatch(str(value).strip()) is not None
 
 
 def build_selection_context_pattern(*, population_re_fragment: str) -> re.Pattern[str]:

--- a/backend/schemas/marketing_selection_reviewed_workflows.py
+++ b/backend/schemas/marketing_selection_reviewed_workflows.py
@@ -1,0 +1,91 @@
+"""Closed reviewed workflow and server-rendered copy grammars.
+
+Clauses the audience-criterion machine recognizes as reviewed Module 0
+product workflows or server-owned campaign copy, each checked by fullmatch
+BEFORE its fail-closed nets. Every grammar here is self-contained -- no
+population or attribute fragment reaches in -- which is what makes this a
+clean seam: split out of ``marketing_selection_criteria`` 2026-08-13 when
+the #225 destination-tail fix pushed that module over the 900-line
+file-size gate (899 at base). Pure move, verdict-identical under the
+1,482-probe battery; the consent-reroute grammar stayed behind because it
+embeds the coreference population fragment.
+"""
+
+from __future__ import annotations
+
+import re
+
+_REVIEWED_NON_POPULATION_STRATEGY_RE = re.compile(
+    # This grammar allocates aggregate outreach capacity; it does not select
+    # people or define an audience predicate. Keep both the allocatable object
+    # and every grouping dimension closed so a health criterion cannot hide in
+    # a canonical strategy-board sentence.
+    r"^(?:(?:prioritize|allocate|sequence|rank|order)\s+(?:the\s+)?(?:next\s+)?"
+    r"(?:[0-9]{1,9}\s+)?(?:outreach\s+)?(?:touches|capacity|budget)\s+"
+    r"(?:by|across)\s+"
+    r"(?:states?|count(?:y|ies)|markets?|metros?|segments?|offer\s+lanes?)"
+    r"(?:\s*,\s*(?:states?|count(?:y|ies)|markets?|metros?|segments?|"
+    r"offer\s+lanes?))*"
+    r"(?:\s*,?\s+and\s+(?:states?|count(?:y|ies)|markets?|metros?|segments?|"
+    r"offer\s+lanes?))?|"
+    # Internal queue ownership is an operating instruction, not an audience
+    # criterion. Keep the reviewed object and terminal role closed.
+    r"(?:review|inspect|confirm)\s+(?:the\s+)?"
+    r"(?:priority|queue|workload|capacity|ownership)\s+distribution\s+and\s+"
+    r"(?:assign|confirm)\s+(?:the\s+)?next\s+"
+    r"(?:owner|operator|reviewer))$",
+    re.IGNORECASE,
+)
+_REVIEWED_SCREEN_GATE_WORKFLOW_RE = re.compile(
+    r"^(?:compose\s+(?:a\s+)?(?:reviewed\s+)?(?:growth\s+)?plan\s+to\s+)?"
+    r"screen\s+(?:prime\s+)?(?:refi|refinance|mortgage)\s+economics"
+    r"(?:\s*,\s*|\s+)(?:then\s+)?gate\s+to\s+eligible(?:\s+leads?)?"
+    r"(?:\s*,?\s*(?:and|then)\s+(?:"
+    r"prepare\s+(?:a\s+)?lead\s+queue\s+handoff\s+for\s+review|"
+    r"hand\s+off\s+for\s+review))?$",
+    re.IGNORECASE,
+)
+_REVIEWED_CAMPAIGN_AUDIENCE_DESCRIPTION = (
+    r"(?:borrowers\s+whose\s+current\s+property\s+and\s+listing\s+signals\s+support\s+"
+    r"a\s+next[ -]?home\s+conversation|"
+    r"borrowers\s+with\s+refinance\s+economics\s+and\s+usable\s+home\s+equity|"
+    r"borrowers\s+whose\s+equity\s+and\s+heloc\s+propensity\s+support\s+an\s+"
+    r"equity[ -]?access\s+review|"
+    r"borrowers\s+whose\s+current\s+lien\s+economics\s+support\s+a\s+refinance\s+review|"
+    r"borrowers\s+with\s+substantial\s+modeled\s+equity\s+for\s+a\s+cash[ -]?out\s+review|"
+    r"multi[ -]?property\s+borrowers\s+whose\s+financing\s+needs\s+may\s+span\s+more\s+"
+    r"than\s+one\s+property|"
+    r"existing\s+or\s+former\s+customers\s+with\s+a\s+timely\s+retention\s+review\s+signal|"
+    r"borrowers\s+who\s+should\s+receive\s+education\s+rather\s+than\s+a\s+"
+    r"product[ -]?specific\s+claim)"
+)
+_REVIEWED_CAMPAIGN_AUDIENCE_DESCRIPTION_RE = re.compile(
+    rf"^{_REVIEWED_CAMPAIGN_AUDIENCE_DESCRIPTION}$",
+    re.IGNORECASE,
+)
+_REVIEWED_CAMPAIGN_AUDIENCE_SUMMARY_RE = re.compile(
+    rf"^the\s+selected\s+audience\s+is\s+led\s+by\s+"
+    rf"{_REVIEWED_CAMPAIGN_AUDIENCE_DESCRIPTION}\s+and\s+is\s+ready\s+for\s+a\s+"
+    r"controlled\s+message\s+test\.?$",
+    re.IGNORECASE,
+)
+_REVIEWED_NAMED_LENDER_RATE_QUERY_RE = re.compile(
+    r"^(?:[Ll]ist|[Ss]how|[Cc]ount)\s+(?:[A-Z][A-Za-z0-9&.'-]*\s+){1,3}"
+    r"(?:borrowers?|customers?|homeowners?|applicants?)\s+whose\s+"
+    r"(?:mortgage\s+)?(?:rate|payment|ltv|loan[- ]to[- ]value|equity)\s+"
+    r"(?:is\s+)?(?:above|below|over|under|at\s+least|no\s+more\s+than)\s+"
+    r"[0-9olieast]{1,3}(?:\.[0-9olieast]{1,3})?"
+    r"(?:\s*(?:%|percent|bps?|basis\s+points?))?$",
+)
+
+
+def is_reviewed_campaign_audience_summary_text(value: str) -> bool:
+    """Return true only for the closed server-rendered offer-audience summary."""
+
+    return _REVIEWED_CAMPAIGN_AUDIENCE_SUMMARY_RE.fullmatch(str(value).strip()) is not None
+
+
+def is_reviewed_campaign_audience_description_text(value: str) -> bool:
+    """Return true only for one closed server-owned offer-audience description."""
+
+    return _REVIEWED_CAMPAIGN_AUDIENCE_DESCRIPTION_RE.fullmatch(str(value).strip()) is not None

--- a/tests/unit/test_round23_health_selection.py
+++ b/tests/unit/test_round23_health_selection.py
@@ -20,7 +20,7 @@ from backend.main import app
 from backend.schemas._validators_protected_class import contains_protected_class_marketing_text
 from backend.schemas.agent_plan import ComposePlanRequest
 from backend.schemas.growth_agent import GrowthAgentPromptRunRequest
-from backend.schemas.marketing_selection_criteria import (
+from backend.schemas.marketing_selection_reviewed_workflows import (
     is_reviewed_campaign_audience_description_text,
     is_reviewed_campaign_audience_summary_text,
 )


### PR DESCRIPTION
## What

Unbreak the **file-size gate** that went red on main when #225 merged: `backend/schemas/marketing_selection_criteria.py` was 899 lines at base — one under the 900-line fail threshold — and #225's 22 comment/fragment lines pushed it to 921. The gate is not a required check, so auto-merge landed it red.

Per the standing doctrine (split, never allowlist): the four **self-contained** reviewed workflow/copy grammars move to a new sibling, `backend/schemas/marketing_selection_reviewed_workflows.py`:

- `_REVIEWED_NON_POPULATION_STRATEGY_RE` (strategy-board capacity allocation)
- `_REVIEWED_SCREEN_GATE_WORKFLOW_RE` (screen → gate → handoff workflow)
- `_REVIEWED_CAMPAIGN_AUDIENCE_DESCRIPTION{,_RE}` + `_REVIEWED_CAMPAIGN_AUDIENCE_SUMMARY_RE` (server-rendered offer-audience copy)
- `_REVIEWED_NAMED_LENDER_RATE_QUERY_RE`
- plus their two public helpers `is_reviewed_campaign_audience_{summary,description}_text` (importers re-pointed: `_validators_protected_class.py`, `test_round23_health_selection.py`)

`_SAFE_CHANNEL_CONSENT_REROUTE_RE` deliberately stays behind — it embeds the coreference population fragment, and this seam moves only grammars with zero fragment reach-in. Criteria drops to **853 lines**; the new module is 91.

## Proof it is a pure move

- The #225 differential battery rerun post-split is **verdict-identical**: 1,482 probes × four surfaces (`protected_prompt_match`, `protected_class_marketing_reason`, `contains_unsafe_ai_text`, `identity_prompt_match`), **0 diffs** against the pre-split run, with distinct file hashes recorded in both runs (both sides really ran).
- `tools/check_file_sizes.py --warn 500 --fail 900` (the exact CI invocation) exits 0.
- ruff, mypy, and the full pytest suite green; the moved helpers' own pins (`test_round23_health_selection.py`) green against the new import site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
