### PR TITLE
fix(guards): reviewed compounds must spell their own hyphen-fold images

### DIFF
--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -173,10 +173,19 @@ _AUDIENCE_FORMATION_ACTION_FRAGMENT = (
 _AUDIENCE_FORMATION_NAMED_POPULATION = (
     rf"(?:{_COREFERENCE_POPULATION}|groups?|cohorts?|audiences?|segments?|populations?)"
 )
+# ``[- ]?`` on reviewed compounds, here and in every allow grammar below: the
+# protected-class scanner also evaluates a de-obfuscated variant that deletes
+# intra-word hyphens ("highest-scoring" -> "highestscoring"), and ONE tripping
+# variant refuses the whole prompt. Each reviewed hyphen-or-space compound must
+# therefore spell its own joined fold image too, or the hyphenated twin of an
+# allowed prompt refuses (measured 2026-08-13 at the prompt boundary: "Add the
+# highest-scoring leads to the campaign." refused while the space twin was
+# answered). This is a closed enumeration of already-reviewed compounds, never
+# a fold relaxation: unreviewed compounds still de-obfuscate and fail closed.
 _AUDIENCE_FORMATION_ACTION_RE = re.compile(
     rf"\b{_AUDIENCE_FORMATION_ACTION_FRAGMENT}\s+"
-    r"(?:(?:the|these|those|all|reviewed|eligible|qualified|marketing[- ]eligible|"
-    r"highest[- ]scoring|prospective|current)\s+){0,3}"
+    r"(?:(?:the|these|those|all|reviewed|eligible|qualified|marketing[- ]?eligible|"
+    r"highest[- ]?scoring|prospective|current)\s+){0,3}"
     rf"{_AUDIENCE_FORMATION_NAMED_POPULATION}\b",
     re.IGNORECASE,
 )
@@ -220,7 +229,7 @@ _REVIEWED_SEGMENT_SIGNAL_BINDING_RE = re.compile(
 )
 _SAFE_CHANNEL_CONSENT_REROUTE_RE = re.compile(
     r"^(?:create|build|prepare)\s+(?:a|the)\s+"
-    r"(?:(?:refi|refinance|heloc|home[- ]equity|retention|mortgage)\s+)?campaign\s+"
+    r"(?:(?:refi|refinance|heloc|home[- ]?equity|retention|mortgage)\s+)?campaign\s+"
     rf"for\s+(?:a|the)\s+{_COREFERENCE_POPULATION}\s+whose\s+"
     r"(?:documented\s+)?(?:email|phone|sms|text(?:\s+message)?)\s+opt[ -]?out\s+"
     r"is\s+on\s+file\s+and\s+(?:instead\s+)?"
@@ -387,7 +396,7 @@ _REVIEWED_AUDIENCE_DECISION_PATTERNS: tuple[re.Pattern[str], ...] = (
         rf"(?:{_AUDIENCE_PASSIVE_AUX_FRAGMENT}\s+)?"
         rf"(?:eligible|qualified|{_AUDIENCE_FORMATION_PARTICIPLE_FRAGMENT})"
         r"(?:\s+for\s+(?:(?:this|the|a|an)\s+)?(?:reviewed\s+)?"
-        r"(?:(?:refi|refinance|heloc|home[- ]equity|retention|portfolio|purchase|"
+        r"(?:(?:refi|refinance|heloc|home[- ]?equity|retention|portfolio|purchase|"
         r"mortgage|loan|servicing)\s+)?(?:campaign|offer|options?|review))?$",
         re.IGNORECASE,
     ),
@@ -396,7 +405,7 @@ _REVIEWED_AUDIENCE_DECISION_PATTERNS: tuple[re.Pattern[str], ...] = (
         rf"(?:{_AUDIENCE_PASSIVE_AUX_FRAGMENT}\s+)?"
         rf"(?:eligible|qualified|{_AUDIENCE_FORMATION_PARTICIPLE_FRAGMENT})"
         r"(?:\s+for\s+(?:(?:this|the|a|an)\s+)?(?:reviewed\s+)?"
-        r"(?:(?:refi|refinance|heloc|home[- ]equity|retention|portfolio|purchase|"
+        r"(?:(?:refi|refinance|heloc|home[- ]?equity|retention|portfolio|purchase|"
         r"mortgage|loan|servicing)\s+)?(?:campaign|offer|options?|review))?$",
         re.IGNORECASE,
     ),
@@ -437,7 +446,7 @@ _REVIEWED_BARE_DIRECTIVE_DESTINATION_TAIL = (
 _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE = re.compile(
     rf"^{_AUDIENCE_DIRECTIVE_PREFIX_FRAGMENT}"
     rf"{_AUDIENCE_FORMATION_COMMAND_FRAGMENT}\s+(?:(?:the|an?)\s+)?"
-    rf"(?:(?:reviewed|eligible|qualified|marketing[- ]eligible|highest[- ]scoring)\s+){{0,2}}"
+    rf"(?:(?:reviewed|eligible|qualified|marketing[- ]?eligible|highest[- ]?scoring)\s+){{0,2}}"
     rf"{_AUDIENCE_DECISION_REFERENCE}"
     r"(?:\s+(?:for\s+(?:(?:this|the|a|an)\s+)?(?:reviewed\s+)?"
     r"(?:campaign|offer|review)|"
@@ -462,7 +471,7 @@ _AFFIRMATIVE_AUDIENCE_DIRECTIVE_RE = re.compile(
     re.IGNORECASE,
 )
 _REVIEWED_DIRECTIVE_POPULATION_PREFIX_RE = re.compile(
-    r"^(?:(?:the|reviewed|eligible|qualified|marketing[- ]eligible|highest[- ]scoring)\s*){0,3}$",
+    r"^(?:(?:the|reviewed|eligible|qualified|marketing[- ]?eligible|highest[- ]?scoring)\s*){0,3}$",
     re.IGNORECASE,
 )
 # The fail-closed half of the quantifier fix (see ``_POPULATION_QUANTIFIER``):
@@ -477,7 +486,7 @@ _SAFE_CONTEXTUAL_CTA_RE = re.compile(
     r"^(?:may|can|should)\s+(?:contact|call|email|text|message|reply|respond|reach\s+out)"
     r"(?:\s+(?:to|with)\s+us|\s+us)?"
     r"(?:\s+to\s+(?:review|discuss|consider|learn\s+about)\s+"
-    r"(?:(?:their|the|available)\s+)?(?:mortgage|loan|refi|refinance|heloc|home[- ]equity)?"
+    r"(?:(?:their|the|available)\s+)?(?:mortgage|loan|refi|refinance|heloc|home[- ]?equity)?"
     r"\s*(?:options?|offer|review))?$",
     re.IGNORECASE,
 )
@@ -540,7 +549,7 @@ def _is_reviewed_pre_population_binding(value: str) -> bool:
         # remains after stripping must still full-match the reviewed
         # vocabulary below.
         r"^(?:(?:the|an?|these|those|all|any|our|your|only|reviewed|eligible|qualified|"
-        r"marketing[- ]eligible|highest[- ]scoring|prospective|current|"
+        r"marketing[- ]?eligible|highest[- ]?scoring|prospective|current|"
         r"(?:which|what)(?:\s+of)?)(?:\s+|$))+",
         "",
         criterion,

--- a/backend/schemas/marketing_selection_reviewed_workflows.py
+++ b/backend/schemas/marketing_selection_reviewed_workflows.py
@@ -72,7 +72,7 @@ _REVIEWED_CAMPAIGN_AUDIENCE_SUMMARY_RE = re.compile(
 _REVIEWED_NAMED_LENDER_RATE_QUERY_RE = re.compile(
     r"^(?:[Ll]ist|[Ss]how|[Cc]ount)\s+(?:[A-Z][A-Za-z0-9&.'-]*\s+){1,3}"
     r"(?:borrowers?|customers?|homeowners?|applicants?)\s+whose\s+"
-    r"(?:mortgage\s+)?(?:rate|payment|ltv|loan[- ]to[- ]value|equity)\s+"
+    r"(?:mortgage\s+)?(?:rate|payment|ltv|loan[- ]?to[- ]?value|equity)\s+"
     r"(?:is\s+)?(?:above|below|over|under|at\s+least|no\s+more\s+than)\s+"
     r"[0-9olieast]{1,3}(?:\.[0-9olieast]{1,3})?"
     r"(?:\s*(?:%|percent|bps?|basis\s+points?))?$",

--- a/backend/schemas/marketing_selection_vocabulary.py
+++ b/backend/schemas/marketing_selection_vocabulary.py
@@ -164,7 +164,7 @@ REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT = (
     # is an ordinary adjective; requiring the noun keeps this to the product's
     # own program vocabulary and cannot admit a geography or a stray modifier.
     r"(?:conventional|conforming|non[- ]?conforming|jumbo|fha|va|usda|"
-    r"government[- ]backed)\s+(?:loans?|mortgages?)|"
+    r"government[- ]?backed)\s+(?:loans?|mortgages?)|"
     r"(?:loan|mortgage)\s+(?:type|program|product)s?|"
     # Bare "home equity" / "equity percentage". Every other equity alternative
     # above REQUIRES a qualifier ("strong equity", "substantial equity"), so
@@ -188,7 +188,7 @@ REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT = (
 )
 REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT = (
     r"(?:\s+for\s+(?:(?:this|the|a)\s+)?"
-    r"(?:(?:refi|refinance|heloc|home[- ]equity|retention|portfolio|purchase|"
+    r"(?:(?:refi|refinance|heloc|home[- ]?equity|retention|portfolio|purchase|"
     r"mortgage|loan|servicing)\s+)?(?:campaign|offer|options?|review))?"
 )
 
@@ -287,7 +287,7 @@ _REVIEWED_ATTRIBUTE_CTA_TAIL = (
     r"prospects?|clients?|owners?)))?"
     r"(?:\s+(?:about|regarding|with|on)\s+(?:(?:the|their|an?)\s+)?"
     r"(?:offers?|options?|reviews?|campaigns?|refinance|refi|heloc|"
-    r"home[- ]equity(?:\s+lines?)?|mortgages?|loans?|rates?|savings?))?)?"
+    r"home[- ]?equity(?:\s+lines?)?|mortgages?|loans?|rates?|savings?))?)?"
 )
 _REVIEWED_ATTRIBUTE_CLOSING = r"(?:\s+(?:too|as\s+well))?"
 

--- a/tests/unit/test_premodifier_fold_image_parity.py
+++ b/tests/unit/test_premodifier_fold_image_parity.py
@@ -1,0 +1,123 @@
+"""Separator parity for reviewed compounds under the intra-word hyphen fold.
+
+"Add the highest-scoring leads to the campaign." refused as
+``unreviewed_criterion`` while the space twin was answered (pre-existing
+false positive, measured 2026-08-13). The protected-class scanner evaluates a
+de-obfuscated variant that deletes intra-word hyphens ("highest-scoring" ->
+"highestscoring"), and one tripping variant refuses the whole prompt. The
+reviewed vocabularies spelled their compounds ``[- ]`` -- hyphen or space,
+never joined -- so on that variant every allow grammar missed and the
+bound-population capture read the joined image as an unreviewed criterion.
+
+Fixed by spelling each already-reviewed compound's own joined fold image
+(``[- ]?``) at every embedding the per-variant machine consults: the four
+premodifier sites (``highest-scoring``/``marketing-eligible``), the
+``government-backed`` attribute, the ``home-equity`` purpose/CTA/consent
+products, and the named-lender ``loan-to-value``. A closed enumeration of
+fold images, never a fold relaxation: the de-obfuscation itself is untouched,
+so unreviewed compounds keep failing closed on their joined images.
+
+Fix battery, 126 prompts x three surfaces (prompt guard, marketing reason,
+campaign copy): every gain is a hyphen or joined spelling of a compound whose
+space twin already answered; 0 losses; controls (unreviewed compounds in all
+three separator forms, leet-inside-compound, spaced-out health terms)
+unchanged. Refusals below assert the EXACT reason string: ``is not None``
+would pass through a silent reclassification.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.schemas.marketing_selection_criteria import (
+    _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE,
+    _is_reviewed_pre_population_binding,
+)
+from backend.services.genie_message_policy import protected_prompt_match
+
+# The restored family: hyphenated and fold-joined spellings of reviewed
+# compounds whose space twin already answered on the pre-fix tree.
+_FOLD_IMAGE_ANSWERABLE = (
+    "Add the highest-scoring leads to the campaign.",
+    "Add the highest-scoring leads.",
+    "Add the highestscoring leads.",
+    "Queue the highest-scoring borrowers for this campaign.",
+    "Add the marketing-eligible leads to the campaign.",
+    "Add the marketingeligible leads to the campaign.",
+    "Add the government-backed loan leads.",
+    "Queue the government-backed loan borrowers for this campaign.",
+    "Queue the borrowers with a high ltv for the home-equity campaign.",
+    "List Rocket borrowers whose loan-to-value is above 80%",
+)
+
+
+@pytest.mark.parametrize("prompt", _FOLD_IMAGE_ANSWERABLE)
+def test_a_reviewed_compound_answers_in_every_separator_form(prompt: str) -> None:
+    assert protected_prompt_match(prompt) is None, prompt
+
+
+def test_the_premodifier_branches_own_the_allow() -> None:
+    """Branch attribution: reroutes of this family should be visible, not silent."""
+
+    assert (
+        _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE.fullmatch("add the highestscoring leads")
+        is not None
+    )
+    assert _is_reviewed_pre_population_binding("the highestscoring") is True
+    assert _is_reviewed_pre_population_binding("the marketingeligible") is True
+
+
+# ---------------------------------------------------------------------------
+# Invariants -- green on BOTH sides of the fix. They pin what the closed
+# fold-image enumeration must never admit, independent of the change.
+
+# An unreviewed compound stays refused in ALL separator forms: the fold keeps
+# de-obfuscating, and the joined image of anything outside the reviewed
+# enumeration is still an unknown criterion.
+_UNREVIEWED_IN_EVERY_FORM = (
+    "Add the left-handed leads to the campaign.",
+    "Add the left handed leads to the campaign.",
+    "Add the lefthanded leads to the campaign.",
+    "Add the equity-rich leads to the campaign.",
+    "Add the equityrich leads to the campaign.",
+    # A reviewed attribute with an UNREVIEWED purpose product: the purpose
+    # slot widened only by its own fold image, not by new vocabulary.
+    "Queue the borrowers with a high ltv for the crypto campaign.",
+    # Trigger-removed twins of the two remaining gain carriers: an unreviewed
+    # measure in the named-lender query, an unreviewed product in the
+    # consent-aware reroute. The carrier admits nothing on its own.
+    "List Rocket borrowers whose credit-worthiness is above 80%",
+    "Create a crypto campaign for the borrowers whose email opt-out is on file and call them instead.",
+)
+
+
+@pytest.mark.parametrize("prompt", _UNREVIEWED_IN_EVERY_FORM)
+def test_an_unreviewed_compound_refuses_in_every_separator_form(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "unreviewed_criterion", prompt
+
+
+# The admitted image alphabet is letters-only: a leet character inside a
+# reviewed compound is not a reviewed spelling, and the plain variant fails
+# closed regardless of what the fold recovers.
+_LEET_INSIDE_A_REVIEWED_COMPOUND = (
+    "Add the highest-sc0ring leads to the campaign.",
+    "Add the marketing-eligib1e leads to the campaign.",
+)
+
+
+@pytest.mark.parametrize("prompt", _LEET_INSIDE_A_REVIEWED_COMPOUND)
+def test_the_admitted_fold_image_is_letters_only(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "unreviewed_criterion", prompt
+
+
+def test_the_fold_still_deobfuscates_protected_terms() -> None:
+    """The de-obfuscation variants themselves are untouched by this fix."""
+
+    assert (
+        protected_prompt_match("Add the e-c-z-e-m-a leads to the campaign.")
+        == "protected_class_language"
+    )
+    assert (
+        protected_prompt_match("Add the wheelchair-bound leads to the campaign.")
+        == "protected_class_language"
+    )


### PR DESCRIPTION
## What

Pre-existing false positive, measured 2026-08-13: `protected_prompt_match("Add the highest-scoring leads to the campaign.")` returned `unreviewed_criterion` while the space twin ("highest scoring") was answered.

The protected-class scanner evaluates a de-obfuscated variant that deletes intra-word hyphens (`highest-scoring` → `highestscoring`), and one tripping variant refuses the whole prompt. The reviewed vocabularies spelled their compounds `[- ]` — hyphen or space, never joined — so on that variant every allow grammar missed, and the bound-population capture read the joined image as an unreviewed criterion.

## Fix

Spell each already-reviewed compound's own joined fold image (`[- ]?`) at every embedding the per-variant criterion machine consults:

- the four premodifier sites (`highest-scoring` / `marketing-eligible`) in `marketing_selection_criteria.py`: `_AUDIENCE_FORMATION_ACTION_RE`, `_REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE`, `_REVIEWED_DIRECTIVE_POPULATION_PREFIX_RE`, `_is_reviewed_pre_population_binding`
- the `government[- ]backed` attribute (the one `[- ]` outlier in a vocabulary that already spells `[- ]?` elsewhere)
- the `home[- ]equity` purpose / CTA / consent-reroute / safe-CTA products
- the named-lender `loan[- ]to[- ]value`

This is a **closed enumeration of fold images of already-reviewed compounds, not a fold relaxation**: the de-obfuscation itself is untouched, so unreviewed compounds keep de-obfuscating and failing closed on their joined images. (`opt[ -]?out` was already fold-safe; the analytics grammars run on the mark-folded text only and are deliberately untouched.)

## Differential battery (base vs fix)

126 prompts × three surfaces (`protected_prompt_match`, `protected_class_marketing_reason`, `contains_unsafe_ai_text`):

- **15 gains**, every one a hyphen or joined spelling of a compound whose space twin already answered on base (6 highest-scoring, 2 marketing-eligible, 4 government-backed, 1 home-equity purpose, 1 home-equity consent-reroute, 1 loan-to-value)
- **0 losses, 0 reason shifts, 0 surface disagreements**
- Trigger-removed twins of every gain carrier still refuse (`left-handed` / `equity-rich` / `crypto campaign` / `credit-worthiness` controls, in all three separator forms)
- Letters-only image invariant holds: `highest-sc0ring` / `marketing-eligib1e` still refuse — the reviewed matcher is not fold-aware
- Fold still de-obfuscates protected terms: `e-c-z-e-m-a` / `wheelchair-bound` → `protected_class_language`

Invariants pinned in `tests/unit/test_premodifier_fold_image_parity.py`.

## Out of scope (residual chips filed)

- The prenominal `to the campaign` destination-tail gap (space-spelled attributes refuse with that tail; sibling of #225)
- Whether hyphenated spellings of `\s+`-joined reviewed criteria (`high-equity`, `in-the-money`) should be admitted — a vocabulary-review decision, not a fold bug

## Gates

ruff ✓ · mypy (255 files) ✓ · file-size gate ✓ (criteria file 862/900) · scaffold ✓ · targeted guard suites ✓ · full `pytest -q -n auto` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
