### PR TITLE
fix(guards): a count quantifies a population, it is not the criterion

### DIFF
--- a/backend/schemas/marketing_audience_admission.py
+++ b/backend/schemas/marketing_audience_admission.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 
 from backend.schemas.marketing_selection_vocabulary import (
-    POPULATION_QUANTIFIER_FRAGMENT,
+    QUANTIFIED_POPULATION_FRAGMENT,
 )
 
 _POPULATION = (
@@ -50,11 +50,32 @@ _MODIFIERS = (
     # bounded modifier run, so "Add the top 50 borrowers with the highest rate
     # spread to the campaign." proved no relation at all and fell through to the
     # fail-closed tail, while the same sentence without the count was answered.
-    # The count admits nothing on its own -- ``POPULATION_QUANTIFIER_FRAGMENT``
-    # is digits or a CLOSED cardinal list, never an open adjective slot -- and
-    # whatever the criterion group captures must still satisfy
-    # ``_is_reviewed_admission_criterion``.
-    rf"(?:{POPULATION_QUANTIFIER_FRAGMENT}\s+)?"
+    # The count admits nothing on its own -- the quantified fragment is an
+    # optional closed lead word (top|best|next|first) plus digits, never an
+    # open adjective slot -- and whatever the criterion group captures must
+    # still satisfy ``_is_reviewed_admission_criterion``.
+    #
+    # The lead word joined the slot on 2026-08-13. The imperative shapes never
+    # needed it (the open action slot absorbed "add the top"), but no passive
+    # or declarative shape has an action slot, so "top" broke the parse there
+    # and the count switched the whole net off in BOTH directions: "The top 50
+    # high equity borrowers are placed into the campaign." refused while its
+    # count-free twin answered, and once the criterion machine learned the
+    # count was transparent, "The top 50 borrowers are placed into the
+    # campaign based on <unreviewed term>." would have proved no relation and
+    # sailed past the criterion capture entirely.
+    rf"(?:{QUANTIFIED_POPULATION_FRAGMENT}\s+)?"
+    # English puts the closed premodifiers AFTER the count -- "the 50 ELIGIBLE
+    # borrowers" -- and with the run only in front of the quantifier, that
+    # order proved no relation at all. The differential battery caught what
+    # that costs: once the count is transparent to the criterion machine,
+    # "The 50 eligible borrowers are placed into the campaign based on
+    # left-handedness." sailed past BOTH nets (measured 2026-08-13, 105
+    # probes), because this grammar could not capture the criterion and the
+    # criterion machine saw only reviewed premodifiers. Adjectives only, no
+    # second determiner: a determiner after a count is not a noun phrase.
+    r"(?:(?:reviewed|eligible|qualified|marketing[- ]eligible|"
+    r"highest[- ]scoring|prospective|current)\s+){0,2}"
 )
 _DESTINATION_REFERENCE = rf"(?:the\s+|this\s+|that\s+|a\s+|an\s+)?{_DESTINATION}"
 _DESTINATION_RELATION = rf"(?:into|in|to|on|onto|for|towards?)\s+{_DESTINATION_REFERENCE}"

--- a/backend/schemas/marketing_selection_contextual_criteria.py
+++ b/backend/schemas/marketing_selection_contextual_criteria.py
@@ -1,0 +1,131 @@
+"""Contextual and self-contained criterion patterns for the selection policy.
+
+Split out of ``marketing_selection_criteria`` when that module crossed the
+900-line gate again (#227 carved the reviewed workflow grammars for the same
+reason; #228 and the population-quantifier fix pushed it back over). Pure
+pattern definitions and the two tuples the clause machine iterates: no
+decisions, no state. The coreference fragments live here because every
+pattern in this family is built from them; the criteria module imports the
+few it embeds in its own grammars.
+"""
+
+from __future__ import annotations
+
+import re
+
+_CRITERION_TAIL = r"(?P<criterion>[^.!?;:]{1,120})"
+_ELIGIBILITY_SUBJECT = (
+    r"(?:(?:their|its)\s+|the\s+(?:group|cohort|audience|segment|population|selection)'?s\s+)?"
+    r"(?:eligibility|qualification)"
+)
+_COREFERENCE_POPULATION = (
+    r"(?:people|persons?|individuals?|residents?|households?|borrowers?|homeowners?|"
+    r"applicants?|recipients?|customers?|prospects?|clients?|owners?|members?|patients?|"
+    r"candidates?|leads?)"
+)
+_COREFERENCE_SUBJECT = (
+    rf"(?:(?:these|those|such|the\s+selected)\s+{_COREFERENCE_POPULATION}|"
+    rf"(?:each|every|all)\s+(?:selected\s+)?{_COREFERENCE_POPULATION}|"
+    r"members?\s+of\s+(?:this|that|the)\s+(?:group|cohort|audience|segment|population)|"
+    r"(?:everyone|everybody|each\s+person|every\s+person)\s+in\s+"
+    r"(?:(?:this|that|the)\s+)?(?:(?:resulting|selected|ranked|ordered)\s+)?"
+    r"(?:list|group|cohort|audience|segment|population)|"
+    r"they(?:\s+all)?|these|those|"
+    r"each(?:\s+one)?(?:\s+of\s+(?:them|these|those))?|"
+    r"every\s+one\s+of\s+(?:them|these|those)|"
+    r"all(?:\s+of\s+(?:them|these|those))?|"
+    r"(?:this|that|the)\s+(?:group|cohort|audience|segment|population|selection)|"
+    rf"(?:the\s+(?:selected\s+)?|){_COREFERENCE_POPULATION})"
+)
+_CONTEXTUAL_SUBJECT_CLAUSE_RE = re.compile(
+    rf"^(?:{_COREFERENCE_SUBJECT}|{_ELIGIBILITY_SUBJECT})\b(?P<predicate>.+)$",
+    re.IGNORECASE,
+)
+
+_ONLY_INCLUDE_CRITERION_RE = re.compile(
+    r"\bonly\s+include\s+(?:those|people|persons?|individuals?|residents?|households?|"
+    r"borrowers?|homeowners?|applicants?)\s+(?:diagnosed\s+with|with|having|"
+    r"whose\s+(?:diagnosis|medical\s+condition|health\s+condition)\s+(?:is|was))\s+"
+    rf"{_CRITERION_TAIL}",
+    re.IGNORECASE,
+)
+_COREFERENCE_REQUIREMENT_RE = re.compile(
+    rf"\b{_COREFERENCE_SUBJECT}\s+(?:"
+    r"must\s+(?:also\s+)?(?:have|meet|show|carry|possess|satisfy)|"
+    r"(?:also\s+)?(?:needs?|requires?))\s+"
+    rf"{_CRITERION_TAIL}",
+    re.IGNORECASE,
+)
+_COREFERENCE_DECLARATIVE_CRITERION_RE = re.compile(
+    rf"\b{_COREFERENCE_SUBJECT}\s+(?:also\s+)?(?:"
+    r"have|has|show|shows|carry|carries|possess|possesses|exhibit|exhibits|"
+    r"present\s+with|presents\s+with)\s+"
+    rf"{_CRITERION_TAIL}",
+    re.IGNORECASE,
+)
+_OBJECT_REQUIREMENT_RE = re.compile(
+    r"(?:^|\b(?:and|but|while)\s+|,\s*)"
+    r"(?P<criterion>[a-z][a-z0-9' -]{0,120}?)\s+"
+    r"(?:(?:is|are|was|were)\s+)?(?<!not\s)(?<!never\s)(?<!no longer\s)"
+    r"(?<!not currently\s)(?<!not presently\s)(?:mandatory|required(?:\s+too)?|"
+    r"an?\s+additional\s+(?:criterion|requirement)|necessary)\b",
+    re.IGNORECASE,
+)
+_PROVIDED_CRITERION_RE = re.compile(
+    rf"\bprovided\s+(?:that\s+)?(?:{_COREFERENCE_SUBJECT}\s+)?"
+    r"(?:have|has|meet|meets|show|shows|carry|carries|possess|possesses|satisfy|satisfies)\s+"
+    rf"{_CRITERION_TAIL}",
+    re.IGNORECASE,
+)
+_DOCUMENTED_FOR_WHOM_RE = re.compile(
+    r"\bfor\s+whom\s+(?P<criterion>[a-z][a-z0-9' -]{0,120}?)\s+"
+    r"(?:(?:is|was)\s+)?(?:documented|verified|confirmed|recorded)\b",
+    re.IGNORECASE,
+)
+_COORDINATE_REQUIRE_RE = re.compile(
+    r"(?:^|\b(?:and|then|but)\s+|,\s*)(?:also\s+)?require\s+" rf"{_CRITERION_TAIL}",
+    re.IGNORECASE,
+)
+_ELIGIBILITY_DEPENDS_RE = re.compile(
+    rf"\b{_ELIGIBILITY_SUBJECT}\s+(?:also\s+)?(?:"
+    r"(?:depends?|hinges?|rests?|relies?)\s+(?:on|upon)|turns?\s+on|"
+    r"is\s+(?:based|conditioned|contingent|dependent)\s+(?:on|upon)|"
+    r"is\s+(?:tied|subject)\s+to)\s+"
+    rf"{_CRITERION_TAIL}",
+    re.IGNORECASE,
+)
+_DETERMINES_ELIGIBILITY_RE = re.compile(
+    r"(?:^|\b(?:and|but|while)\s+|,\s*)"
+    r"(?P<criterion>[a-z][a-z0-9' -]{0,120}?)\s+"
+    r"(?<!never\s)(?<!no longer\s)determines\s+"
+    r"(?:the\s+)?(?:final\s+)?eligibility\b",
+    re.IGNORECASE,
+)
+_ONLY_SELECT_OR_FILTER_BY_RE = re.compile(
+    r"\bonly\s+(?:select|filter)(?:\s+(?:them|those|these|people|persons?|individuals?|"
+    r"households?|borrowers?|homeowners?|applicants?|recipients?|"
+    r"the\s+(?:group|cohort|audience|segment|selection)))?\s+by\s+"
+    rf"{_CRITERION_TAIL}",
+    re.IGNORECASE,
+)
+_FILTER_CRITERION_RE = re.compile(
+    r"\bfilter\s+(?:them|those|these|this\s+(?:group|cohort|audience|segment)|"
+    r"the\s+(?:group|cohort|audience|segment|selection|recipients?))\s+by\s+"
+    rf"{_CRITERION_TAIL}",
+    re.IGNORECASE,
+)
+_CONTEXTUAL_CRITERION_PATTERNS = (
+    _COREFERENCE_REQUIREMENT_RE,
+    _COREFERENCE_DECLARATIVE_CRITERION_RE,
+    _OBJECT_REQUIREMENT_RE,
+    _PROVIDED_CRITERION_RE,
+    _DOCUMENTED_FOR_WHOM_RE,
+    _COORDINATE_REQUIRE_RE,
+    _FILTER_CRITERION_RE,
+)
+_SELF_CONTAINED_CRITERION_PATTERNS = (
+    _ONLY_INCLUDE_CRITERION_RE,
+    _ONLY_SELECT_OR_FILTER_BY_RE,
+    _ELIGIBILITY_DEPENDS_RE,
+    _DETERMINES_ELIGIBILITY_RE,
+)

--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -21,6 +21,7 @@ from backend.schemas.marketing_selection_reviewed_workflows import (
 )
 from backend.schemas.marketing_selection_vocabulary import (
     POPULATION_QUANTIFIER_DIGITS,
+    QUANTIFIED_POPULATION_FRAGMENT,
     REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT,
     REVIEWED_MORTGAGE_ATTRIBUTE_BOUND_LIST_FRAGMENT,
     REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT,
@@ -269,10 +270,24 @@ _PASSIVE_AUDIENCE_SELECTION_OUTCOME_RE = re.compile(
     rf"(?:eligible|qualified|{_AUDIENCE_FORMATION_PARTICIPLE_FRAGMENT})\b",
     re.IGNORECASE,
 )
+# The optional destination span and the causal connectors mirror the
+# admission grammar's ``_DESTINATION_RELATION``/``_CONDITION`` exactly. They
+# close a hole the quantifier battery exposed on 2026-08-13, pre-existing on
+# main and count-free: "The high home equity borrowers are placed into the
+# campaign based on left-handedness." sailed, because the admission grammar
+# cannot parse a reviewed-ATTRIBUTE premodifier (only its closed adjectives),
+# the reviewed premodifier made this machine's population prefix transparent,
+# and this capture required the connector to touch the participle -- so the
+# criterion behind the destination was never read by anything. Every slot
+# added is a closed literal; the captured criterion is judged by the same
+# reviewer the admission grammar uses, so "because of their rate spread"
+# stays exactly as answerable through this capture as through that one.
 _OUTCOME_THEN_CRITERION_RE = re.compile(
     rf"^\s+{_AUDIENCE_PASSIVE_AUX_FRAGMENT}\s+"
-    rf"(?:eligible|qualified|{_AUDIENCE_FORMATION_PARTICIPLE_FRAGMENT})\s+"
-    r"(?:by|according\s+to|based\s+on|using)\s+"
+    rf"(?:eligible|qualified|{_AUDIENCE_FORMATION_PARTICIPLE_FRAGMENT})"
+    r"(?:\s+(?:into|in|to|onto)\s+(?:(?:the|this|that|a|an)\s+)?"
+    r"(?:campaign|cohort|audience|segment|population|list|queue|offer))?\s+"
+    r"(?:by|according\s+to|based\s+on|using|because\s+of|due\s+to|owing\s+to)\s+"
     rf"{_CRITERION_TAIL}$",
     re.IGNORECASE,
 )
@@ -453,9 +468,22 @@ _REVIEWED_BARE_DIRECTIVE_DESTINATION_TAIL = (
 # as an unreviewed criterion, while "Assign the owner." and "Assign owners."
 # were answered (measured 2026-08-13; same family: "Queue a borrower.",
 # "Target a customer.", "Prioritize a lead.", "Shortlist an applicant.").
+# The quantifier slot after the determiner takes a count exactly as the
+# determiner takes an article: "the top 50 borrowers" is the same closed
+# population reference as "the borrowers", sized. Without it the CRITERION-FREE
+# quantified command was the only refused member of its family (measured
+# 2026-08-13): "Add the top 50 borrowers to the campaign." fell past this
+# branch and the bound-population capture below read "the top 50" itself as an
+# unreviewed criterion, while the criterion-CARRYING twin ("... with the
+# highest rate spread ...") answered through the admission grammar -- backwards
+# on both ends, since a count quantifies a population and names nobody. The
+# slot is the shared closed fragment (optional top|best|next|first plus
+# digits), so no open vocabulary rides in: "Add the top 50 left-handed
+# borrowers ..." still breaks the shape and still fails closed.
 _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE = re.compile(
     rf"^{_AUDIENCE_DIRECTIVE_PREFIX_FRAGMENT}"
     rf"{_AUDIENCE_FORMATION_COMMAND_FRAGMENT}\s+(?:(?:the|an?)\s+)?"
+    rf"(?:{QUANTIFIED_POPULATION_FRAGMENT}\s+)?"
     rf"(?:(?:reviewed|eligible|qualified|marketing[- ]?eligible|highest[- ]?scoring)\s+){{0,2}}"
     rf"{_AUDIENCE_DECISION_REFERENCE}"
     r"(?:\s+(?:for\s+(?:(?:this|the|a|an)\s+)?(?:reviewed\s+)?"
@@ -466,6 +494,7 @@ _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE = re.compile(
 _REVIEWED_PRENOMINAL_AUDIENCE_DIRECTIVE_RE = re.compile(
     rf"^{_AUDIENCE_DIRECTIVE_PREFIX_FRAGMENT}"
     rf"{_AUDIENCE_FORMATION_COMMAND_FRAGMENT}\s+(?:the\s+)?"
+    rf"(?:{QUANTIFIED_POPULATION_FRAGMENT}\s+)?"
     rf"(?:{REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT})\s+"
     rf"{_AUDIENCE_DECISION_REFERENCE}"
     # The scope precedes the destination tail because both can appear, and in
@@ -558,12 +587,17 @@ def _is_reviewed_pre_population_binding(value: str) -> bool:
         # ``a``/``an`` joins the list because the bound-population capture
         # hands this function the bare article: "assign an owner" captured
         # criterion "an" and refused while the ``the`` twin was answered
-        # (measured 2026-08-13). Only the determiner is transparent: whatever
+        # (measured 2026-08-13). The quantifier phrase joins for the same
+        # reason on the same day: declarative formation clauses never reach
+        # the imperative allow branches, so "We picked the top 50 borrowers
+        # for the campaign." captured "the top 50" here and refused while the
+        # count-free twin was answered. A count sizes the population; it is
+        # not the criterion. Only the determiner run is transparent: whatever
         # remains after stripping must still full-match the reviewed
-        # vocabulary below.
-        r"^(?:(?:the|an?|these|those|all|any|our|your|only|reviewed|eligible|qualified|"
-        r"marketing[- ]?eligible|highest[- ]?scoring|prospective|current|"
-        r"(?:which|what)(?:\s+of)?)(?:\s+|$))+",
+        # vocabulary below, so "the top 50 left-handed" still fails closed.
+        rf"^(?:(?:the|an?|these|those|all|any|our|your|only|reviewed|eligible|qualified|"
+        rf"marketing[- ]?eligible|highest[- ]?scoring|prospective|current|"
+        rf"(?:which|what)(?:\s+of)?|{QUANTIFIED_POPULATION_FRAGMENT})(?:\s+|$))+",
         "",
         criterion,
         flags=re.IGNORECASE,
@@ -616,6 +650,18 @@ def _is_reviewed_admission_criterion(value: str) -> bool:
         flags=re.IGNORECASE,
     )
     criterion = re.sub(r"^(?:their|the)\s+", "", criterion, flags=re.IGNORECASE)
+    # The criterion-first admission shapes ("<criterion> borrowers are placed
+    # into the campaign") capture everything left of the population noun, so a
+    # count rides in front of the real criterion: "The top 50 high equity
+    # borrowers are placed into the campaign." captured "the top 50 high
+    # equity" and refused while the count-free twin answered (measured
+    # 2026-08-13). The quantifier phrase is transparent -- it sizes the
+    # population -- and ONLY the phrase: what remains must still full-match
+    # the reviewed vocabulary, and a bare count strips to empty, which proves
+    # no criterion and keeps the unproved-relation refusal.
+    criterion = re.sub(
+        rf"^{QUANTIFIED_POPULATION_FRAGMENT}(?:\s+|$)", "", criterion, flags=re.IGNORECASE
+    )
     criterion = re.sub(
         r"\s+(?:is|are|was|were)\s+"
         r"(?:present|current|active|documented|verified|confirmed|recorded)$",
@@ -724,13 +770,10 @@ def _contains_unreviewed_audience_decision(
         ):
             return True
         post_outcome_criterion = _OUTCOME_THEN_CRITERION_RE.fullmatch(suffix)
-        if post_outcome_criterion is not None:
-            criterion = _normalize_criterion(post_outcome_criterion.group("criterion"))
-            if not (
-                matches_reviewed_mortgage_attribute(criterion)
-                or is_closed_reviewed_segment_signal_criterion(criterion)
-            ):
-                return True
+        if post_outcome_criterion is not None and not _is_reviewed_admission_criterion(
+            post_outcome_criterion.group("criterion")
+        ):
+            return True
         passive_selection = _PASSIVE_AUDIENCE_SELECTION_OUTCOME_RE.search(suffix)
         make_cut = _AUDIENCE_MAKE_CUT_OUTCOME_RE.search(suffix)
         decision_outcome = passive_selection or make_cut

--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -8,6 +8,14 @@ from backend.schemas.growth_agent_segment_intent import (
     is_closed_reviewed_segment_signal_criterion,
 )
 from backend.schemas.marketing_audience_admission import audience_admission_criterion
+from backend.schemas.marketing_selection_contextual_criteria import (
+    _CONTEXTUAL_CRITERION_PATTERNS,
+    _CONTEXTUAL_SUBJECT_CLAUSE_RE,
+    _COREFERENCE_POPULATION,
+    _COREFERENCE_SUBJECT,
+    _CRITERION_TAIL,
+    _SELF_CONTAINED_CRITERION_PATTERNS,
+)
 from backend.schemas.marketing_selection_reviewed_analytics import (
     _REVIEWED_ANALYSIS_PREAMBLE_RE,
     _REVIEWED_READ_ONLY_ANALYTIC_PATTERNS,
@@ -29,123 +37,6 @@ from backend.schemas.marketing_selection_vocabulary import (
     matches_reviewed_mortgage_attribute,
     reviewed_attribute_scope_fragment,
     reviewed_fullmatch,
-)
-
-_CRITERION_TAIL = r"(?P<criterion>[^.!?;:]{1,120})"
-_ELIGIBILITY_SUBJECT = (
-    r"(?:(?:their|its)\s+|the\s+(?:group|cohort|audience|segment|population|selection)'?s\s+)?"
-    r"(?:eligibility|qualification)"
-)
-_COREFERENCE_POPULATION = (
-    r"(?:people|persons?|individuals?|residents?|households?|borrowers?|homeowners?|"
-    r"applicants?|recipients?|customers?|prospects?|clients?|owners?|members?|patients?|"
-    r"candidates?|leads?)"
-)
-_COREFERENCE_SUBJECT = (
-    rf"(?:(?:these|those|such|the\s+selected)\s+{_COREFERENCE_POPULATION}|"
-    rf"(?:each|every|all)\s+(?:selected\s+)?{_COREFERENCE_POPULATION}|"
-    r"members?\s+of\s+(?:this|that|the)\s+(?:group|cohort|audience|segment|population)|"
-    r"(?:everyone|everybody|each\s+person|every\s+person)\s+in\s+"
-    r"(?:(?:this|that|the)\s+)?(?:(?:resulting|selected|ranked|ordered)\s+)?"
-    r"(?:list|group|cohort|audience|segment|population)|"
-    r"they(?:\s+all)?|these|those|"
-    r"each(?:\s+one)?(?:\s+of\s+(?:them|these|those))?|"
-    r"every\s+one\s+of\s+(?:them|these|those)|"
-    r"all(?:\s+of\s+(?:them|these|those))?|"
-    r"(?:this|that|the)\s+(?:group|cohort|audience|segment|population|selection)|"
-    rf"(?:the\s+(?:selected\s+)?|){_COREFERENCE_POPULATION})"
-)
-_CONTEXTUAL_SUBJECT_CLAUSE_RE = re.compile(
-    rf"^(?:{_COREFERENCE_SUBJECT}|{_ELIGIBILITY_SUBJECT})\b(?P<predicate>.+)$",
-    re.IGNORECASE,
-)
-
-_ONLY_INCLUDE_CRITERION_RE = re.compile(
-    r"\bonly\s+include\s+(?:those|people|persons?|individuals?|residents?|households?|"
-    r"borrowers?|homeowners?|applicants?)\s+(?:diagnosed\s+with|with|having|"
-    r"whose\s+(?:diagnosis|medical\s+condition|health\s+condition)\s+(?:is|was))\s+"
-    rf"{_CRITERION_TAIL}",
-    re.IGNORECASE,
-)
-_COREFERENCE_REQUIREMENT_RE = re.compile(
-    rf"\b{_COREFERENCE_SUBJECT}\s+(?:"
-    r"must\s+(?:also\s+)?(?:have|meet|show|carry|possess|satisfy)|"
-    r"(?:also\s+)?(?:needs?|requires?))\s+"
-    rf"{_CRITERION_TAIL}",
-    re.IGNORECASE,
-)
-_COREFERENCE_DECLARATIVE_CRITERION_RE = re.compile(
-    rf"\b{_COREFERENCE_SUBJECT}\s+(?:also\s+)?(?:"
-    r"have|has|show|shows|carry|carries|possess|possesses|exhibit|exhibits|"
-    r"present\s+with|presents\s+with)\s+"
-    rf"{_CRITERION_TAIL}",
-    re.IGNORECASE,
-)
-_OBJECT_REQUIREMENT_RE = re.compile(
-    r"(?:^|\b(?:and|but|while)\s+|,\s*)"
-    r"(?P<criterion>[a-z][a-z0-9' -]{0,120}?)\s+"
-    r"(?:(?:is|are|was|were)\s+)?(?<!not\s)(?<!never\s)(?<!no longer\s)"
-    r"(?<!not currently\s)(?<!not presently\s)(?:mandatory|required(?:\s+too)?|"
-    r"an?\s+additional\s+(?:criterion|requirement)|necessary)\b",
-    re.IGNORECASE,
-)
-_PROVIDED_CRITERION_RE = re.compile(
-    rf"\bprovided\s+(?:that\s+)?(?:{_COREFERENCE_SUBJECT}\s+)?"
-    r"(?:have|has|meet|meets|show|shows|carry|carries|possess|possesses|satisfy|satisfies)\s+"
-    rf"{_CRITERION_TAIL}",
-    re.IGNORECASE,
-)
-_DOCUMENTED_FOR_WHOM_RE = re.compile(
-    r"\bfor\s+whom\s+(?P<criterion>[a-z][a-z0-9' -]{0,120}?)\s+"
-    r"(?:(?:is|was)\s+)?(?:documented|verified|confirmed|recorded)\b",
-    re.IGNORECASE,
-)
-_COORDINATE_REQUIRE_RE = re.compile(
-    r"(?:^|\b(?:and|then|but)\s+|,\s*)(?:also\s+)?require\s+" rf"{_CRITERION_TAIL}",
-    re.IGNORECASE,
-)
-_ELIGIBILITY_DEPENDS_RE = re.compile(
-    rf"\b{_ELIGIBILITY_SUBJECT}\s+(?:also\s+)?(?:"
-    r"(?:depends?|hinges?|rests?|relies?)\s+(?:on|upon)|turns?\s+on|"
-    r"is\s+(?:based|conditioned|contingent|dependent)\s+(?:on|upon)|"
-    r"is\s+(?:tied|subject)\s+to)\s+"
-    rf"{_CRITERION_TAIL}",
-    re.IGNORECASE,
-)
-_DETERMINES_ELIGIBILITY_RE = re.compile(
-    r"(?:^|\b(?:and|but|while)\s+|,\s*)"
-    r"(?P<criterion>[a-z][a-z0-9' -]{0,120}?)\s+"
-    r"(?<!never\s)(?<!no longer\s)determines\s+"
-    r"(?:the\s+)?(?:final\s+)?eligibility\b",
-    re.IGNORECASE,
-)
-_ONLY_SELECT_OR_FILTER_BY_RE = re.compile(
-    r"\bonly\s+(?:select|filter)(?:\s+(?:them|those|these|people|persons?|individuals?|"
-    r"households?|borrowers?|homeowners?|applicants?|recipients?|"
-    r"the\s+(?:group|cohort|audience|segment|selection)))?\s+by\s+"
-    rf"{_CRITERION_TAIL}",
-    re.IGNORECASE,
-)
-_FILTER_CRITERION_RE = re.compile(
-    r"\bfilter\s+(?:them|those|these|this\s+(?:group|cohort|audience|segment)|"
-    r"the\s+(?:group|cohort|audience|segment|selection|recipients?))\s+by\s+"
-    rf"{_CRITERION_TAIL}",
-    re.IGNORECASE,
-)
-_CONTEXTUAL_CRITERION_PATTERNS = (
-    _COREFERENCE_REQUIREMENT_RE,
-    _COREFERENCE_DECLARATIVE_CRITERION_RE,
-    _OBJECT_REQUIREMENT_RE,
-    _PROVIDED_CRITERION_RE,
-    _DOCUMENTED_FOR_WHOM_RE,
-    _COORDINATE_REQUIRE_RE,
-    _FILTER_CRITERION_RE,
-)
-_SELF_CONTAINED_CRITERION_PATTERNS = (
-    _ONLY_INCLUDE_CRITERION_RE,
-    _ONLY_SELECT_OR_FILTER_BY_RE,
-    _ELIGIBILITY_DEPENDS_RE,
-    _DETERMINES_ELIGIBILITY_RE,
 )
 
 _AUDIENCE_DECISION_REFERENCE = (

--- a/backend/schemas/marketing_selection_vocabulary.py
+++ b/backend/schemas/marketing_selection_vocabulary.py
@@ -84,6 +84,29 @@ _REVIEWED_ATTRIBUTE_ARTICLE = r"(?:(?:an?|the)\s+)?"
 POPULATION_QUANTIFIER_DIGITS = r"(?:[0-9]{1,3}(?:,[0-9]{3})*|[0-9]+)"
 POPULATION_QUANTIFIER_FRAGMENT = POPULATION_QUANTIFIER_DIGITS
 
+# The closed lead words a count composes with: "the TOP 50 borrowers", "the
+# NEXT 1,000 leads", "the BEST 25 customers", "the FIRST 100 applicants".
+#
+# The lead word admits nothing alone -- every embedding site couples it to the
+# digits, so a count-free "the top borrowers" keeps whatever verdict its
+# grammar gives it today. The pair still names no criterion: it says how MANY
+# of an already-formed ranking to take, never who ranks. Without it the
+# CRITERION-FREE quantified command was the only refused member of its family
+# (measured 2026-08-13): "Add the top 50 borrowers to the campaign." refused
+# as ``unreviewed_criterion`` while "Add the top 50 borrowers with the highest
+# rate spread to the campaign." answered -- the criterion-carrying form parsed
+# through the admission grammar's open action slot, and the criterion-free
+# form had no slot for the count anywhere.
+#
+# A LITERAL four-word alternation on purpose, never an open adjective slot and
+# never a fold image: a de-obfuscated variant that mints "b3st" -> "best"
+# still refuses on the original string, which is the direction the variant
+# combiner fails.
+POPULATION_QUANTIFIER_LEAD_WORDS = r"(?:top|best|next|first)"
+QUANTIFIED_POPULATION_FRAGMENT = (
+    rf"(?:{POPULATION_QUANTIFIER_LEAD_WORDS}\s+)?{POPULATION_QUANTIFIER_FRAGMENT}"
+)
+
 REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT = (
     rf"{_REVIEWED_ATTRIBUTE_ARTICLE}"
     # An aggregate qualifier is a DESCRIPTOR of a reviewed attribute, not a new

--- a/tests/unit/test_bare_directive_destination_tail.py
+++ b/tests/unit/test_bare_directive_destination_tail.py
@@ -128,7 +128,13 @@ _CLOSED_SHAPE_KEEPS_FAILING_CLOSED = (
     "Add borrowers to the queue to hide the audit trail.",
     "Assign an owner to this campaign for the review.",
     "Assign a zyrplax borrower to the campaign.",
-    "Add the top 50 borrowers to the campaign.",
+    # "Add the top 50 borrowers to the campaign." sat here as a closed-shape
+    # control, but it was pinning the NEXT false positive, not a control: a
+    # count quantifies the population and names no criterion, and the
+    # quantifier slot admitted it on 2026-08-13. Its family now lives in
+    # ``test_population_quantifier_parity``; the open-vocabulary twin keeps
+    # the fail-closed seat.
+    "Add the top 50 zyrplax borrowers to the campaign.",
 )
 
 

--- a/tests/unit/test_population_quantifier_parity.py
+++ b/tests/unit/test_population_quantifier_parity.py
@@ -1,0 +1,224 @@
+"""A count quantifies a population; the criterion-free quantified command answers.
+
+Pre-existing false positive, measured 2026-08-13: "Add the top 50 borrowers
+to the campaign." and "Add the top 50 borrowers." both refused as
+``unreviewed_criterion`` while "Add the top 50 borrowers with the highest
+rate spread to the campaign." answered -- the CRITERION-FREE quantified
+command was the only refused member of its family, backwards twice over: a
+count quantifies a population and names no criterion (#218 doctrine), and
+the criterion-carrying form is the one that binds more, not less.
+
+The criterion-carrying form parsed because the admission grammar's open
+action slot absorbed "add the top" and the #218 quantifier slot took "50".
+No criterion-free branch had a slot for the count anywhere, so the family
+refused through five distinct sites, each measured with a flipping twin:
+
+* the bare-directive allow branch ("Add the top 50 borrowers to the
+  campaign." / "Add the top 50 eligible borrowers to the campaign."),
+* the prenominal-attribute allow branch ("Select the top 50 high home
+  equity borrowers."),
+* the bound-population capture, which read "the top 50" ITSELF as the
+  unreviewed criterion in declarative clauses no imperative branch sees
+  ("We picked the top 50 borrowers for the campaign."),
+* the admission grammar's passive shapes, where no open action slot exists
+  to absorb the lead word ("The top 50 high equity borrowers are placed
+  into the campaign."), and
+* the admission-criterion reviewer, handed "the top 50 high equity" by the
+  criterion-first passive capture.
+
+Fix: one shared closed fragment -- an optional literal lead word
+(top|best|next|first) plus ``POPULATION_QUANTIFIER_DIGITS`` -- embedded at
+all five sites, allow side and fail-closed side together, per the
+numeric-quantifier-blind-lead-ins pattern. The lead word admits nothing
+alone ("Add the top borrowers ..." keeps refusing), the digits admit
+nothing anywhere (never an open adjective slot), and the admission
+``_MODIFIERS`` half is load-bearing for fail-closed parity: without it,
+teaching the criterion machine that a count is transparent would have let
+"The top 50 borrowers are placed into the campaign based on <unreviewed
+term>." prove no relation and sail past the criterion capture.
+
+The battery then caught what the first cut of this fix would have cost, and
+two closures rode along because of it:
+
+* the admission ``_MODIFIERS`` run sat only IN FRONT of the count, so "the
+  50 ELIGIBLE borrowers" proved no relation -- once the count was
+  transparent, "The 50 eligible borrowers are placed into the campaign
+  based on left-handedness." sailed past both nets (105 probes). The run
+  now also follows the count, adjectives only.
+* count-free and PRE-EXISTING on main: "The high home equity borrowers are
+  placed into the campaign based on left-handedness." sailed, because a
+  reviewed-attribute premodifier parses in neither grammar and the
+  post-outcome capture required its connector to touch the participle. The
+  capture now reads through a closed destination span and the admission
+  grammar's causal connectors, and judges the criterion with the admission
+  reviewer.
+
+Differential battery, 4,200 verdict probes x four surfaces plus a 530-probe
+admission-deletion name battery, base (main 26b3ae56) vs fix -- results
+recorded in the PR description; every gain criterion-free or
+reviewed-criterion with a base-allowed count-free twin, every loss an
+unreviewed/banked condition riding a passive destination (the hole above,
+closed), zero reason shifts, zero name-detection changes.
+
+Every refusal below asserts the EXACT reason string: ``is not None`` passes
+through a silent reclassification.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.schemas._validators_unsafe_text import contains_unsafe_ai_text
+from backend.schemas.marketing_selection_criteria import (
+    _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE,
+)
+from backend.services.genie_message_policy import (
+    identity_prompt_match,
+    protected_prompt_match,
+)
+
+# The admitted family, one row per measured flipping site: imperative bare
+# and destination-tailed forms across counts and lead words, the closed
+# premodifier composition, the prenominal reviewed attribute, declarative
+# formation, and the passive admission shapes.
+_QUANTIFIED_CRITERION_FREE_ANSWERABLE = (
+    "Add the top 50 borrowers to the campaign.",
+    "Add the top 50 borrowers.",
+    "Add 50 borrowers to the campaign.",
+    "Add the top 1,000 borrowers to the campaign.",
+    "Queue the next 25 leads.",
+    "Shortlist the best 10 customers for the campaign.",
+    "Move the first 100 borrowers into the queue.",
+    "Add the top 50 eligible borrowers to the campaign.",
+    "Select the top 50 high home equity borrowers.",
+    "We picked the top 50 borrowers for the campaign.",
+    "We shortlisted the best 25 customers for the offer.",
+    "The top 50 high equity borrowers are placed into the campaign.",
+    "The top 50 borrowers are placed into the campaign based on rate spread.",
+    # The criterion-carrying twin that always answered; pinned so the family
+    # can never split again.
+    "Add the top 50 borrowers with the highest rate spread to the campaign.",
+)
+
+
+@pytest.mark.parametrize("prompt", _QUANTIFIED_CRITERION_FREE_ANSWERABLE)
+def test_a_quantified_criterion_free_command_is_answerable(prompt: str) -> None:
+    assert protected_prompt_match(prompt) is None, prompt
+
+
+def test_the_bare_directive_branch_owns_the_quantifier_slot() -> None:
+    """Branch attribution: reroutes of this family should be visible, not silent."""
+
+    for clause in (
+        "add the top 50 borrowers to the campaign",
+        "add 50 borrowers to the campaign",
+        "queue the next 25 leads",
+        "add the top 1,000 eligible borrowers to the campaign",
+    ):
+        assert _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE.fullmatch(clause) is not None, clause
+    # The closed shape: a count-free lead word, an open adjective riding the
+    # slot, or a fold-image lead word each break the anchor.
+    for clause in (
+        "add the top borrowers to the campaign",
+        "add the top 50 left-handed borrowers to the campaign",
+        "add the b3st 50 borrowers to the campaign",
+    ):
+        assert _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE.fullmatch(clause) is None, clause
+
+
+# ---------------------------------------------------------------------------
+# Invariants -- green on BOTH sides of the fix. The refusal this change
+# removed bought nothing these machines do not already own.
+
+_COUNT_FREE_LEAD_WORD_KEEPS_ITS_VERDICT = (
+    # The lead word alone is NOT admitted by this change: whether "the top
+    # borrowers" should answer is a separate widening with its own battery.
+    "Add the top borrowers to the campaign.",
+    "Add the best customers to the campaign.",
+)
+
+
+@pytest.mark.parametrize("prompt", _COUNT_FREE_LEAD_WORD_KEEPS_ITS_VERDICT)
+def test_a_count_free_lead_word_still_fails_closed(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "unreviewed_criterion", prompt
+
+
+_CLOSED_SHAPE_KEEPS_FAILING_CLOSED = (
+    # An unreviewed word anywhere still breaks every shape the count now
+    # fits: pre-population modifier, unreviewed with-criterion, unreviewed
+    # passive condition, fold-image lead word, and the count riding where
+    # only a criterion may stand.
+    "Add the top 50 left-handed borrowers to the campaign.",
+    "Add the top 50 zyrplax borrowers to the campaign.",
+    "Add the b3st 50 borrowers to the campaign.",
+    "The top 50 borrowers are placed into the campaign based on left-handedness.",
+    "The top 50 borrowers are moved into the campaign.",
+    "The top 50 borrowers are selected for the campaign.",
+    # The two fail-opens the battery caught, pinned at their worst: the
+    # closed premodifier AFTER the count, and the reviewed-attribute
+    # premodifier that parses in neither grammar -- count-free, this second
+    # shape sailed on main before this change.
+    "The 50 eligible borrowers are placed into the campaign based on left-handedness.",
+    "The top 50 eligible borrowers are placed into the campaign based on left-handedness.",
+    "The high home equity borrowers are placed into the campaign based on left-handedness.",
+    "The top 50 high home equity borrowers are placed into the campaign based on left-handedness.",
+    "The qualified borrowers are routed to the queue because of left-handedness.",
+)
+
+
+_PASSIVE_DESTINATION_REVIEWED_CONDITIONS_ANSWER = (
+    # The closure above must not cost the reviewed twins: the same passive
+    # destination shapes with a reviewed condition keep answering, premod or
+    # not, count or not, ``their`` or not.
+    "The high home equity borrowers are placed into the campaign based on rate spread.",
+    "The top 50 eligible borrowers are placed into the campaign based on rate spread.",
+    "The eligible borrowers are placed into the campaign because of their rate spread.",
+)
+
+
+@pytest.mark.parametrize("prompt", _PASSIVE_DESTINATION_REVIEWED_CONDITIONS_ANSWER)
+def test_a_reviewed_condition_behind_a_destination_still_answers(prompt: str) -> None:
+    assert protected_prompt_match(prompt) is None, prompt
+
+
+@pytest.mark.parametrize("prompt", _CLOSED_SHAPE_KEEPS_FAILING_CLOSED)
+def test_anything_outside_the_closed_shape_still_fails_closed(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "unreviewed_criterion", prompt
+
+
+_TERM_BANKS_KEEP_THE_BANKED_TWINS = (
+    "Add the top 50 borrowers with eczema to the campaign.",
+    "Add the top 50 patients to the campaign.",
+    "The top 50 borrowers are placed into the campaign based on eczema.",
+)
+
+
+@pytest.mark.parametrize("prompt", _TERM_BANKS_KEEP_THE_BANKED_TWINS)
+def test_the_term_banks_still_own_the_banked_twins(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "protected_class_language", prompt
+
+
+def test_a_count_cannot_launder_a_coordinated_unsafe_object() -> None:
+    """#218's laundering pins hold with the new slots in place."""
+
+    for prompt in (
+        "Add the top 1,000 borrowers with a rate spread for the campaign and eczema.",
+        "Add the top 50 borrowers with the home equity and credit score to the campaign.",
+    ):
+        assert protected_prompt_match(prompt) is not None, prompt
+
+
+def test_person_names_stay_with_the_identity_scan() -> None:
+    """The count must not change which surface owns a person name."""
+
+    assert identity_prompt_match("Assign Maria Garcia to this campaign.") is True
+    assert identity_prompt_match("Add the top 50 borrowers to the campaign.") is False
+
+
+def test_campaign_copy_surface_moves_with_the_prompt_surface() -> None:
+    """The strict surface admits the quantified command and keeps the controls."""
+
+    assert contains_unsafe_ai_text("Add the top 50 borrowers to the campaign.") is False
+    assert contains_unsafe_ai_text("We picked the top 50 borrowers for the campaign.") is False
+    assert contains_unsafe_ai_text("Add the top 50 zyrplax borrowers to the campaign.") is True
+    assert contains_unsafe_ai_text("Add the top 50 borrowers with eczema to the campaign.") is True


### PR DESCRIPTION
## What

A count quantifies a population; it names no criterion. The CRITERION-FREE quantified command was the only refused member of its family (measured 2026-08-13, pre-existing on main):

- `Add the top 50 borrowers to the campaign.` → `unreviewed_criterion`
- `Add the top 50 borrowers.` → `unreviewed_criterion`
- `Add the top 50 borrowers with the highest rate spread to the campaign.` → answered

Backwards twice over per #218 doctrine: the count selects nobody, and the criterion-carrying form is the one that binds more. The carrying form only parsed because the admission grammar's open action slot absorbed "add the top" and the #218 quantifier slot took "50"; no criterion-free branch had a slot for the count anywhere.

## Where it was broken — six families, five sites, two modules

Twin-measured (count flips the verdict, count-free twin answers):

| Family | Example |
|---|---|
| bare directive | `Add the top 50 borrowers to the campaign.` / bare counts / `1,000` / `next 25` / `best 10` |
| closed premodifier | `Add the top 50 eligible borrowers to the campaign.` |
| prenominal attribute | `Select the top 50 high home equity borrowers.` |
| declarative formation | `We picked the top 50 borrowers for the campaign.` |
| criterion-first passive | `The top 50 high equity borrowers are placed into the campaign.` |
| condition-tailed passive | `The top 50 borrowers are placed into the campaign based on rate spread.` |

Fix: one shared closed fragment in `marketing_selection_vocabulary` — `(?:top|best|next|first)?` + `POPULATION_QUANTIFIER_DIGITS`, never an open adjective slot — embedded at five sites, allow side and fail-closed side together (the numeric-quantifier-blind-lead-ins pattern):

1. `_REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE` (allow)
2. `_REVIEWED_PRENOMINAL_AUDIENCE_DIRECTIVE_RE` (allow)
3. `_is_reviewed_pre_population_binding` transparent strip (fail-closed)
4. admission `_MODIFIERS` quantifier slot gains the lead word (fail-closed parity — without it, a transparent count would have let condition-tailed passives prove no relation and sail past the criterion capture)
5. `_is_reviewed_admission_criterion` transparent strip (criterion-first passive capture)

## What the battery caught, and the two closures that rode along

The differential battery caught 105 fail-opens the first cut would have shipped, plus a pre-existing hole:

- **Admission premodifier order**: `_MODIFIERS` put its closed run only IN FRONT of the count, but English puts adjectives after it — `The 50 eligible borrowers are placed into the campaign based on left-handedness.` sailed past both nets once the count was transparent. The run now also follows the count (adjectives only, no second determiner).
- **Pre-existing, count-free, on main**: `The high home equity borrowers are placed into the campaign based on left-handedness.` sails on main today — a reviewed-ATTRIBUTE premodifier parses in neither grammar, and the post-outcome capture required its connector to touch the participle, so the criterion behind the destination was never read by anything. `_OUTCOME_THEN_CRITERION_RE` now reads through a closed destination span with the admission grammar's causal connectors, and judges the criterion with the admission reviewer (so `because of their rate spread` stays answerable).

## Differential battery (base = main 26b3ae56 vs fix)

4,200 verdict probes × four surfaces (`protected_prompt_match`, `protected_class_marketing_reason`, `contains_unsafe_ai_text`, `identity_prompt_match`) + 530-probe admission-deletion name battery (`contains_borrower_copy_contextual_name`, including post-quantifier premodifier shapes):

- **4,077 gains** — 1,386 criterion-free + 2,691 reviewed-criterion; trigger-removal attribution: **zero** gains whose count-free twin is base-refused; **zero** gains carrying a banked/unreviewed/fold token.
- **12 unique loss probes** (30 surface-rows) — every one the pre-existing passive-destination hole above (`high home equity … based on left-handedness / maria garcia` and `top`-only variants), i.e. deliberate closures; **zero** losses on clean vocabulary.
- **Zero** reason shifts among still-refused probes.
- **Zero** name-detection changes (the `_MODIFIERS` widening does not move the identity-scan deletion boundary on any measured shape).

Controls that hold on both sides: banked terms keep their owners (`…with eczema…` → `protected_class_language`), open vocabulary still fails closed (`top 50 left-handed borrowers`, `top 50 zyrplax borrowers`), the count-free lead word is NOT admitted (`Add the top borrowers…` still refuses — separate widening, separately decidable), fold images are not lead words (`b3st 50` refuses), and #218's laundering pins stay green.

## Tests

- New `tests/unit/test_population_quantifier_parity.py`: family pins, closed-shape controls, hole-closure pins, reviewed-condition-behind-destination pins, branch attribution.
- `tests/unit/test_bare_directive_destination_tail.py`: `Add the top 50 borrowers to the campaign.` moved out of the fail-closed list — it sat there as a closed-shape control but was pinning this false positive; the open-vocabulary twin (`top 50 zyrplax`) keeps the fail-closed seat.

Rebased onto #228 (hyphen-fold compounds); conflicts were the two lines where both changes met, resolved by taking both, and the battery re-baselined against the new main — classification identical. Composition verified: `Add the top 50 marketing-eligible borrowers to the campaign.` answers, the fold-composed launder still refuses.

Second commit: the rebase left `marketing_selection_criteria.py` at 905/900, so the contextual criterion patterns move to their own module (`marketing_selection_contextual_criteria`, the #227 pattern — split, never allowlist). Pure move, proven by AST def-set diff (18 moved + 45 remaining = 63 original, nothing missing) and the full suite.

Gates: full `pytest tests/unit`, `ruff`, `mypy backend`, `tools/check_file_sizes.py` all green locally on the final tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
