### PR TITLE
fix(guards): the plural of a banked health adjective names the same population

### DIFF
--- a/backend/schemas/marketing_safety_terms.py
+++ b/backend/schemas/marketing_safety_terms.py
@@ -391,7 +391,15 @@ def _build_health_trait_fragments(
     medical_condition = (
         rf"(?:{dotted_medical_conditions}|{condition_abbreviations}|{named_conditions}|"
         rf"{condition_morphology}|"
-        r"heart[- ]attack|diabetic|asthmatic|hiv(?:[- ]positive)?|epileptic|"
+        # The banked condition ADJECTIVES double as population nouns in the
+        # plural ("add diabetics to this campaign"), and the trailing word
+        # boundary every consumer applies means the singular literal can never
+        # reach them. Each plural is enumerated with ``s?`` — a closed two-form
+        # spelling for exactly these three terms, not a morphological rule
+        # applied across the bank (2026-08-13 admission-command capture: the
+        # singular refused on all three guard surfaces while the plural passed
+        # every one).
+        r"heart[- ]attack|diabetics?|asthmatics?|hiv(?:[- ]positive)?|epileptics?|"
         r"terminal[- ]illness(?:es)?|terminally[- ]ill|"
         r"(?:chronic|serious|long[- ]term|terminal|acute)\s+(?:illness(?:es)?|disease|"
         r"conditions?|diagnos(?:is|es)|disorders?|syndromes?)|"

--- a/tests/unit/test_health_population_plural_parity.py
+++ b/tests/unit/test_health_population_plural_parity.py
@@ -1,0 +1,122 @@
+"""Singular/plural parity on the banked health-condition population nouns.
+
+"Add diabetics to this campaign." passed every guard surface while "Assign a
+diabetic." and "Add diabetic borrowers to this campaign." refused
+(pre-existing gap, measured 2026-08-13 during the destination-tail fix). The
+three banked condition ADJECTIVES (``diabetic``, ``asthmatic``, ``epileptic``)
+lived in the trait bank as singular literals only, and every consumer wraps
+the trait in a trailing word boundary, so the plural population noun could
+never match: the vocabulary listed the adjective, not the noun that names the
+population.
+
+The fix enumerates exactly those three plural forms (``s?`` on the literals) —
+a closed spelling, not a morphological rule across the bank. The stems have
+one definition site (``_build_health_trait_fragments``), so the term detector,
+the status/governance binders, and the compliance safe-context mask all move
+together.
+
+Fix battery, 30 cases x four verdicts (prompt, marketing reason, its analytics
+variant, campaign copy): 10 gains, every one a plural form of an
+already-refused singular; 0 losses; every trigger-removed frame stays
+answerable; the dotted/spaced plural evasions already refused at base through
+the dotted singular's trailing boundary and are pinned below.
+
+Out of scope, deliberately: sibling person-noun stems whose SINGULAR is not
+banked either (schizophrenic, alcoholic, paraplegic, hemophiliac, ...) are a
+different gap — the stem is absent, not the plural — and are pinned in
+neither direction here.
+
+Every refusal asserts the EXACT reason string: ``is not None`` would pass
+through a silent reclassification into the fail-closed criterion machine.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.schemas._validators_protected_class import protected_class_marketing_reason
+from backend.schemas._validators_unsafe_text import contains_unsafe_ai_text
+from backend.services.genie_message_policy import protected_prompt_match
+
+_BANKED_STEMS = ("diabetic", "asthmatic", "epileptic")
+
+
+@pytest.mark.parametrize("stem", _BANKED_STEMS)
+def test_the_plural_population_noun_refuses_like_its_singular(stem: str) -> None:
+    """MS≡TX doctrine: the two forms of one banked term carry one verdict."""
+
+    article = "an" if stem[0] in "aeiou" else "a"
+    singular = f"Assign {article} {stem}."
+    plural = f"Add {stem}s to this campaign."
+    assert protected_prompt_match(singular) == "protected_class_language", singular
+    assert protected_prompt_match(plural) == "protected_class_language", plural
+
+
+_PLURAL_ADMISSION_FORMS = (
+    "Add diabetics to this campaign.",
+    "Add asthmatics to this campaign.",
+    "Add epileptics to this campaign.",
+    "Target diabetics.",
+    "Filter to diabetics only.",
+    "Email asthmatics about the HELOC offer.",
+    "Build a segment of epileptics.",
+    "Add Diabetics to this campaign.",
+    "ADD DIABETICS TO THIS CAMPAIGN.",
+    "Which diabetics should we contact first?",
+)
+
+
+@pytest.mark.parametrize("prompt", _PLURAL_ADMISSION_FORMS)
+def test_a_plural_health_population_refuses_on_every_surface(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "protected_class_language", prompt
+    assert protected_class_marketing_reason(prompt) == "protected_class", prompt
+    assert (
+        protected_class_marketing_reason(prompt, assume_reviewed_read_only_analytics=True)
+        == "protected_class"
+    ), prompt
+    assert contains_unsafe_ai_text(prompt) is True, prompt
+
+
+# ---------------------------------------------------------------------------
+# Invariants -- green on BOTH sides of the fix.
+
+_DOTTED_PLURAL_EVASIONS = (
+    # The dotted singular's optional trailing dot plus the word boundary
+    # already covered these at base; pinned so a dotted-bank refactor cannot
+    # silently reopen them.
+    "Add d.i.a.b.e.t.i.c.s to this campaign.",
+    "Add d i a b e t i c s to this campaign.",
+)
+
+
+@pytest.mark.parametrize("prompt", _DOTTED_PLURAL_EVASIONS)
+def test_a_separator_obfuscated_plural_still_refuses(prompt: str) -> None:
+    assert protected_prompt_match(prompt) == "protected_class_language", prompt
+
+
+_TRIGGER_REMOVED_FRAMES = (
+    # Each gain re-tested with the banked term swapped for a reviewed
+    # population noun: the FRAME must never be what refuses.
+    "Add borrowers to this campaign.",
+    "Target borrowers.",
+    "Filter to borrowers only.",
+    "Email borrowers about the HELOC offer.",
+    "Build a segment of borrowers.",
+    "Which borrowers should we contact first?",
+)
+
+
+@pytest.mark.parametrize("prompt", _TRIGGER_REMOVED_FRAMES)
+def test_the_admission_frames_stay_answerable_without_the_term(prompt: str) -> None:
+    assert protected_prompt_match(prompt) is None, prompt
+    assert contains_unsafe_ai_text(prompt) is False, prompt
+
+
+def test_the_compliance_mask_covers_the_plural_trait() -> None:
+    """The safe-context mask is built from the same fragment bank and must
+    move with it: a reviewed exclusion note over the plural stays documentation,
+    not targeting."""
+
+    note = "Diabetics documentation is excluded from campaign targeting."
+    assert protected_prompt_match(note) is None
+    assert contains_unsafe_ai_text(note) is False


### PR DESCRIPTION
## What

`protected_prompt_match("Add diabetics to this campaign.")` returned `None` and `contains_unsafe_ai_text` returned `False`, while `"Assign a diabetic."` and `"Add diabetic borrowers to this campaign."` both refused as `protected_class_language` (pre-existing gap, measured 2026-08-13 during the destination-tail fix on claude/zen-feistel-02be68).

## Root cause

The three banked condition **adjectives** — `diabetic`, `asthmatic`, `epileptic` — live as singular inline literals in `_build_health_trait_fragments` (`backend/schemas/marketing_safety_terms.py`), and every consumer wraps the trait in a trailing `\b`. The plural population noun (`diabetics`) can therefore never match: the vocabulary listed the adjective, not the noun that names the population. Not a windowing issue — the term simply wasn't in the closed vocabulary.

## Fix

Closed two-form enumeration (`diabetics?|asthmatics?|epileptics?`) at the single definition site — not a morphological rule across the bank. The one fragment builder feeds the term detector, the status/governance binders, and the compliance safe-context mask, so all surfaces move together (the safe-context mask keeps a plural compliance note like "Diabetics documentation is excluded from campaign targeting." answerable).

## Differential battery (base vs fix)

30 cases × 4 verdicts (`protected_prompt_match`, `protected_class_marketing_reason`, its `assume_reviewed_read_only_analytics=True` variant, `contains_unsafe_ai_text`):

- **10 gains**, every one a plural form of an already-refused singular (admission commands, targeting, filter, outreach, question form, all capitalizations) — each re-tested with the trigger removed: every frame stays answerable, so the term, not the frame, is what flips.
- **0 losses** — stay-refused invariants, dotted/spaced evasions, MS-state control, compliance-note masks, and plain campaign admissions are verdict-identical.
- The dotted/spaced plural evasions (`d.i.a.b.e.t.i.c.s`) already refused at base via the dotted singular's optional trailing dot + word boundary — pinned, no dotted-bank change needed.

## Out of scope, filed separately

Fourteen sibling person-noun stems (schizophrenics, alcoholics, paraplegics, hemophiliacs, …) are unbanked in **both** singular and plural — a stem-absence gap, not a plural gap. Chipped as a follow-up task rather than widening this closed change.

## Validation

Focused guard suites + full `pytest -q` green, `ruff` clean, `mypy backend` clean (255 files), `tools/check_file_sizes.py` exit 0 run locally before push (the gate is not a required check). New pins: `tests/unit/test_health_population_plural_parity.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)