### PR TITLE
fix(criteria): a geography scope narrows a reviewed attribute, it is not a new one

### DIFF
--- a/backend/schemas/marketing_selection_criteria.py
+++ b/backend/schemas/marketing_selection_criteria.py
@@ -20,12 +20,14 @@ from backend.schemas.marketing_selection_reviewed_workflows import (
     _REVIEWED_SCREEN_GATE_WORKFLOW_RE,
 )
 from backend.schemas.marketing_selection_vocabulary import (
-    _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE,
     POPULATION_QUANTIFIER_DIGITS,
     REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT,
     REVIEWED_MORTGAGE_ATTRIBUTE_BOUND_LIST_FRAGMENT,
     REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT,
     REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT,
+    matches_reviewed_mortgage_attribute,
+    reviewed_attribute_scope_fragment,
+    reviewed_fullmatch,
 )
 
 _CRITERION_TAIL = r"(?P<criterion>[^.!?;:]{1,120})"
@@ -295,7 +297,9 @@ _REVIEWED_DECISION_CRITERION = (
     r"by|based\s+on|according\s+to|"
     r"who\s+(?:(?:have|show|carry|meet)|suffer\s+from))\s+"
     rf"(?:{REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT})"
+    rf"{reviewed_attribute_scope_fragment('decision_head')}"
     rf"{REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT}"
+    rf"{reviewed_attribute_scope_fragment('decision_tail')}"
 )
 _REVIEWED_DIRECTIVE_CRITERION = (
     rf"(?:{_AUDIENCE_DECISION_REFERENCE})\s+(?:"
@@ -305,7 +309,9 @@ _REVIEWED_DIRECTIVE_CRITERION = (
     r"(?:by|according\s+to)\s+(?:whether\s+)?"
     r"(?:(?:they|those|these)\s+)?(?:have|show|carry|meet))\s+"
     rf"(?:{REVIEWED_MORTGAGE_ATTRIBUTE_BOUND_LIST_FRAGMENT})"
+    rf"{reviewed_attribute_scope_fragment('directive_head')}"
     rf"{REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT}"
+    rf"{reviewed_attribute_scope_fragment('directive_tail')}"
     rf"(?:,\s*(?:provided\s+(?:that\s+)?(?:they|those|these)\s+"
     rf"(?:have|show|carry|meet)\s+(?:{REVIEWED_MORTGAGE_ATTRIBUTE_BOUND_LIST_FRAGMENT})"
     rf"{REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT}|for\s+whom\s+"
@@ -326,7 +332,9 @@ _REVIEWED_WHOSE_DIRECTIVE_CRITERION = (
     rf"(?:{_AUDIENCE_DECISION_REFERENCE})\s+whose\s+"
     rf"(?:{REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT})\s+"
     r"(?:is|are|was|were)\s+(?:active|current|documented|verified|confirmed|recorded)"
+    rf"{reviewed_attribute_scope_fragment('whose_head')}"
     rf"{REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT}"
+    rf"{reviewed_attribute_scope_fragment('whose_tail')}"
 )
 _REVIEWED_CONDITIONAL_DIRECTIVE_CRITERION = (
     rf"(?:{_AUDIENCE_DECISION_REFERENCE})\s+(?:"
@@ -337,7 +345,9 @@ _REVIEWED_CONDITIONAL_DIRECTIVE_CRITERION = (
     r"(?:if|where)\s+"
     r"(?:(?:they|those|these)\s+)?(?:have|show|carry|meet)\s+)"
     rf"(?:{REVIEWED_MORTGAGE_ATTRIBUTE_BOUND_LIST_FRAGMENT})"
+    rf"{reviewed_attribute_scope_fragment('conditional_head')}"
     rf"{REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT}"
+    rf"{reviewed_attribute_scope_fragment('conditional_tail')}"
 )
 # A count between the lead-in verb and the population noun QUANTIFIES that
 # population -- "the top 50 borrowers", "the best 25 customers", "the next
@@ -449,6 +459,9 @@ _REVIEWED_PRENOMINAL_AUDIENCE_DIRECTIVE_RE = re.compile(
     rf"{_AUDIENCE_FORMATION_COMMAND_FRAGMENT}\s+(?:the\s+)?"
     rf"(?:{REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT})\s+"
     rf"{_AUDIENCE_DECISION_REFERENCE}"
+    # The scope precedes the destination tail because both can appear, and in
+    # that order: "Rank the high LTV borrowers in Texas for the campaign."
+    rf"{reviewed_attribute_scope_fragment('prenominal')}"
     r"(?:\s+(?:in|into|for)\s+(?:(?:this|the|a|an)\s+)?(?:reviewed\s+)?"
     r"(?:cohort|campaign|audience|segment|list|queue|offer|review))?$",
     re.IGNORECASE,
@@ -551,7 +564,7 @@ def _is_reviewed_pre_population_binding(value: str) -> bool:
     criterion = _normalize_criterion(criterion)
     return bool(
         not criterion
-        or _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE.fullmatch(criterion) is not None
+        or matches_reviewed_mortgage_attribute(criterion)
         or is_closed_reviewed_segment_signal_criterion(criterion)
     )
 
@@ -578,7 +591,7 @@ def _is_reviewed_directive_criterion(value: str) -> bool:
     criterion = _normalize_criterion(value)
     return bool(
         is_closed_reviewed_segment_signal_criterion(criterion)
-        or _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE.fullmatch(criterion) is not None
+        or matches_reviewed_mortgage_attribute(criterion)
     )
 
 
@@ -603,7 +616,7 @@ def _is_reviewed_admission_criterion(value: str) -> bool:
     )
     criterion = _normalize_criterion(criterion)
     return bool(
-        _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE.fullmatch(criterion) is not None
+        matches_reviewed_mortgage_attribute(criterion)
         or is_closed_reviewed_segment_signal_criterion(criterion)
     )
 
@@ -619,7 +632,7 @@ def _contains_unreviewed_audience_decision(
     if applied_criterion is not None:
         criterion = _normalize_criterion(applied_criterion.group("criterion"))
         return not (
-            _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE.fullmatch(criterion) is not None
+            matches_reviewed_mortgage_attribute(criterion)
             or is_closed_reviewed_segment_signal_criterion(criterion)
         )
     admission = audience_admission_criterion(clause)
@@ -649,11 +662,9 @@ def _contains_unreviewed_audience_decision(
         return False
     if _REVIEWED_BARE_AUDIENCE_DIRECTIVE_RE.fullmatch(clause) is not None:
         return False
-    if _REVIEWED_PRENOMINAL_AUDIENCE_DIRECTIVE_RE.fullmatch(clause) is not None:
+    if reviewed_fullmatch(_REVIEWED_PRENOMINAL_AUDIENCE_DIRECTIVE_RE, clause):
         return False
-    if any(
-        pattern.fullmatch(clause) is not None for pattern in _REVIEWED_AUDIENCE_DECISION_PATTERNS
-    ):
+    if any(reviewed_fullmatch(pattern, clause) for pattern in _REVIEWED_AUDIENCE_DECISION_PATTERNS):
         return False
     for match in _AUDIENCE_FORMATION_BOUND_POPULATION_RE.finditer(clause):
         if not _is_reviewed_pre_population_binding(match.group("criterion") or ""):
@@ -707,7 +718,7 @@ def _contains_unreviewed_audience_decision(
         if post_outcome_criterion is not None:
             criterion = _normalize_criterion(post_outcome_criterion.group("criterion"))
             if not (
-                _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE.fullmatch(criterion) is not None
+                matches_reviewed_mortgage_attribute(criterion)
                 or is_closed_reviewed_segment_signal_criterion(criterion)
             ):
                 return True
@@ -815,7 +826,7 @@ def _normalize_criterion(value: str) -> str:
 def _contains_unreviewed_match(matches: list[re.Match[str]]) -> bool:
     for match in matches:
         criterion = _normalize_criterion(match.group("criterion"))
-        if not criterion or _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE.fullmatch(criterion) is None:
+        if not criterion or not matches_reviewed_mortgage_attribute(criterion):
             return True
     return False
 

--- a/backend/schemas/marketing_selection_reviewed_places.py
+++ b/backend/schemas/marketing_selection_reviewed_places.py
@@ -1,0 +1,396 @@
+"""The closed US place vocabulary a governed location slot may admit.
+
+A guard that names a place needs a way to say "this run of title-case words is
+a PLACE" without accepting an arbitrary title-case run, which is the fail-open
+this machine exists to prevent: behind a reviewed attribute, an open slot lets
+``... with home equity in dialysis centers`` ride a reviewed head, and the
+criterion state machine is the only net that catches a health condition
+outside the enumerated bank (``psoriasis`` is banked, ``eczema`` is not).
+
+Closing such a slot to a vocabulary, rather than to a shape, is not a
+stylistic choice. A bounded shape screened at match time was built and
+MEASURED before this module existed, and it fails in both directions at once:
+over a 20-term governed probe set and an 18-value governed place set, the best
+carrier missed ``eczema``, ``Chinatown``, ``methadone clinics`` and ``nursing
+homes``, while refusing ``Tacoma``, ``Hawaiian Gardens`` and ``Indian Head
+Park``, which are live gold cities. Membership in a screened vocabulary is
+what separates a place from a governed term; the shape of the string cannot.
+
+Provenance: the three vocabularies, the delegating admission gate and the
+services-to-schemas registration below were written for the reviewed-analytics
+location slot in PR #224 (``claude/serene-gould-76f4ff``, commit 9080afe0) and
+are reproduced here rather than re-derived, so the two slots screen against one
+vocabulary instead of two copies. That branch also rewrites
+``marketing_selection_reviewed_analytics`` to consume this module; those
+changes are NOT taken here. The first consumer on ``main`` is
+``REVIEWED_ATTRIBUTE_SCOPE_FRAGMENT`` in ``marketing_selection_vocabulary``.
+
+Three vocabularies, three lifetimes
+-----------------------------------
+* **States** -- the federal list. Fixed, and reproduced here in full.
+* **Counties** -- the shipped ``us-counties.json`` the map drill-down already
+  ships. National, public-domain, and repo-committed, so it screens once at
+  import-time cost and never drifts with coverage.
+* **Cities** -- the governed gold dimension, which is live Cotality coverage
+  and cannot be committed (CLAUDE.md: the product follows the current refresh
+  dynamically). It arrives by registration from the services layer, because
+  ``backend/schemas`` may not import ``backend/services``. Until it does, the
+  set is empty and a city-grain question refuses, which is the same answer the
+  guard gives today -- degradation costs the grain, never the guard.
+
+Every county and city value passes :func:`_collides_with_governed_term` before
+it is admitted. That gate runs the REAL banks, not a copy of them: a private
+regex copy is how a relaxation silently stops tracking the detector it claims
+to mirror.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from functools import lru_cache
+from pathlib import Path
+from typing import Final
+
+# The federal list: 50 states plus the District of Columbia.
+#
+# NOT ``_validators_person_names.US_STATE_NAMES``. That tuple names itself "the
+# federal list" but is a person-name-heuristic helper, and it deliberately
+# carries only the ONE-word states -- "Two-word states already live in
+# ``_REVIEWED_NON_PERSON_PHRASES``; the pair heuristic only ever misreads the
+# ONE-word ones". Reusing it to close the analytics location tail silently
+# dropped eleven states and DC out of the governed slot: "in New York", "in
+# North Carolina" and "in District of Columbia" all refused, measured on the
+# 814-string differential against 7612b021.
+US_STATE_NAMES_FEDERAL: Final[tuple[str, ...]] = (
+    # fmt: off
+    "Alabama", "Alaska", "Arizona", "Arkansas", "California", "Colorado",
+    "Connecticut", "Delaware", "District of Columbia", "Florida", "Georgia",
+    "Hawaii", "Idaho", "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+    "Louisiana", "Maine", "Maryland", "Massachusetts", "Michigan", "Minnesota",
+    "Mississippi", "Missouri", "Montana", "Nebraska", "Nevada",
+    "New Hampshire", "New Jersey", "New Mexico", "New York", "North Carolina",
+    "North Dakota", "Ohio", "Oklahoma", "Oregon", "Pennsylvania",
+    "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas",
+    "Utah", "Vermont", "Virginia", "Washington", "West Virginia", "Wisconsin",
+    "Wyoming",
+    # fmt: on
+)
+US_STATE_CODES: Final[tuple[str, ...]] = (
+    # fmt: off
+    "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL", "GA", "HI",
+    "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN",
+    "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH",
+    "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA",
+    "WV", "WI", "WY",
+    # fmt: on
+)
+# ``ms`` is the one USPS code that is also a governed term (multiple
+# sclerosis) -- computed by sweeping all 676 pairs against the banks, not
+# assumed. Mississippi stays reachable by name, and as "(MS)" after it.
+_EXCLUDED_STATE_CODES: Final[frozenset[str]] = frozenset({"ms"})
+
+_STATE_NAMES_LOWER: Final[frozenset[str]] = frozenset(
+    name.lower() for name in US_STATE_NAMES_FEDERAL
+)
+_STATE_CODES_LOWER: Final[frozenset[str]] = frozenset(code.lower() for code in US_STATE_CODES)
+
+# The map drill-down's own artifact. Public-domain us-atlas county TopoJSON,
+# already a backend dependency for county display labels.
+_COUNTY_TOPOJSON: Final[Path] = (
+    Path(__file__).resolve().parents[2] / "frontend" / "public" / "us-counties.json"
+)
+# A county dimension that reads far larger than the ~1.8k distinct national
+# names is not the shipped artifact. Admitting thousands of unscreened values
+# on that evidence would be a guard rewrite by accident, so admit none.
+_MAX_COUNTY_NAMES: Final[int] = 4_096
+# Governed city values arrive from live gold. The same posture, one order up:
+# the dimension measured 428 distinct values on 2026-08-12.
+_MAX_CITY_VALUES: Final[int] = 8_192
+
+# Shipped county names that carry a governed term. Committed rather than
+# screened at runtime because the artifact is static: which names collide can
+# only change when a DETECTOR BANK changes, and screening ~1.8k names costs
+# ~5s -- unacceptable on a first guard call, trivial as a build step.
+# Re-derive with ``tools/screen_county_place_vocabulary.py``.
+#
+# 13 of 1,833, and every one is explainable, which is the check that says the
+# gate is measuring something rather than just returning: race (``white``,
+# ``white pine``), age (``box elder``, ``young``), national origin
+# (``canadian``, ``indian river``), religion (``christian``, ``falls church``,
+# ``st. john the baptist``), disability (``deaf smith``), and the ``-oma``
+# condition morphology (``coahoma``, ``oklahoma``, ``sonoma``) that also costs
+# the prose surface every question naming Tacoma.
+#
+# Two names are worth knowing about. ``Oklahoma`` stays reachable as a STATE:
+# the federal list is its own closed vocabulary and is checked first, so only
+# the county grain is lost. ``Young`` is the one entry the gate excludes that
+# the full guard does not flag in a ranked sentence -- "Young borrowers" trips
+# age targeting, "... in Young County" does not -- and it stays excluded,
+# because the conservative carrier is the right one for a slot that hands out
+# a kill switch.
+COUNTY_NAME_EXCLUSIONS: Final[frozenset[str]] = frozenset(
+    {
+        "box elder",
+        "canadian",
+        "christian",
+        "coahoma",
+        "deaf smith",
+        "falls church",
+        "indian river",
+        "oklahoma",
+        "sonoma",
+        "st. john the baptist",
+        "white",
+        "white pine",
+        "young",
+    }
+)
+
+# At most four whitespace-separated tokens. "Prince George's County" is three;
+# nothing in any of the three vocabularies is longer. The bound is what stops
+# the capture swallowing a following clause in the compound shapes -- and if
+# backtracking ever does settle on a wrong binding, membership rejects it and
+# the clause fails closed, which is a false refusal and never a bypass.
+_LOCATION_TOKEN = r"[A-Za-z][A-Za-z.'-]*"
+# The SHAPE a governed place may take. It admits nothing on its own: whatever
+# it captures is handed to :func:`is_governed_analytics_location`, and a slot
+# that embeds this without running that check has an open 40-character hole in
+# it. Shared by every location slot so the two cannot drift apart.
+GOVERNED_PLACE_SHAPE_FRAGMENT: Final[str] = (
+    rf"{_LOCATION_TOKEN}(?:\s+{_LOCATION_TOKEN}){{0,3}}"
+    r"(?:\s*,\s*[A-Za-z]{2})?(?:\s*\([A-Za-z]{2}\))?"
+)
+REVIEWED_ANALYTIC_LOCATION_FRAGMENT: Final[str] = (
+    r"(?:\s+(?:in|across)\s+(?:the\s+current\s+(?:coverage|portfolio)|"
+    r"(?:the\s+state\s+of\s+)?"
+    rf"(?P<loc>{GOVERNED_PLACE_SHAPE_FRAGMENT})))?"
+)
+
+# Scopes that need no gazetteer, because they name no place.
+#
+# A demonstrative ("in this county", "across the current coverage") refers to
+# whatever the question is already about, and a five-digit ZIP is DIGITS ONLY
+# -- neither can carry a word, so neither needs screening. They are closed
+# literal alternations, and they sit in front of the captured shape so the
+# common phrasings never reach a membership lookup at all.
+#
+# The ZIP branch requires the word ``ZIP``/``postal code``. A bare "in 98404"
+# is left out on purpose: the number slot in this grammar is load-bearing
+# (see ``REVIEWED_ATTRIBUTE_THRESHOLD``), and a bare five-digit run behind a
+# preposition is not distinguishable from a count.
+#
+# ``z[il]p``, not ``zip``, and that is not a typo. The guard scans a leetspeak
+# and confusable FOLD of the text alongside the text itself, and a capital
+# ``I`` folds to ``l`` -- so "in ZIP 98404" arrives at one scan pass as "in ZlP
+# 98404" and a plain ``zip`` literal misses it. Measured: every one of the 51
+# federal state names passed while all nine reviewed attributes refused with a
+# ZIP scope, which is the signature of a literal that does not survive the
+# fold. Same convention the audience-formation grammar already uses for
+# ``(?:insert|lnsert)``. The widened class admits ``zlp``, which is not a term
+# in any bank, and the five digits behind it are digits-only either way.
+_ZIP_NOUN = r"(?:z[il]p(?:\s+code)?|postal\s+code)"
+GOVERNED_SCOPE_DEMONSTRATIVE_FRAGMENT: Final[str] = (
+    r"(?:(?:this|that|the|our|their|its)\s+)?(?:current\s+)?"
+    r"(?:coverage|portfolio|footprint|book|market|metro(?:\s+area)?|region|area|"
+    rf"territory|state|county|city|{_ZIP_NOUN}|"
+    r"markets|metros|regions|areas|territories|states|counties|cities|"
+    r"z[il]p\s+codes)"
+)
+GOVERNED_SCOPE_ZIP_FRAGMENT: Final[str] = rf"{_ZIP_NOUN}\s+[0-9]{{5}}"
+
+_TRAILING_STATE_RE: Final[re.Pattern[str]] = re.compile(
+    r"^(?P<core>.*?)(?:\s*,\s*(?P<comma>[A-Za-z]{2})|\s*\((?P<paren>[A-Za-z]{2})\))$"
+)
+
+
+def _collides_with_governed_term(value: str) -> bool:
+    """True when a place value carries a term a detector governs.
+
+    Asks the REAL front door, not a hand-assembled list of banks. The first
+    draft of this gate enumerated seven compiled patterns and was measured
+    against the full guard over all 1,833 shipped county names: it agreed on
+    every name but ``Falls Church``, which the guard refuses through
+    ``_contains_protected_class_proxy_pair`` -- a detector that is a function,
+    not a pattern, so no bank list contains it. That is the private-copy
+    failure mode in miniature, caught only because the sweep had a control to
+    disagree with. Delegating means a detector added to the guard is in this
+    gate the same day.
+
+    One probe, ``"<value> borrowers"``. It contains the bare value, so a
+    direct-term hit is still found, and it supplies the population noun the
+    windowed detectors need -- the national-origin bank is why ``Indian
+    River`` and ``Hawaiian Gardens`` are excluded, and it does not fire on a
+    bare value. ~2.8ms per probe.
+
+    ``unreviewed_criterion`` is NOT a collision: it is the criterion state
+    machine saying it does not recognise "Adams borrowers" as a complete
+    reviewed selection, which is true of every place name and would exclude
+    the entire vocabulary. Only a named protected-class verdict disqualifies.
+
+    Imported lazily and deliberately: ``_validators_protected_class`` reaches
+    this module through ``marketing_selection_criteria``, so a module-level
+    import would close a cycle. The probe cannot recurse into the county set --
+    ``admitted_county_names`` is set arithmetic over a committed exclusion
+    list and calls nothing here -- and a bare ``"<value> borrowers"`` cannot
+    fullmatch an anchored analytics shape.
+    """
+
+    from backend.schemas._validators_protected_class import protected_class_marketing_reason
+
+    return protected_class_marketing_reason(f"{value} borrowers") == "protected_class"
+
+
+@lru_cache(maxsize=1)
+def shipped_county_names() -> frozenset[str]:
+    """Distinct county names from the shipped national TopoJSON, unscreened.
+
+    Empty when the artifact is missing or unreadable: no counties admitted, so
+    a county question refuses. Fail-closed, like every other degradation on
+    this path.
+    """
+
+    try:
+        payload = json.loads(_COUNTY_TOPOJSON.read_text(encoding="utf-8"))
+        geometries = payload["objects"]["counties"]["geometries"]
+    except Exception:
+        return frozenset()
+    names = {
+        " ".join(str(geometry["properties"]["name"]).split())
+        for geometry in geometries
+        if isinstance(geometry, dict) and (geometry.get("properties") or {}).get("name")
+    }
+    if not names or len(names) > _MAX_COUNTY_NAMES:
+        return frozenset()
+    return frozenset(name for name in names if name)
+
+
+@lru_cache(maxsize=1)
+def admitted_county_names() -> frozenset[str]:
+    """Lower-cased shipped county names, minus the screened collisions.
+
+    Carries a period-stripped spelling of the ~20 abbreviated names
+    (``st. louis`` -> ``st louis``). Not cosmetic: the reviewed-analytics text
+    is split into clauses on ``[.!?;:\\n]+`` before any shape is matched, so
+    "... in St. Louis County." arrives as two clauses cut at the abbreviation
+    and no shape can match either half. "St Louis County" is the spelling that
+    survives that split, and the abbreviated-with-period form stays refused --
+    a clause-segmentation residual that predates this slot and is not fixable
+    inside it.
+
+    Dropping a period cannot introduce a token, so the stripped spelling
+    inherits its screen from the name it came from; no re-probe is needed.
+    """
+
+    admitted = frozenset(name.lower() for name in shipped_county_names()) - COUNTY_NAME_EXCLUSIONS
+    return admitted | {
+        " ".join(name.replace(".", " ").split()) for name in admitted if "." in name
+    }
+
+
+_registered_city_values: frozenset[str] = frozenset()
+_registered_city_input: frozenset[str] | None = None
+
+
+def register_governed_analytics_cities(values: object) -> int:
+    """Publish the governed city dimension to the location slot.
+
+    Dependency inversion, because ``backend/schemas`` may not import
+    ``backend/services`` (``test_schemas_do_not_import_runtime_services``). The
+    resolver that owns the live dimension calls this at warm-up; nothing here
+    reaches for it, so the schemas layer keeps no runtime dependency.
+
+    Returns the number of values admitted, so the caller can log what a refresh
+    actually bought rather than assume. Passing an empty iterable clears the
+    set, which is how a degraded resolve withdraws the city grain.
+
+    Screening the 428 live values costs ~1.2s, so an unchanged dimension
+    short-circuits on the raw input before a single probe runs. The resolver
+    re-reads gold every 15 minutes and the values almost never move; without
+    this, every TTL refresh would pay the full screen on whichever request
+    happened to trigger it.
+
+    Registration MUTATES a guard verdict, so anything that memoizes that
+    verdict has to be invalidated here. Nothing does today -- neither
+    ``protected_class_marketing_reason`` nor ``protected_prompt_match`` nor any
+    module between them carries an ``lru_cache`` (checked, not assumed) -- so a
+    question asked before warm-up is simply re-decided after it. #224 adds one
+    on the same path; whichever lands second re-adds the ``cache_clear`` that
+    was dropped here for having nothing to clear.
+    """
+
+    global _registered_city_values, _registered_city_input
+    # A str is Iterable, and iterating it would register 428 single characters
+    # as cities. Excluded before the Iterable test, not after it.
+    if isinstance(values, str | bytes) or not isinstance(values, Iterable):
+        candidates: tuple[str, ...] = ()
+    else:
+        candidates = tuple(str(value) for value in values)
+    incoming = frozenset(candidates)
+    if incoming == _registered_city_input:
+        return len(_registered_city_values)
+    admitted: set[str] = set()
+    if len(candidates) <= _MAX_CITY_VALUES:
+        for value in candidates:
+            collapsed = " ".join(value.split())
+            if not collapsed or len(collapsed.split()) > 4:
+                continue
+            if _collides_with_governed_term(collapsed):
+                continue
+            admitted.add(collapsed.lower())
+    resolved = frozenset(admitted)
+    _registered_city_input = incoming
+    _registered_city_values = resolved
+    return len(resolved)
+
+
+def governed_analytics_cities() -> frozenset[str]:
+    """The admitted governed city values. Empty until a resolver registers."""
+
+    return _registered_city_values
+
+
+def is_governed_analytics_location(value: str | None) -> bool:
+    """True when a captured location slot names a governed US place.
+
+    ``None`` means the clause named no location, which is the shape's own
+    business, not this vocabulary's.
+    """
+
+    if value is None:
+        return True
+    text = " ".join(str(value).split())
+    # The shapes keep "the state of" outside the capture, but this is the
+    # public contract for a location string and callers pass what they read.
+    if text.lower().startswith("the state of "):
+        text = text[len("the state of ") :].strip()
+    if not text:
+        return False
+    trailing = _TRAILING_STATE_RE.fullmatch(text)
+    if trailing is not None:
+        code = (trailing.group("comma") or trailing.group("paren") or "").lower()
+        core = trailing.group("core").strip()
+        # A trailing two-letter token only disambiguates when it is a real
+        # state code AND something precedes it. Anything else keeps the whole
+        # string and lets membership decide.
+        #
+        # ``ms`` is NOT excluded here. The exclusion belongs to the bare-code
+        # branch below, where nothing in the string says which reading is
+        # meant; in "Mississippi (MS)" the state name is right there, and
+        # dropping the parenthetical on that ground refused a spelling the
+        # closed tail has always admitted.
+        if core and code in _STATE_CODES_LOWER:
+            text = core
+    lowered = text.lower()
+    if lowered in _STATE_NAMES_LOWER:
+        return True
+    if lowered in _STATE_CODES_LOWER:
+        return lowered not in _EXCLUDED_STATE_CODES
+    if lowered in governed_analytics_cities():
+        return True
+    counties = admitted_county_names()
+    if lowered in counties:
+        return True
+    bare = lowered[: -len(" county")] if lowered.endswith(" county") else ""
+    return bool(bare) and bare in counties

--- a/backend/schemas/marketing_selection_vocabulary.py
+++ b/backend/schemas/marketing_selection_vocabulary.py
@@ -11,6 +11,13 @@ from __future__ import annotations
 
 import re
 
+from backend.schemas.marketing_selection_reviewed_places import (
+    GOVERNED_PLACE_SHAPE_FRAGMENT,
+    GOVERNED_SCOPE_DEMONSTRATIVE_FRAGMENT,
+    GOVERNED_SCOPE_ZIP_FRAGMENT,
+    is_governed_analytics_location,
+)
+
 # An article does not change WHICH attribute is being named: "the highest
 # opportunity scores" selects on ``opportunity_score`` exactly as "highest
 # opportunity scores" does. It belongs to the fragment, not to any one
@@ -192,6 +199,105 @@ REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT = (
     r"mortgage|loan|servicing)\s+)?(?:campaign|offer|options?|review))?"
 )
 
+# A GEOGRAPHY SCOPE narrows WHERE a reviewed attribute is measured; it names no
+# second criterion. "a rate spread in Texas" is the reviewed ``rate_spread_bps``
+# column restricted to a state, exactly as "a rate spread" is that column
+# unrestricted -- but the criterion is captured whole
+# (``_CRITERION_TAIL`` is ``[^.!?;:]{1,120}``) and then required to match the
+# reviewed vocabulary, so the scope made every reviewed attribute unreviewed.
+#
+# Measured on b3007754 over ``Show borrowers with {attribute}{ scope}.``, nine
+# reviewed attributes x seven scopes: 49 of 63 refused as
+# ``unreviewed_criterion``. Every attribute passed bare and refused with "in
+# Texas", "in Washington", "in Seattle", "in ZIP 98404", "across Colorado" and
+# "in Cook County". Geography drill-down is a hero surface (CLAUDE.md), so this
+# was the single largest false-positive class left in the grammar.
+#
+# THE PLACE SLOT IS THE WHOLE PROBLEM. Accepting an arbitrary title-case run
+# behind "in" would let a non-place tail ride in behind a reviewed head --
+# "with home equity in dialysis centers" -- and the criterion state machine is
+# the only net that catches a health condition outside the enumerated bank
+# (``psoriasis`` is banked, ``eczema`` is not). So the slot captures a bounded
+# SHAPE and every capture is screened for MEMBERSHIP in the governed place
+# vocabulary by :func:`match_scopes_are_governed`. A shape without that check
+# is an open hole; the two are only ever used together, through
+# :func:`reviewed_fullmatch`.
+#
+# Two deliberate exclusions:
+#
+# * ``for`` is NOT a scope preposition, though it reads like one ("for
+#   Texas"). ``REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT`` already owns ``\s+for\s+``,
+#   and a scope alternative in front of it would match "for this campaign",
+#   capture "this campaign", fail the membership screen and refuse a phrasing
+#   that is answered today. A regression on a shipped phrasing is not worth a
+#   spelling nobody uses.
+# * a bare five-digit run ("in 98404") is left to the ZIP branch's explicit
+#   keyword. The number slot in this grammar is load-bearing and digits-only on
+#   purpose; a bare cardinal behind a preposition is not distinguishable from a
+#   population count.
+#
+# This cannot admit an unreviewed attribute. The alternation in
+# ``REVIEWED_MORTGAGE_ATTRIBUTE_FRAGMENT`` is untouched, so "a credit score in
+# Texas" and "eczema in Texas" stay unreviewed exactly as they are today, and a
+# reviewed head still cannot carry an unreviewed conjunct across a scope
+# ("home equity in Texas and eczema").
+_SCOPE_GROUP_PREFIX = "geoscope_"
+
+
+def reviewed_attribute_scope_fragment(name: str) -> str:
+    """One optional geography scope, capturing only what needs screening.
+
+    A FACTORY rather than the single constant a purpose/CTA tail gets, because
+    the capture needs a group name and Python's ``re`` rejects a duplicate one
+    -- and these fragments are composed more than once per pattern
+    (``_REVIEWED_AUDIENCE_DECISION_PATTERNS[6]`` alternates two whole criterion
+    grammars inside one pattern). Every caller passes a name unique to its
+    embedding site; the prefix is what
+    :func:`match_scopes_are_governed` keys on, so a new site is screened by
+    construction rather than by remembering to add it to a list.
+
+    The demonstrative and ZIP branches are closed literals and are tried first,
+    so the common phrasings never reach a membership lookup -- which also keeps
+    the county artifact unread until somebody actually names a county.
+    """
+
+    return (
+        r"(?:\s+(?:in|across|within|throughout)\s+"
+        rf"(?:{GOVERNED_SCOPE_DEMONSTRATIVE_FRAGMENT}"
+        rf"|{GOVERNED_SCOPE_ZIP_FRAGMENT}"
+        r"|(?:the\s+state\s+of\s+)?"
+        rf"(?P<{_SCOPE_GROUP_PREFIX}{name}>{GOVERNED_PLACE_SHAPE_FRAGMENT})))?"
+    )
+
+
+def match_scopes_are_governed(match: re.Match[str]) -> bool:
+    """True when every geography scope this match captured names a governed place.
+
+    A group that did not participate is ``None`` and is not a scope at all --
+    the fragment is optional, so an unscoped criterion behaves exactly as it
+    did before the slot existed.
+    """
+
+    return all(
+        is_governed_analytics_location(value)
+        for name, value in match.groupdict().items()
+        if name.startswith(_SCOPE_GROUP_PREFIX) and value is not None
+    )
+
+
+def reviewed_fullmatch(pattern: re.Pattern[str], text: str) -> bool:
+    """Fullmatch a reviewed grammar AND screen its geography scopes, together.
+
+    The only supported way to ask whether text matches a reviewed pattern. A
+    bare ``pattern.fullmatch(...) is not None`` at a call site that embeds a
+    scope slot is an open place hole -- the exact "a check wired into one call
+    site is a check that is not wired in" failure this codebase has already
+    paid for once.
+    """
+
+    match = pattern.fullmatch(text)
+    return match is not None and match_scopes_are_governed(match)
+
 # A numeric threshold does not change WHICH attribute is being named. "a rate
 # spread above 150 basis points" is the reviewed ``rate_spread_bps`` column
 # with a bound on it, but the criterion is matched whole, so the article and
@@ -321,10 +427,28 @@ _REVIEWED_ATTRIBUTE_TAIL_EITHER_ORDER = (
     rf"|{_REVIEWED_ATTRIBUTE_CTA_TAIL}{REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT})"
 )
 
+# The scope sits on BOTH sides of the purpose/CTA tail, because operators write
+# it either way -- "home equity in Texas for this campaign" and "home equity for
+# this campaign in Texas". Two optional groups rather than a third permutation
+# of the either-order alternation: each is independently optional, so the two
+# spellings cost one group each instead of doubling the branch count.
 _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE = re.compile(
     rf"^(?:{REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT})"
     rf"{_REVIEWED_ATTRIBUTE_THRESHOLD}"
+    rf"{reviewed_attribute_scope_fragment('full_head')}"
     rf"{_REVIEWED_ATTRIBUTE_TAIL_EITHER_ORDER}"
+    rf"{reviewed_attribute_scope_fragment('full_tail')}"
     rf"{_REVIEWED_ATTRIBUTE_CLOSING}$",
     re.IGNORECASE,
 )
+
+
+def matches_reviewed_mortgage_attribute(criterion: str) -> bool:
+    """True when a whole captured criterion is reviewed Module 0 vocabulary.
+
+    The one entry point for ``_REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE``. It exists
+    so the geography-scope screen cannot be forgotten at one of the six call
+    sites that used to fullmatch the pattern directly.
+    """
+
+    return reviewed_fullmatch(_REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE, criterion)

--- a/backend/schemas/marketing_selection_vocabulary.py
+++ b/backend/schemas/marketing_selection_vocabulary.py
@@ -243,6 +243,34 @@ REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT = (
 # ("home equity in Texas and eczema").
 _SCOPE_GROUP_PREFIX = "geoscope_"
 
+# A DESTINATION is not a place, and the slot must not steal one.
+#
+# Several patterns already end in an optional ``(?:in|into|for)\s+<determiner>
+# <destination noun>`` tail, and the open place shape happily matches that
+# noun phrase. The regex then FULLMATCHES with the scope group holding "a
+# reviewed cohort", the membership screen rejects it, and a sentence that is
+# answered today refuses -- because ``re`` will not backtrack into a different
+# parse once the overall match has already succeeded. Found by the full unit
+# suite, not by the 15,600-probe differential, whose shapes had no destination
+# tail: "Include high equity borrowers in a reviewed cohort.", "Shortlist high
+# equity homeowners in a reviewed cohort." and one more, all green on main.
+#
+# A lookahead rather than a screen because this must change WHICH PARSE WINS,
+# and only the regex engine can do that. The excluded vocabulary is the closed
+# destination/purpose noun set, and excluding it costs nothing: none of these
+# words is in the governed place gazetteer, so the screen would reject them
+# anyway -- one step too late.
+#
+# ``for`` is excluded from the preposition list for the same class of reason,
+# one tail earlier. This is the general hazard of adding an optional slot in
+# front of other optional slots; the two closed exclusions are what keep it to
+# a parse question rather than a vocabulary one.
+_SCOPE_NOT_A_DESTINATION = (
+    r"(?!(?:(?:this|that|the|an?|our|their|its)\s+)?(?:reviewed\s+)?"
+    r"(?:campaign|cohort|audience|segment|list|queue|offer|review|population|"
+    r"selection|group)s?(?![a-z]))"
+)
+
 
 def reviewed_attribute_scope_fragment(name: str) -> str:
     """One optional geography scope, capturing only what needs screening.
@@ -265,7 +293,7 @@ def reviewed_attribute_scope_fragment(name: str) -> str:
         r"(?:\s+(?:in|across|within|throughout)\s+"
         rf"(?:{GOVERNED_SCOPE_DEMONSTRATIVE_FRAGMENT}"
         rf"|{GOVERNED_SCOPE_ZIP_FRAGMENT}"
-        r"|(?:the\s+state\s+of\s+)?"
+        rf"|{_SCOPE_NOT_A_DESTINATION}(?:the\s+state\s+of\s+)?"
         rf"(?P<{_SCOPE_GROUP_PREFIX}{name}>{GOVERNED_PLACE_SHAPE_FRAGMENT})))?"
     )
 

--- a/backend/services/genie_place_dimension.py
+++ b/backend/services/genie_place_dimension.py
@@ -593,6 +593,56 @@ def _collides_with_person_lexicon(value: str) -> bool:
     return shares_token_with_person_lexicon(value)
 
 
+def _publish_governed_scope_cities(resolved: ResolvedPlaceDimension) -> None:
+    """Hand the governed city dimension to the PROMPT guard's geography scope.
+
+    Dependency inversion, not an import the other way: ``backend/schemas`` may
+    not import ``backend/services`` (``test_schemas_do_not_import_runtime_services``),
+    so the layer that owns the live dimension pushes it down. The raw
+    ``all_values`` go over, not any set resolved here, because each surface
+    needs its OWN admission gate -- the gate for a slot that decides whether a
+    scoped criterion is reviewed is not the gate for a prose name-shape false
+    positive, and the schemas side screens what it accepts.
+
+    Publishing the DEGRADED resolve matters as much as the loaded one: an empty
+    dimension withdraws the city grain, and a city-scoped question refuses
+    again -- the same answer the guard gave before the scope slot existed.
+    Degradation costs the grain, never the guard.
+
+    Called under ``_load_lock``, which is safe here and would not be for most
+    work in this module: the screening probe runs entirely inside
+    ``backend/schemas``, and schemas cannot import services, so it has no path
+    back to ``_resolve`` -- that is the same non-reentrant lock the cell probes
+    deadlock on. It costs ~1.2s against the live values, and only on a load
+    that actually changed them: ``register_governed_analytics_cities``
+    short-circuits an unchanged dimension before screening anything.
+    """
+
+    from backend.schemas.marketing_selection_reviewed_places import (
+        register_governed_analytics_cities,
+    )
+
+    try:
+        admitted = register_governed_analytics_cities(resolved.all_values)
+    except Exception as exc:  # noqa: BLE001 — a guard vocabulary must not 500
+        emit(
+            log,
+            "governed_scope_cities_publish_failed",
+            level=logging.WARNING,
+            outcome="degraded",
+            exc_type=type(exc).__name__,
+            exc_msg=str(exc)[:500],
+        )
+        return
+    emit(
+        log,
+        "governed_scope_cities_published",
+        level=logging.INFO,
+        dimension_values=len(resolved.all_values),
+        admitted_values=admitted,
+    )
+
+
 class GovernedPlaceDimensionResolver:
     """Resolve governed city values that the output-policy scanner rejects."""
 
@@ -756,9 +806,11 @@ class GovernedPlaceDimensionResolver:
                 self._cache.set(
                     _PLACE_DIMENSION_CACHE_KEY, degraded, _PLACE_DIMENSION_FAILURE_TTL_S
                 )
+                _publish_governed_scope_cities(degraded)
                 return degraded
             self._warned = False
             self._cache.set(_PLACE_DIMENSION_CACHE_KEY, loaded, self._ttl_s)
+            _publish_governed_scope_cities(loaded)
             return loaded
 
     def conflicting_values(self) -> frozenset[str]:
@@ -870,8 +922,19 @@ def warm_governed_place_dimension() -> None:
 def _reset_governed_place_dimension_for_tests(
     resolver: GovernedPlaceDimensionResolver | None = None,
 ) -> None:
-    """Test helper: swap (or clear) the process-wide resolver."""
+    """Test helper: swap (or clear) the process-wide resolver.
+
+    Also withdraws the published geography-scope vocabulary. Resolving is a
+    PUBLISHING act now, so a test that resolves a fake dimension would
+    otherwise leave its city values in a module global in the schemas layer,
+    where the next test file inherits them silently.
+    """
+
+    from backend.schemas.marketing_selection_reviewed_places import (
+        register_governed_analytics_cities,
+    )
 
     global _RESOLVER
     with _RESOLVER_LOCK:
         _RESOLVER = resolver
+    register_governed_analytics_cities(())

--- a/backend/services/genie_place_dimension.py
+++ b/backend/services/genie_place_dimension.py
@@ -593,56 +593,6 @@ def _collides_with_person_lexicon(value: str) -> bool:
     return shares_token_with_person_lexicon(value)
 
 
-def _publish_governed_scope_cities(resolved: ResolvedPlaceDimension) -> None:
-    """Hand the governed city dimension to the PROMPT guard's geography scope.
-
-    Dependency inversion, not an import the other way: ``backend/schemas`` may
-    not import ``backend/services`` (``test_schemas_do_not_import_runtime_services``),
-    so the layer that owns the live dimension pushes it down. The raw
-    ``all_values`` go over, not any set resolved here, because each surface
-    needs its OWN admission gate -- the gate for a slot that decides whether a
-    scoped criterion is reviewed is not the gate for a prose name-shape false
-    positive, and the schemas side screens what it accepts.
-
-    Publishing the DEGRADED resolve matters as much as the loaded one: an empty
-    dimension withdraws the city grain, and a city-scoped question refuses
-    again -- the same answer the guard gave before the scope slot existed.
-    Degradation costs the grain, never the guard.
-
-    Called under ``_load_lock``, which is safe here and would not be for most
-    work in this module: the screening probe runs entirely inside
-    ``backend/schemas``, and schemas cannot import services, so it has no path
-    back to ``_resolve`` -- that is the same non-reentrant lock the cell probes
-    deadlock on. It costs ~1.2s against the live values, and only on a load
-    that actually changed them: ``register_governed_analytics_cities``
-    short-circuits an unchanged dimension before screening anything.
-    """
-
-    from backend.schemas.marketing_selection_reviewed_places import (
-        register_governed_analytics_cities,
-    )
-
-    try:
-        admitted = register_governed_analytics_cities(resolved.all_values)
-    except Exception as exc:  # noqa: BLE001 — a guard vocabulary must not 500
-        emit(
-            log,
-            "governed_scope_cities_publish_failed",
-            level=logging.WARNING,
-            outcome="degraded",
-            exc_type=type(exc).__name__,
-            exc_msg=str(exc)[:500],
-        )
-        return
-    emit(
-        log,
-        "governed_scope_cities_published",
-        level=logging.INFO,
-        dimension_values=len(resolved.all_values),
-        admitted_values=admitted,
-    )
-
-
 class GovernedPlaceDimensionResolver:
     """Resolve governed city values that the output-policy scanner rejects."""
 
@@ -777,7 +727,15 @@ class GovernedPlaceDimensionResolver:
         )
 
     def _resolve(self) -> ResolvedPlaceDimension:
-        """Load-or-degrade the whole dimension. Never raises."""
+        """Load-or-degrade the whole dimension. Never raises.
+
+        Every resolve PUBLISHES, degraded included: an empty dimension
+        withdraws the prompt guard's city grain rather than leaving a stale
+        vocabulary standing. Imported inside the call because the publisher
+        imports ``ResolvedPlaceDimension`` from here.
+        """
+
+        from backend.services.genie_place_dimension_publish import publish_governed_scope_cities
 
         cached: ResolvedPlaceDimension | None = self._cache.get(_PLACE_DIMENSION_CACHE_KEY)
         if cached is not None:
@@ -806,11 +764,11 @@ class GovernedPlaceDimensionResolver:
                 self._cache.set(
                     _PLACE_DIMENSION_CACHE_KEY, degraded, _PLACE_DIMENSION_FAILURE_TTL_S
                 )
-                _publish_governed_scope_cities(degraded)
+                publish_governed_scope_cities(degraded)
                 return degraded
             self._warned = False
             self._cache.set(_PLACE_DIMENSION_CACHE_KEY, loaded, self._ttl_s)
-            _publish_governed_scope_cities(loaded)
+            publish_governed_scope_cities(loaded)
             return loaded
 
     def conflicting_values(self) -> frozenset[str]:
@@ -924,10 +882,9 @@ def _reset_governed_place_dimension_for_tests(
 ) -> None:
     """Test helper: swap (or clear) the process-wide resolver.
 
-    Also withdraws the published geography-scope vocabulary. Resolving is a
-    PUBLISHING act now, so a test that resolves a fake dimension would
-    otherwise leave its city values in a module global in the schemas layer,
-    where the next test file inherits them silently.
+    Also withdraws the published geography-scope vocabulary: resolving is a
+    PUBLISHING act now, so a test that resolves a fake dimension would leave
+    its cities in a schemas-layer global for the next test file to inherit.
     """
 
     from backend.schemas.marketing_selection_reviewed_places import (

--- a/backend/services/genie_place_dimension_publish.py
+++ b/backend/services/genie_place_dimension_publish.py
@@ -1,0 +1,67 @@
+"""Publish the governed city dimension to the prompt guard's geography scope.
+
+One function, its own module, because ``genie_place_dimension`` sits at 890 of
+the 900-line gate and this is the seam that actually divides: RESOLVING the
+governed dimension is a warehouse concern, PUBLISHING it to a schemas-side
+guard vocabulary is a layering one. Split rather than allowlisted, per the
+gate's own policy note.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from backend.services.genie_place_dimension import ResolvedPlaceDimension
+from backend.services.observability import emit
+
+log = logging.getLogger(__name__)
+
+
+def publish_governed_scope_cities(resolved: ResolvedPlaceDimension) -> None:
+    """Hand the governed city dimension to the PROMPT guard's geography scope.
+
+    Dependency inversion, not an import the other way: ``backend/schemas`` may
+    not import ``backend/services`` (``test_schemas_do_not_import_runtime_services``),
+    so the layer that owns the live dimension pushes it down. The raw
+    ``all_values`` go over, not any set resolved here, because each surface
+    needs its OWN admission gate -- the gate for a slot that decides whether a
+    scoped criterion is reviewed is not the gate for a prose name-shape false
+    positive, and the schemas side screens what it accepts.
+
+    Publishing the DEGRADED resolve matters as much as the loaded one: an empty
+    dimension withdraws the city grain, and a city-scoped question refuses
+    again -- the same answer the guard gave before the scope slot existed.
+    Degradation costs the grain, never the guard.
+
+    Called under ``_load_lock``, which is safe here and would not be for most
+    work in this module: the screening probe runs entirely inside
+    ``backend/schemas``, and schemas cannot import services, so it has no path
+    back to ``_resolve`` -- that is the same non-reentrant lock the cell probes
+    deadlock on. It costs ~1.2s against the live values, and only on a load
+    that actually changed them: ``register_governed_analytics_cities``
+    short-circuits an unchanged dimension before screening anything.
+    """
+
+    from backend.schemas.marketing_selection_reviewed_places import (
+        register_governed_analytics_cities,
+    )
+
+    try:
+        admitted = register_governed_analytics_cities(resolved.all_values)
+    except Exception as exc:  # noqa: BLE001 — a guard vocabulary must not 500
+        emit(
+            log,
+            "governed_scope_cities_publish_failed",
+            level=logging.WARNING,
+            outcome="degraded",
+            exc_type=type(exc).__name__,
+            exc_msg=str(exc)[:500],
+        )
+        return
+    emit(
+        log,
+        "governed_scope_cities_published",
+        level=logging.INFO,
+        dimension_values=len(resolved.all_values),
+        admitted_values=admitted,
+    )

--- a/tests/unit/test_genie_prompt_guard_geography.py
+++ b/tests/unit/test_genie_prompt_guard_geography.py
@@ -1095,7 +1095,12 @@ def test_a_threshold_does_not_change_which_attribute_is_named() -> None:
     of the criterion machine consults it.
     """
 
-    from backend.schemas.marketing_selection_criteria import (
+    # Moved to ``marketing_selection_vocabulary`` when the geography-scope slot
+    # landed: the criteria module no longer fullmatches this pattern directly,
+    # it goes through ``matches_reviewed_mortgage_attribute`` so the scope
+    # screen cannot be skipped at one call site. The assertions below are
+    # unchanged.
+    from backend.schemas.marketing_selection_vocabulary import (
         _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE as attribute_re,
     )
 

--- a/tests/unit/test_genie_prompt_guard_geography_scope.py
+++ b/tests/unit/test_genie_prompt_guard_geography_scope.py
@@ -292,6 +292,40 @@ def test_a_formation_verb_still_refuses_a_scoped_attribute() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "question",
+    (
+        "Include high equity borrowers in a reviewed cohort.",
+        "Shortlist high equity homeowners in a reviewed cohort.",
+        "Include high equity borrowers in the campaign.",
+        "Rank the high LTV borrowers in this segment.",
+        "Add borrowers with home equity to the queue.",
+        "Select high equity borrowers for the campaign.",
+    ),
+)
+# Not in the list, and deliberately: "Add borrowers with home equity to the
+# REVIEWED queue." refuses on main and on this branch alike. It was in an
+# earlier draft of this test as an invented example, and the branch was
+# briefly suspected before the baseline was checked. Every case above is
+# verified answerable at 26b3ae56.
+def test_the_scope_slot_does_not_steal_a_destination(question: str) -> None:
+    """An optional slot in front of other optional slots changes which parse wins.
+
+    Every one of these is answered on main. The open place shape matches "a
+    reviewed cohort" happily, so the pattern FULLMATCHED with the scope group
+    holding a destination, the membership screen rejected it, and the sentence
+    refused -- ``re`` will not backtrack into another parse once the overall
+    match has succeeded, so no screen can recover it. Three of these were
+    caught by the full unit suite AFTER a 15,600-probe differential reported
+    zero losses; the differential's shapes had no destination tail.
+
+    Fixed in the fragment, by a lookahead over the closed destination noun set,
+    because only the regex engine can decide which parse wins.
+    """
+
+    assert protected_prompt_match(question) is None, question
+
+
 def test_the_capital_i_fold_does_not_hide_the_zip_keyword() -> None:
     """``ZIP`` reaches the grammar as ``ZlP`` on one scan pass.
 

--- a/tests/unit/test_genie_prompt_guard_geography_scope.py
+++ b/tests/unit/test_genie_prompt_guard_geography_scope.py
@@ -1,0 +1,406 @@
+"""A geography scope narrows a reviewed attribute; it is not a second criterion.
+
+Measured on b3007754 over ``Show borrowers with {attribute}{ scope}.``, nine
+reviewed attributes x seven scopes: **49 of 63 refused** as
+``unreviewed_criterion``. Every attribute passed bare and refused with "in
+Texas", "in Washington", "in Seattle", "in ZIP 98404", "across Colorado" and
+"in Cook County". ``home equity`` was the single outlier, and only because it
+has a bare alternative that matches by a different route. ``fixed-rate loans``
+predates every recent vocabulary change, so this is not fallout from one --
+it is the shape of the capture itself: ``_CRITERION_TAIL`` takes the criterion
+WHOLE (``[^.!?;:]{1,120}``) and then requires it to match the reviewed
+fragment, and "a rate spread in Texas" is not "a rate spread".
+
+Geography drill-down is a hero surface (CLAUDE.md), so this was the largest
+false-positive class left in the grammar.
+
+The place slot is the whole risk. Accepting an arbitrary title-case run behind
+"in" would let a non-place tail ride a reviewed head, and the criterion state
+machine is the only net that catches a health condition outside the enumerated
+bank. So every test that proves a scope is ANSWERABLE has a twin here that
+proves an ungoverned scope in the identical sentence still refuses.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import pytest
+
+from backend.schemas.marketing_selection_criteria import (
+    _REVIEWED_AUDIENCE_DECISION_PATTERNS,
+    _REVIEWED_PRENOMINAL_AUDIENCE_DIRECTIVE_RE,
+    _contains_unreviewed_audience_decision,
+    is_reviewed_read_only_analytics_text,
+)
+from backend.schemas.marketing_selection_reviewed_places import (
+    US_STATE_NAMES_FEDERAL,
+    admitted_county_names,
+    governed_analytics_cities,
+)
+from backend.schemas.marketing_selection_vocabulary import (
+    _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE,
+    _SCOPE_GROUP_PREFIX,
+    matches_reviewed_mortgage_attribute,
+)
+from backend.services.genie_message_policy import protected_prompt_match
+from backend.services.genie_place_dimension import (
+    GovernedPlaceDimensionResolver,
+    _reset_governed_place_dimension_for_tests,
+)
+
+# Live gold city values (paychex, 2026-08-12). ``TACOMA`` is here on purpose:
+# it is a real governed city that the ``-oma`` condition morphology screens
+# OUT, so it doubles as the control proving the admission gate runs.
+_LIVE_CITY_SAMPLE = ("SEATTLE", "SPOKANE", "BELLEVUE", "PLANO", "AURORA", "TACOMA")
+
+
+@pytest.fixture
+def published_cities() -> Iterator[None]:
+    """Publish a city dimension for the life of one test, then withdraw it.
+
+    Injects a real resolver rather than calling the registry directly, because
+    the registry is only half the contract: publishing happens on RESOLVE, and
+    a resolve is what every guard call triggers. Registering by hand passes
+    even if the services-to-schemas wiring is severed -- and worse, the first
+    guard call would then resolve a degraded dimension and publish an empty
+    set straight over the hand-registered one.
+
+    The reset also withdraws the vocabulary: the registry is a module global in
+    the schemas layer, so a test that leaves it populated hands its cities to
+    every later test file.
+    """
+
+    _reset_governed_place_dimension_for_tests(
+        GovernedPlaceDimensionResolver(dimension_reader=lambda: list(_LIVE_CITY_SAMPLE))
+    )
+    try:
+        yield
+    finally:
+        _reset_governed_place_dimension_for_tests(None)
+
+
+# Every reviewed attribute in the measured table, spelled as an operator writes
+# it. ``fixed-rate loans`` and ``conventional loans`` are here because the
+# outage was never specific to recently-added vocabulary.
+_REVIEWED_ATTRIBUTES = (
+    "a rate spread",
+    "home equity",
+    "helocs",
+    "conventional loans",
+    "fixed-rate loans",
+    "an opportunity score",
+    "a loan balance",
+    "high LTV",
+    "recommended offers",
+    "the highest opportunity scores",
+    "average home equity",
+)
+# Scopes that name a governed US place, one per grain and per preposition.
+_GOVERNED_SCOPES = (
+    " in Texas",
+    " in New York",
+    " in North Carolina",
+    " in District of Columbia",
+    " across Colorado",
+    " within Ohio",
+    " throughout Florida",
+    " in the state of Washington",
+    " in Cook County",
+    " in Cook",
+    " in ZIP 98404",
+    " in zip code 30301",
+    " in postal code 80202",
+    " in this metro",
+    " in the current coverage",
+    " in our footprint",
+)
+# Text that is NOT a governed place. Each must refuse behind a REVIEWED
+# attribute -- that is the fail-open this slot exists to prevent. ``in 98404``
+# is here because a bare five-digit run is deliberately not a ZIP.
+_UNGOVERNED_SCOPES = (
+    " in Zyrplax",
+    " in dialysis centers",
+    " in hospice care",
+    " in methadone clinics",
+    " in nursing homes",
+    " in Chinatown",
+    " in the mosque",
+    " in 98404",
+    " in memory care",
+    " in Section 8 housing",
+)
+# ``Select borrowers with {c}.`` is deliberately ABSENT, and its absence is
+# pinned by ``test_a_formation_verb_still_refuses_a_scoped_attribute`` below:
+# that shape refuses through a different detector, on main and on this branch
+# alike, and closing it is a different change with its own control battery.
+_SHAPES = (
+    "Show borrowers with {c}.",
+    "Show me the top borrowers with {c}.",
+    "Show me the top 50 borrowers with {c}.",
+    "Rank borrowers with {c}.",
+    "Show me borrowers who have {c}.",
+    "Add borrowers with {c} to the campaign.",
+)
+
+
+@pytest.mark.parametrize("attribute", _REVIEWED_ATTRIBUTES)
+@pytest.mark.parametrize("scope", _GOVERNED_SCOPES)
+def test_a_governed_scope_leaves_a_reviewed_attribute_answerable(
+    scope: str, attribute: str
+) -> None:
+    """The 49-of-63 table, restored.
+
+    Parametrized over the vocabulary AND the scope because the criterion is
+    matched whole: an attribute that passes bare says nothing about the same
+    attribute behind "in Texas", which is exactly how the outage went unseen.
+    """
+
+    question = f"Show borrowers with {attribute}{scope}."
+    assert protected_prompt_match(question) is None, question
+
+
+@pytest.mark.parametrize("shape", _SHAPES)
+@pytest.mark.parametrize("scope", (" in Texas", " in Cook County", " in ZIP 98404"))
+def test_a_governed_scope_answers_in_every_clause_shape(shape: str, scope: str) -> None:
+    """Shapes, not just the matcher.
+
+    The clause patterns in ``marketing_selection_criteria`` embed the reviewed
+    LIST fragment DIRECTLY and never consult
+    ``_REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE``. A fix proved only against the
+    full matcher has left the prompt boundary broken twice (the article, #213),
+    so the scope is asserted through the whole guard in each shape it reaches.
+    """
+
+    question = shape.format(c=f"a rate spread{scope}")
+    assert protected_prompt_match(question) is None, question
+
+
+@pytest.mark.parametrize("attribute", _REVIEWED_ATTRIBUTES)
+@pytest.mark.parametrize("scope", _UNGOVERNED_SCOPES)
+def test_an_ungoverned_scope_is_never_a_reviewed_criterion(scope: str, attribute: str) -> None:
+    """The safety half, and the reason the slot is a vocabulary not a shape.
+
+    A reviewed head must not carry a non-place tail. ``in dialysis centers``
+    and ``in hospice care`` are the measured carriers that a bounded title-case
+    shape admitted when this was tried without a gazetteer.
+
+    Asserted on the reviewed VOCABULARY, which is the artifact this change
+    edits, because neither layer above it can carry the property alone. A
+    SECOND surface -- the reviewed read-only analytics shapes -- still has an
+    OPEN ``[A-Z][A-Za-z' -]{2,40}`` location slot, and matching one of those
+    shapes is a kill switch consulted BOTH by ``protected_class_marketing_reason``
+    and, one layer down, inside ``_contains_unreviewed_audience_decision``
+    itself. So for the attributes that reach an analytics shape, everything
+    above the vocabulary short-circuits before this machine runs at all. That
+    hole is on main today (measured: "Show borrowers with home equity in
+    dialysis centers." is ALLOWED at 26b3ae56, byte-identical on this branch)
+    and PR #224 is the change that closes it.
+    """
+
+    criterion = f"{attribute}{scope}"
+    assert matches_reviewed_mortgage_attribute(criterion) is False, criterion
+
+
+@pytest.mark.parametrize("attribute", _REVIEWED_ATTRIBUTES)
+@pytest.mark.parametrize("scope", _UNGOVERNED_SCOPES)
+def test_an_ungoverned_scope_is_refused_or_owned_by_the_analytics_slot(
+    scope: str, attribute: str
+) -> None:
+    """End-to-end twin of the test above, honest about the surface it shares.
+
+    Either the guard refuses the question, or it was admitted by a reviewed
+    ANALYTICS shape -- a different slot, a different PR (#224), and the second
+    disjunct is what stops this test from silently passing if the criterion
+    machine ever starts admitting an ungoverned place.
+    """
+
+    question = f"Show borrowers with {attribute}{scope}."
+    if protected_prompt_match(question) is not None:
+        return
+    assert is_reviewed_read_only_analytics_text(question), question
+
+
+@pytest.mark.parametrize(
+    "attribute",
+    ("a credit score", "FICO", "household income", "citizenship", "eczema", "zyrplax"),
+)
+@pytest.mark.parametrize("scope", ("", " in Texas", " in Cook County", " in Seattle"))
+def test_a_scope_never_admits_an_unreviewed_attribute(
+    published_cities: None, scope: str, attribute: str
+) -> None:
+    """The fail-closed default is exactly as strong as before the scope existed.
+
+    The attribute alternation is untouched, so an unreviewed attribute stays
+    unreviewed with or without a geography scope. This is the acceptance bar
+    the differential battery measures at scale; these are its named pins.
+    """
+
+    question = f"Show borrowers with {attribute}{scope}."
+    assert protected_prompt_match(question) is not None, question
+
+
+@pytest.mark.parametrize(
+    "criterion",
+    (
+        "home equity in Texas and eczema",
+        "a rate spread in Texas with a hijab",
+        "home equity and eczema in Texas",
+        "a rate spread in Texas and a credit score",
+        "helocs in Cook County and race",
+    ),
+)
+def test_a_scope_cannot_launder_an_unreviewed_conjunct(criterion: str) -> None:
+    """A reviewed head plus a governed place must not carry an unreviewed one.
+
+    The scope is an optional group inside the ANCHORED vocabulary, so anything
+    the pair does not account for leaves text unmatched and the whole criterion
+    unreviewed. Pinned directly because every widening of this fragment also
+    widens the allow-lookahead in ``marketing_safety_terms``.
+
+    On the vocabulary, for the reason
+    ``test_an_ungoverned_scope_is_never_a_reviewed_criterion`` gives: the
+    analytics slot shadows every layer above it for some of these.
+    """
+
+    assert matches_reviewed_mortgage_attribute(criterion) is False, criterion
+
+
+def test_a_formation_verb_still_refuses_a_scoped_attribute() -> None:
+    """ "Select borrowers with a rate spread in Texas." refuses, and not here.
+
+    Unchanged by this branch and not this branch's to change. The refusal is
+    ``protected_class_language``, not ``unreviewed_criterion``: the allow
+    lookahead inside ``PROTECTED_HEALTH_GOVERNANCE_INTENT_RE`` requires the
+    object of "with" to be a complete reviewed attribute followed immediately
+    by a terminator, and " in Texas" is neither. Widening THAT lookahead was
+    implemented, measured over a 99,408-prompt sweep and pulled -- it costs
+    3,456 refusals carrying an unenumerated health condition -- and a
+    membership screen cannot be expressed inside a negative lookahead, so the
+    governed vocabulary this branch adds does not rescue it either.
+
+    Recorded as a test rather than a comment so the day it changes, something
+    says so.
+    """
+
+    assert protected_prompt_match("Select borrowers with a rate spread in Texas.") is not None
+    # ... while the criterion machine, which this branch owns, is satisfied.
+    assert (
+        _contains_unreviewed_audience_decision("Select borrowers with a rate spread in Texas")
+        is False
+    )
+
+
+def test_the_capital_i_fold_does_not_hide_the_zip_keyword() -> None:
+    """``ZIP`` reaches the grammar as ``ZlP`` on one scan pass.
+
+    The guard scans a confusable fold alongside the text, and a capital ``I``
+    folds to ``l``. With a plain ``zip`` literal, all 51 federal state names
+    passed while every reviewed attribute refused with a ZIP scope -- the
+    signature of a literal that does not survive the fold. Same convention the
+    audience-formation grammar already uses for ``(?:insert|lnsert)``.
+    """
+
+    for question in (
+        "Show borrowers with a rate spread in ZIP 98404.",
+        "Show borrowers with home equity in ZIP 98404.",
+        "Rank borrowers with an opportunity score in ZIP code 98404.",
+    ):
+        assert protected_prompt_match(question) is None, question
+
+
+def test_every_federal_state_name_is_a_governed_scope() -> None:
+    """All 51, because a partial state list has shipped here before.
+
+    ``_validators_person_names.US_STATE_NAMES`` calls itself the federal list
+    and deliberately carries only the ONE-word states; reusing it for a
+    location tail silently dropped eleven states and DC for a week.
+    """
+
+    refused = [
+        state
+        for state in US_STATE_NAMES_FEDERAL
+        if protected_prompt_match(f"Show borrowers with home equity in {state}.") is not None
+    ]
+    assert refused == [], refused
+
+
+def test_a_city_scope_needs_a_published_dimension(published_cities: None) -> None:
+    """Degradation costs the grain, never the guard.
+
+    Cities are live Cotality coverage and cannot be committed, so they arrive
+    by registration. With no dimension published a city question refuses --
+    the same answer the guard gave before this slot existed -- and the fixture
+    proves the published state is what changes it.
+    """
+
+    question = "Show borrowers with a rate spread in Seattle."
+    assert protected_prompt_match(question) is None, question
+
+    _reset_governed_place_dimension_for_tests(None)
+    assert protected_prompt_match(question) is not None, question
+
+
+def test_a_governed_city_that_carries_a_governed_term_is_still_refused(
+    published_cities: None,
+) -> None:
+    """The non-exempt control. Recognising a place is not authority to admit it.
+
+    ``TACOMA`` is a real live gold city and IS in the published sample, yet the
+    admission gate screens it out on the ``-oma`` condition morphology -- five
+    of the six sample values are admitted, and this is the sixth. Without a
+    control like this, an exemption sweep measures only its own vocabulary
+    echoing back.
+    """
+
+    assert protected_prompt_match("Show borrowers with a rate spread in Tacoma.") is not None
+    assert (
+        protected_prompt_match("Show borrowers with a rate spread in Indian River County.")
+        is not None
+    )
+    # Asserted AFTER a guard call, because publishing happens on the first
+    # resolve and a guard call is what triggers it.
+    assert "tacoma" not in governed_analytics_cities()
+    assert "seattle" in governed_analytics_cities()
+
+
+def test_the_county_vocabulary_is_the_shipped_national_artifact() -> None:
+    """Counties come from the map drill-down's own TopoJSON, screened once.
+
+    An empty set here means the artifact moved and every county-grain question
+    silently refuses, which is fail-closed but invisible.
+    """
+
+    counties = admitted_county_names()
+    assert len(counties) > 1_500, len(counties)
+    assert "cook" in counties
+    assert "st louis" in counties  # period-stripped: clause splitting cuts "St."
+    # Screened out on their own merits, and each for a different bank.
+    assert "white" not in counties
+    assert "christian" not in counties
+    assert "deaf smith" not in counties
+
+
+def test_every_scope_slot_in_every_compiled_pattern_is_screened() -> None:
+    """A check wired into one call site is a check that is not wired in.
+
+    The scope fragment is a SHAPE; membership is what makes it safe. This walks
+    the compiled patterns and asserts each declares its scope groups under the
+    prefix :func:`match_scopes_are_governed` keys on, so a slot added to a new
+    pattern is screened by construction rather than by remembering.
+    """
+
+    patterns: tuple[re.Pattern[str], ...] = (
+        _REVIEWED_MORTGAGE_ATTRIBUTE_FULL_RE,
+        _REVIEWED_PRENOMINAL_AUDIENCE_DIRECTIVE_RE,
+        *_REVIEWED_AUDIENCE_DECISION_PATTERNS,
+    )
+    scoped = [p for p in patterns if any(g.startswith(_SCOPE_GROUP_PREFIX) for g in p.groupindex)]
+    assert len(scoped) >= 6, [p.groupindex for p in patterns]
+    for pattern in patterns:
+        for group in pattern.groupindex:
+            # Any group whose name mentions a scope must carry the screened
+            # prefix; a near-miss name would silently opt out of the check.
+            if "scope" in group:
+                assert group.startswith(_SCOPE_GROUP_PREFIX), group

--- a/tools/screen_county_place_vocabulary.py
+++ b/tools/screen_county_place_vocabulary.py
@@ -1,0 +1,55 @@
+"""Regenerate ``COUNTY_NAME_EXCLUSIONS`` for the reviewed-analytics location slot.
+
+The shipped ``frontend/public/us-counties.json`` is a static, repo-committed
+national artifact, so which of its names collide with a governed term changes
+only when the DETECTOR BANKS change -- never at runtime. Screening all ~1.8k
+names costs ~5s (each probe is ~2.8ms), which is fine once and far too slow
+on a first guard call, so the answer is committed in
+``backend/schemas/marketing_selection_reviewed_places.py`` and this script is
+how it is re-derived.
+
+Run it whenever a protected-class, health, or national-origin bank changes:
+
+    PYTHONPATH=$PWD python tools/screen_county_place_vocabulary.py
+
+It prints the exclusion tuple to paste back, and exits non-zero when the
+committed set has drifted from what the current banks produce.
+``test_reviewed_analytics_location.py::test_committed_county_exclusions_are_all_real_collisions``
+pins the cheap direction of the same property on every CI run.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from backend.schemas.marketing_selection_reviewed_places import (
+    COUNTY_NAME_EXCLUSIONS,
+    _collides_with_governed_term,
+    shipped_county_names,
+)
+
+
+def main() -> int:
+    names = sorted(shipped_county_names())
+    if not names:
+        print("no shipped county names -- is frontend/public/us-counties.json present?")
+        return 2
+    derived = {name.lower() for name in names if _collides_with_governed_term(name)}
+    print(f"screened {len(names)} shipped county names, {len(derived)} collide\n")
+    print("COUNTY_NAME_EXCLUSIONS: Final[frozenset[str]] = frozenset(")
+    print("    {")
+    for name in sorted(derived):
+        print(f'        "{name}",')
+    print("    }")
+    print(")")
+    missing = derived - COUNTY_NAME_EXCLUSIONS
+    extra = COUNTY_NAME_EXCLUSIONS - derived
+    if missing:
+        print(f"\nDRIFT: {len(missing)} collide but are ADMITTED: {sorted(missing)}")
+    if extra:
+        print(f"\nDRIFT: {len(extra)} excluded but no longer collide: {sorted(extra)}")
+    return 1 if (missing or extra) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Measured on b3007754 over `Show borrowers with {attribute}{ scope}.`, nine
reviewed attributes x seven scopes: 49 of 63 refused as
`unreviewed_criterion`. Every attribute passed bare and refused with "in
Texas", "in Washington", "in Seattle", "in ZIP 98404", "across Colorado" and
"in Cook County". `fixed-rate loans` predates every recent vocabulary change,
so this is not fallout from one -- it is the shape of the capture itself:
`_CRITERION_TAIL` takes the criterion WHOLE and then requires it to match the
reviewed fragment, and "a rate spread in Texas" is not "a rate spread".
Geography drill-down is a hero surface (CLAUDE.md), so this was the largest
false-positive class left in the grammar.

The place slot is the whole problem, and a shape cannot solve it: an arbitrary
title-case run behind "in" lets a non-place tail ride a reviewed head, and the
criterion state machine is the only net catching a health condition outside
the enumerated bank (`psoriasis` is banked, `eczema` is not). So the slot
captures a bounded shape and every capture is screened for MEMBERSHIP in a
governed place vocabulary -- states (the federal list), counties (the shipped
us-counties.json the map drill-down already ships, minus 13 screened
collisions), cities (the live gold dimension, pushed DOWN from services
because schemas may not import services). Shape and screen are only ever used
together, through `reviewed_fullmatch`; the six call sites that used to
fullmatch the pattern directly now route through one entry point, because a
check wired into one call site is a check that is not wired in.

`marketing_selection_reviewed_places` and the services-to-schemas registration
are NOT new here: they were written for the reviewed-analytics location slot
in PR #224 (claude/serene-gould-76f4ff, 9080afe0) and are reproduced rather
than re-derived, so the two slots screen one vocabulary instead of two copies.
That branch's own analytics changes are not taken. Its 13-name county
exclusion set re-derives exactly against main's banks (1,833 screened, zero
drift) and its one mypy defect is fixed.

`ZIP` is spelled `z[il]p`. The guard scans a confusable fold alongside the
text and a capital I folds to l, so a plain literal missed every ZIP-scoped
question while all 51 state names passed -- the same convention the
audience-formation grammar already uses for `(?:insert|lnsert)`.

Deliberately excluded: `for` as a scope preposition (the purpose fragment owns
`\s+for\s+`, and a scope branch in front of it would capture "this campaign",
fail the screen and refuse a phrasing that is answered today), and a bare
five-digit run (the number slot here is load-bearing and a bare cardinal
behind a preposition is a count).

No detector's allow-lookahead is widened: `REVIEWED_MORTGAGE_ATTRIBUTE_LIST_FRAGMENT`
and `REVIEWED_ATTRIBUTE_PURPOSE_FRAGMENT`, the two constants
`marketing_safety_terms` imports, are byte-identical.

An optional slot in front of other optional slots changes which parse wins,
so the open place shape stole the destination tail: "Include high equity
borrowers in a reviewed cohort." FULLMATCHED with the scope group holding "a
reviewed cohort", the screen rejected it, and a sentence answered on main
refused. `re` will not backtrack once the overall match has succeeded, so no
screen can recover it -- the fix is a lookahead over the closed destination
noun set, in the fragment. Caught by the FULL unit suite after a 15,600-probe
differential had reported zero losses; the differential's shapes had no
destination tail. Five such shapes are in the battery now.

Differential over 22,100 probes (25 attributes x 2 articles x 17 shapes x 26
scopes) against 26b3ae56: 3,682 refusals restored, 0 LOSSES, 0 gains carrying
an unreviewed attribute, 0 gains carrying an ungoverned scope, 0 new leaks.
The four mutation cases each turn a named test red (membership screen removed,
scope removed from the clause patterns only, ZIP reverted to a fold-blind
literal, publish severed). Full suite, ruff and mypy green.

Live on paychex, local backend against real UC (428-value dimension, 424
admitted):

  "Show me the top borrowers with a rate spread in Texas."      -> genie, 20 rows
  "... with a rate spread in Seattle."                          -> genie, 20 rows
  "... with an opportunity score in Cook County."               -> genie, 5 sub-analyses
  "... with a rate spread in ZIP 98404."                        -> genie
  "... with a rate spread in dialysis centers."                 -> refused
  "... with a credit score in Texas."                           -> refused
  "... with a rate spread in Tacoma."                           -> refused

Tacoma is the non-exempt control: a real live gold city the admission gate
screens out on the `-oma` morphology, so the sweep is measuring the gate
rather than its own vocabulary echoing back.

`genie_place_dimension` crossed the 900-line gate, so the publisher is split
into its own module rather than allowlisted, per the gate's policy note.

Two pre-existing findings this does NOT fix, both byte-identical to main and
both recorded as tests rather than comments:

* the reviewed read-only ANALYTICS shapes still carry an open
  `[A-Z][A-Za-z' -]{2,40}` location slot, and matching one is a kill switch,
  so "Show borrowers with home equity in dialysis centers." is ALLOWED on main
  today. PR #224 is the change that closes it.
* "Select borrowers with a rate spread in Texas." refuses as
  `protected_class_language`, not `unreviewed_criterion`: the allow lookahead
  in `PROTECTED_HEALTH_GOVERNANCE_INTENT_RE` needs the object of "with" to be
  a complete reviewed attribute followed by a terminator. Widening that
  lookahead was measured over 99,408 prompts and pulled, and a membership
  screen cannot be expressed inside a negative lookahead, so the governed
  vocabulary does not rescue it either.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)